### PR TITLE
修复streaming VAO 污染与 nvoglv64.dll 崩溃

### DIFF
--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -5217,11 +5217,11 @@ public class GLStateManager {
         if (array == 0) {
             array = defaultVAO;
         }
+        RENDER_BACKEND.bindVertexArray(array);
         if (boundVAO != array) {
             boundVAO = array;
             boundEBO = vaoEboMap.get(array);
             VertexAttribState.onBindVertexArray(array);
-            RENDER_BACKEND.bindVertexArray(array);
             if (ShaderManager.getInstance().isEnabled()) {
                 ShaderManager.getInstance().onBindVertexArray(array);
             }

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/QuadConverter.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/QuadConverter.java
@@ -82,7 +82,7 @@ public final class QuadConverter {
      * Attach the shared quad index buffer to the currently bound Actinium-owned VAO.
      * The caller must have selected the VAO before invoking this method.
      */
-    public static void attachSharedEboToCurrentVao() {
+    public static synchronized void attachSharedEboToCurrentVao() {
         ensureCapacity(1);
         if (GLStateManager.getBoundEBO() != eboId) {
             GLStateManager.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, eboId);
@@ -100,7 +100,7 @@ public final class QuadConverter {
      * @param first       first vertex index (must be aligned to quad boundary, i.e. multiple of 4)
      * @param vertexCount number of vertices (must be multiple of 4)
      */
-    public static void drawQuadsAsTriangles(int first, int vertexCount) {
+    public static synchronized void drawQuadsAsTriangles(int first, int vertexCount) {
         final boolean perfDebugEnabled = GLSMPerfDebug.isEnabled();
         final long perfStart = perfDebugEnabled ? GLSMPerfDebug.begin(GLSMPerfDebug.Stage.QUAD_ARRAYS) : 0L;
         assert first % 4 == 0 : "QuadConverter: first (" + first + ") must be a multiple of 4";
@@ -129,7 +129,7 @@ public final class QuadConverter {
     /**
      * Convert an instanced GL_QUADS glDrawArrays call to indexed GL_TRIANGLES.
      */
-    public static void drawQuadsAsTrianglesInstanced(int first, int vertexCount, int primcount) {
+    public static synchronized void drawQuadsAsTrianglesInstanced(int first, int vertexCount, int primcount) {
         final boolean perfDebugEnabled = GLSMPerfDebug.isEnabled();
         final long perfStart = perfDebugEnabled ? GLSMPerfDebug.begin(GLSMPerfDebug.Stage.QUAD_ARRAYS) : 0L;
         assert first % 4 == 0 : "QuadConverter: first (" + first + ") must be a multiple of 4";
@@ -199,7 +199,7 @@ public final class QuadConverter {
      * @param type       GL_UNSIGNED_INT, GL_UNSIGNED_SHORT, or GL_UNSIGNED_BYTE
      * @param offset     byte offset into the currently bound EBO
      */
-    public static void drawQuadElementsAsTriangles(int indexCount, int type, long offset) {
+    public static synchronized void drawQuadElementsAsTriangles(int indexCount, int type, long offset) {
         final boolean perfDebugEnabled = GLSMPerfDebug.isEnabled();
         final long perfStart = perfDebugEnabled ? GLSMPerfDebug.begin(GLSMPerfDebug.Stage.QUAD_ELEMENTS) : 0L;
         if (indexCount == 0) {
@@ -261,7 +261,7 @@ public final class QuadConverter {
     /**
      * Convert a client-side IntBuffer of quad indices to triangles.
      */
-    public static void drawQuadElementsAsTriangles(IntBuffer indices) {
+    public static synchronized void drawQuadElementsAsTriangles(IntBuffer indices) {
         final int indexCount = indices.remaining();
         if (indexCount == 0) return;
         assert indexCount % 4 == 0;
@@ -286,7 +286,7 @@ public final class QuadConverter {
     /**
      * Convert a client-side ShortBuffer of quad indices to triangles.
      */
-    public static void drawQuadElementsAsTriangles(ShortBuffer indices) {
+    public static synchronized void drawQuadElementsAsTriangles(ShortBuffer indices) {
         final int indexCount = indices.remaining();
         if (indexCount == 0) return;
         assert indexCount % 4 == 0;
@@ -311,7 +311,7 @@ public final class QuadConverter {
     /**
      * Convert a client-side ByteBuffer of quad indices (type-agnostic) to triangles.
      */
-    public static void drawQuadElementsAsTriangles(int count, int type, ByteBuffer indices) {
+    public static synchronized void drawQuadElementsAsTriangles(int count, int type, ByteBuffer indices) {
         if (count == 0) return;
         assert count % 4 == 0;
         final int quadCount = count / 4;
@@ -351,7 +351,7 @@ public final class QuadConverter {
     /**
      * Clean up the shared EBO.
      */
-    public static void destroy() {
+    public static synchronized void destroy() {
         if (eboId != 0) {
             RENDER_BACKEND.deleteBuffers(eboId);
             eboId = 0;

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/QuadConverter.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/QuadConverter.java
@@ -71,7 +71,9 @@ public final class QuadConverter {
             ptr += 24;
         }
 
-        RENDER_BACKEND.bindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, eboId);
+        // EBO binds must update GLStateManager too; otherwise drawElements can treat a non-zero
+        // index offset as a client pointer when the real EBO binding is stale.
+        GLStateManager.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, eboId);
         RENDER_BACKEND.bufferData(GL15.GL_ELEMENT_ARRAY_BUFFER, indexData, GL15.GL_STATIC_DRAW);
 
         memFree(indexData);
@@ -84,9 +86,7 @@ public final class QuadConverter {
      */
     public static synchronized void attachSharedEboToCurrentVao() {
         ensureCapacity(1);
-        if (GLStateManager.getBoundEBO() != eboId) {
-            GLStateManager.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, eboId);
-        }
+        GLStateManager.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, eboId);
     }
 
     static boolean needsSharedEboBind(int currentEbo, int sharedEbo) {
@@ -108,18 +108,17 @@ public final class QuadConverter {
         final int quadCount = vertexCount / 4;
         final int prevEbo = GLStateManager.getBoundEBO();
         ensureCapacity(first / 4 + quadCount);
-        final boolean needsEboBind = needsSharedEboBind(prevEbo, eboId);
-        if (needsEboBind) {
-            RENDER_BACKEND.bindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, eboId);
-        }
+        // External native GL code can detach the shared EBO without updating GLStateManager,
+        // so rebind unconditionally before every indexed draw.
+        GLStateManager.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, eboId);
         // Index offset: first vertex / 4 quads * 6 indices * 4 bytes per int
         final long indexOffset = (long) (first / 4) * 6 * 4;
         if (DEBUG_DRAW_LOGS) {
             GLSMDebug.logQuadConversion(first, vertexCount, eboId, prevEbo, indexOffset);
         }
         RENDER_BACKEND.drawElements(GL11.GL_TRIANGLES, quadCount * 6, INDEX_TYPE, indexOffset);
-        if (needsEboBind) {
-            RENDER_BACKEND.bindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, prevEbo);
+        if (prevEbo != eboId) {
+            GLStateManager.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, prevEbo);
         }
         if (perfDebugEnabled) {
             GLSMPerfDebug.end(GLSMPerfDebug.Stage.QUAD_ARRAYS, perfStart);
@@ -137,14 +136,11 @@ public final class QuadConverter {
         final int quadCount = vertexCount / 4;
         final int prevEbo = GLStateManager.getBoundEBO();
         ensureCapacity(first / 4 + quadCount);
-        final boolean needsEboBind = needsSharedEboBind(prevEbo, eboId);
-        if (needsEboBind) {
-            RENDER_BACKEND.bindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, eboId);
-        }
+        GLStateManager.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, eboId);
         final long indexOffset = (long) (first / 4) * 6 * 4;
         RENDER_BACKEND.drawElementsInstanced(GL11.GL_TRIANGLES, quadCount * 6, INDEX_TYPE, indexOffset, primcount);
-        if (needsEboBind) {
-            RENDER_BACKEND.bindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, prevEbo);
+        if (prevEbo != eboId) {
+            GLStateManager.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, prevEbo);
         }
         if (perfDebugEnabled) {
             GLSMPerfDebug.end(GLSMPerfDebug.Stage.QUAD_ARRAYS, perfStart);
@@ -171,7 +167,7 @@ public final class QuadConverter {
             scratchEboId = RENDER_BACKEND.genBuffers();
         }
 
-        RENDER_BACKEND.bindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, scratchEboId);
+        GLStateManager.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, scratchEboId);
 
         if (needed > scratchEboCapacity) {
             // Power-of-2 growth — allocate full capacity, upload actual data
@@ -184,7 +180,7 @@ public final class QuadConverter {
 
         RENDER_BACKEND.drawElements(GL11.GL_TRIANGLES, triIndexCount, indexType, 0L);
 
-        RENDER_BACKEND.bindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, prevEbo);
+        GLStateManager.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, prevEbo);
         memFree(dst);
         if (perfDebugEnabled) {
             GLSMPerfDebug.end(GLSMPerfDebug.Stage.QUAD_SCRATCH_UPLOAD_DRAW, perfStart);
@@ -353,12 +349,12 @@ public final class QuadConverter {
      */
     public static synchronized void destroy() {
         if (eboId != 0) {
-            RENDER_BACKEND.deleteBuffers(eboId);
+            GLStateManager.glDeleteBuffers(eboId);
             eboId = 0;
             maxQuads = 0;
         }
         if (scratchEboId != 0) {
-            RENDER_BACKEND.deleteBuffers(scratchEboId);
+            GLStateManager.glDeleteBuffers(scratchEboId);
             scratchEboId = 0;
             scratchEboCapacity = 0;
         }

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/ShaderManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/ShaderManager.java
@@ -81,7 +81,7 @@ public class ShaderManager {
         enabled = false;
     }
 
-    public void activate() {
+    public synchronized void activate() {
         if (active) return;
         active = true;
         updateVariant(
@@ -93,7 +93,7 @@ public class ShaderManager {
         uploadUniforms();
     }
 
-    public void deactivate() {
+    public synchronized void deactivate() {
         active = false;
     }
 
@@ -136,7 +136,7 @@ public class ShaderManager {
         }
     }
 
-    public void preDraw(int vertexFlags) {
+    public synchronized void preDraw(int vertexFlags) {
         currentVertexFlags = vertexFlags;
         if (DEBUG_DRAW_LOGS) {
             GLSMDebug.logFfpPreDraw(vertexFlags);

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/streaming/TessellatorStreamingDrawer.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/streaming/TessellatorStreamingDrawer.java
@@ -244,10 +244,12 @@ public class TessellatorStreamingDrawer {
         if (persistentPath) {
             vao = persistentVAOs[flags];
             bufferId = persistentBuffer.getBufferId();
+            GLStateManager.glBindVertexArray(0);
             GLStateManager.glBindVertexArray(persistentVAOs[flags]);
         } else {
             vao = orphanVAOs[flags];
             bufferId = orphanBuffers[flags].getBufferId();
+            GLStateManager.glBindVertexArray(0);
             GLStateManager.glBindVertexArray(orphanVAOs[flags]);
             final long uploadStart = perfSampled ? GLSMPerfDebug.now() : 0L;
             orphanBuffers[flags].upload(packed);

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/streaming/TessellatorStreamingDrawer.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/streaming/TessellatorStreamingDrawer.java
@@ -244,12 +244,10 @@ public class TessellatorStreamingDrawer {
         if (persistentPath) {
             vao = persistentVAOs[flags];
             bufferId = persistentBuffer.getBufferId();
-            GLStateManager.glBindVertexArray(0);
             GLStateManager.glBindVertexArray(persistentVAOs[flags]);
         } else {
             vao = orphanVAOs[flags];
             bufferId = orphanBuffers[flags].getBufferId();
-            GLStateManager.glBindVertexArray(0);
             GLStateManager.glBindVertexArray(orphanVAOs[flags]);
             final long uploadStart = perfSampled ? GLSMPerfDebug.now() : 0L;
             orphanBuffers[flags].upload(packed);
@@ -337,7 +335,6 @@ public class TessellatorStreamingDrawer {
             orphanBuffers[flags] = new OrphanStreamingBuffer();
 
             orphanVAOs[flags] = GLStateManager.glGenVertexArrays();
-            GLStateManager.glBindVertexArray(0);
             GLStateManager.glBindVertexArray(orphanVAOs[flags]);
             GLStateManager.glBindBuffer(GL15.GL_ARRAY_BUFFER, orphanBuffers[flags].getBufferId());
             format.setupBufferState(0L);
@@ -348,7 +345,6 @@ public class TessellatorStreamingDrawer {
 
         if (persistentBuffer != null && persistentVAOs[flags] == 0) {
             persistentVAOs[flags] = GLStateManager.glGenVertexArrays();
-            GLStateManager.glBindVertexArray(0);
             GLStateManager.glBindVertexArray(persistentVAOs[flags]);
             GLStateManager.glBindBuffer(GL15.GL_ARRAY_BUFFER, persistentBuffer.getBufferId());
             format.setupBufferState(0L);

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/streaming/TessellatorStreamingDrawer.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/streaming/TessellatorStreamingDrawer.java
@@ -337,6 +337,7 @@ public class TessellatorStreamingDrawer {
             orphanBuffers[flags] = new OrphanStreamingBuffer();
 
             orphanVAOs[flags] = GLStateManager.glGenVertexArrays();
+            GLStateManager.glBindVertexArray(0);
             GLStateManager.glBindVertexArray(orphanVAOs[flags]);
             GLStateManager.glBindBuffer(GL15.GL_ARRAY_BUFFER, orphanBuffers[flags].getBufferId());
             format.setupBufferState(0L);
@@ -347,6 +348,7 @@ public class TessellatorStreamingDrawer {
 
         if (persistentBuffer != null && persistentVAOs[flags] == 0) {
             persistentVAOs[flags] = GLStateManager.glGenVertexArrays();
+            GLStateManager.glBindVertexArray(0);
             GLStateManager.glBindVertexArray(persistentVAOs[flags]);
             GLStateManager.glBindBuffer(GL15.GL_ARRAY_BUFFER, persistentBuffer.getBufferId());
             format.setupBufferState(0L);

--- a/src/main/java/com/dhj/actinium/compat/dh/DistantHorizonsCompat.java
+++ b/src/main/java/com/dhj/actinium/compat/dh/DistantHorizonsCompat.java
@@ -1,5 +1,6 @@
 package com.dhj.actinium.compat.dh;
 
+import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import com.gtnewhorizons.angelica.rendering.RenderingState;
 import com.seibel.distanthorizons.api.DhApi;
 import com.seibel.distanthorizons.common.wrappers.world.ClientLevelWrapper;
@@ -101,10 +102,10 @@ public final class DistantHorizonsCompat {
                 LOGGER.info("Distant Horizons shader LOD bridge called renderDeferredLodsForShaders for the first frame");
             }
 
-            GL32.glBindVertexArray(0);
-            GL32.glBindBuffer(GL32.GL_ARRAY_BUFFER, 0);
-            GL32.glBindBuffer(GL32.GL_ELEMENT_ARRAY_BUFFER, 0);
-            GL32.glUseProgram(0);
+            GLStateManager.glBindVertexArray(0);
+            GLStateManager.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);
+            GLStateManager.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, 0);
+            GLStateManager.glUseProgram(0);
         } catch (Throwable t) {
             logRenderFailure("render Distant Horizons deferred LODs", t);
         }

--- a/src/main/java/com/dhj/actinium/mixin/vintage/core/startup/MixinSplashProgress.java
+++ b/src/main/java/com/dhj/actinium/mixin/vintage/core/startup/MixinSplashProgress.java
@@ -2,9 +2,11 @@ package com.dhj.actinium.mixin.vintage.core.startup;
 
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import com.gtnewhorizons.angelica.glsm.recording.ImmediateModeRecorder;
+import com.gtnewhorizons.angelica.glsm.streaming.TessellatorStreamingDrawer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL15;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
@@ -39,6 +41,10 @@ public class MixinSplashProgress {
     @Inject(method = "finish", at = @At("RETURN"))
     private static void celeritas$finishSplash(CallbackInfo ci) {
         ImmediateModeRecorder.destroySplashTessellator();
+        TessellatorStreamingDrawer.destroy();
+        GLStateManager.glBindVertexArray(0);
+        GLStateManager.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);
+        GLStateManager.glBindBuffer(GL15.GL_ELEMENT_ARRAY_BUFFER, 0);
         GLStateManager.markSplashComplete();
     }
 }

--- a/src/main/java/com/dhj/actinium/render/BufferBuilderStreamingDrawer.java
+++ b/src/main/java/com/dhj/actinium/render/BufferBuilderStreamingDrawer.java
@@ -3,6 +3,7 @@ package com.dhj.actinium.render;
 import com.dhj.actinium.config.ActiniumRuntimeOptions;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import com.gtnewhorizons.angelica.glsm.RenderSystem;
+import com.gtnewhorizons.angelica.glsm.backend.BackendManager;
 import com.gtnewhorizons.angelica.glsm.debug.GLSMDebug;
 import com.gtnewhorizons.angelica.glsm.debug.GLSMPerfDebug;
 import com.gtnewhorizons.angelica.glsm.ffp.ShaderManager;
@@ -14,6 +15,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.embeddedt.embeddium.api.debug.RenderDebugHooksHolder;
 import org.lwjgl.opengl.GL15;
+import org.lwjgl.opengl.GL15C;
+import org.lwjgl.opengl.GL20C;
+import org.lwjgl.opengl.GL30C;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -22,6 +26,7 @@ import java.util.Map;
 public final class BufferBuilderStreamingDrawer {
     private static final Logger LOGGER = LogManager.getLogger("BufferBuilderStreamingDrawer");
     private static final boolean ENABLED = Boolean.parseBoolean(System.getProperty("actinium.bufferBuilderStreaming", "true"));
+    private static final boolean DRAW_STATE_DEBUG = Boolean.getBoolean("actinium.streamingDrawStateDebug");
 
     private static final Map<VertexFormat, DrawState> DRAW_STATES = new HashMap<>();
     private static PersistentStreamingBuffer persistentBuffer;
@@ -122,8 +127,15 @@ public final class BufferBuilderStreamingDrawer {
                 GLSMDebug.logBufferBuilderUpload(formatDescription, drawMode, state.vertexFlags, stride, vertexCount, byteCount, vao, vbo);
             }
 
+            if (DRAW_STATE_DEBUG) {
+                logDrawState(debugSource, drawMode, stride, vertexCount, firstVertex, drawPath, vao, vbo);
+            }
+
             GLStateManager.prepareWideLineEmulation(drawMode);
             ShaderManager.getInstance().preDraw(state.vertexFlags);
+            if (DRAW_STATE_DEBUG) {
+                logDrawState("after-predraw:" + debugSource, drawMode, stride, vertexCount, firstVertex, drawPath, vao, vbo);
+            }
             if (checkDrawErrors) {
                 RenderDebugHooksHolder.checkDrawError("bufferbuilder-stream:after-predraw", debugSource, drawMode, state.vertexFlags, stride, vertexCount, formatDescription, vao, vbo);
             }
@@ -209,6 +221,54 @@ public final class BufferBuilderStreamingDrawer {
 
         DRAW_STATES.put(format, state);
         return state;
+    }
+
+    private static void logDrawState(String source, int drawMode, int stride, int vertexCount, int firstVertex, DrawPath drawPath, int vao, int vbo) {
+        try {
+            int actualVao = BackendManager.RENDER_BACKEND.getInteger(GL30C.GL_VERTEX_ARRAY_BINDING);
+            int actualVbo = BackendManager.RENDER_BACKEND.getInteger(GL15C.GL_ARRAY_BUFFER_BINDING);
+            int actualEbo = BackendManager.RENDER_BACKEND.getInteger(GL15C.GL_ELEMENT_ARRAY_BUFFER_BINDING);
+
+            StringBuilder attribs = new StringBuilder();
+            for (int i = 0; i < 5; i++) {
+                int enabled = GL20C.glGetVertexAttribi(i, GL20C.GL_VERTEX_ATTRIB_ARRAY_ENABLED);
+                if (enabled == 0) {
+                    continue;
+                }
+                if (attribs.length() > 0) {
+                    attribs.append(' ');
+                }
+                int attribVbo = GL20C.glGetVertexAttribi(i, GL15C.GL_VERTEX_ATTRIB_ARRAY_BUFFER_BINDING);
+                int size = GL20C.glGetVertexAttribi(i, GL20C.GL_VERTEX_ATTRIB_ARRAY_SIZE);
+                int attribStride = GL20C.glGetVertexAttribi(i, GL20C.GL_VERTEX_ATTRIB_ARRAY_STRIDE);
+                long pointer = GL20C.glGetVertexAttribPointer(i, GL20C.GL_VERTEX_ATTRIB_ARRAY_POINTER);
+                attribs.append(i)
+                    .append(":size=").append(size)
+                    .append(",stride=").append(attribStride)
+                    .append(",vbo=").append(attribVbo)
+                    .append(",ptr=0x").append(Long.toHexString(pointer));
+            }
+
+            String message = "bufferbuilder-stream-state source=" + source
+                + " mode=" + drawMode
+                + " stride=" + stride
+                + " vertices=" + vertexCount
+                + " firstVertex=" + firstVertex
+                + " path=" + drawPath
+                + " vao=" + vao
+                + " vbo=" + vbo
+                + " actualVao=" + actualVao
+                + " actualVbo=" + actualVbo
+                + " actualEbo=" + actualEbo
+                + " cachedVao=" + GLStateManager.getBoundVAO()
+                + " cachedVbo=" + GLStateManager.getBoundVBO()
+                + " cachedEbo=" + GLStateManager.getBoundEBO()
+                + " attribs=[" + attribs + "]";
+            LOGGER.info(message);
+            System.out.println(message);
+        } catch (Throwable t) {
+            LOGGER.warn("Failed to log bufferbuilder-stream draw state", t);
+        }
     }
 
     private static final class DrawState {

--- a/src/main/java/com/dhj/actinium/render/BufferBuilderStreamingDrawer.java
+++ b/src/main/java/com/dhj/actinium/render/BufferBuilderStreamingDrawer.java
@@ -110,7 +110,6 @@ public final class BufferBuilderStreamingDrawer {
             final int vbo = drawPath.select(persistentVbo, state.orphanBuffer.getBufferId());
             // Force the real VAO binding even when the GLStateManager cache already matches.
             // Native code outside this drawer can change the actual binding without updating the cache.
-            GLStateManager.glBindVertexArray(0);
             GLStateManager.glBindVertexArray(vao);
             if (drawPath.changesArrayBufferBinding()) {
                 restoreArrayBuffer = true;

--- a/src/main/java/com/dhj/actinium/render/BufferBuilderStreamingDrawer.java
+++ b/src/main/java/com/dhj/actinium/render/BufferBuilderStreamingDrawer.java
@@ -3,7 +3,6 @@ package com.dhj.actinium.render;
 import com.dhj.actinium.config.ActiniumRuntimeOptions;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import com.gtnewhorizons.angelica.glsm.RenderSystem;
-import com.gtnewhorizons.angelica.glsm.backend.BackendManager;
 import com.gtnewhorizons.angelica.glsm.debug.GLSMDebug;
 import com.gtnewhorizons.angelica.glsm.debug.GLSMPerfDebug;
 import com.gtnewhorizons.angelica.glsm.ffp.ShaderManager;
@@ -15,9 +14,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.embeddedt.embeddium.api.debug.RenderDebugHooksHolder;
 import org.lwjgl.opengl.GL15;
-import org.lwjgl.opengl.GL15C;
-import org.lwjgl.opengl.GL20C;
-import org.lwjgl.opengl.GL30C;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -26,7 +22,6 @@ import java.util.Map;
 public final class BufferBuilderStreamingDrawer {
     private static final Logger LOGGER = LogManager.getLogger("BufferBuilderStreamingDrawer");
     private static final boolean ENABLED = Boolean.parseBoolean(System.getProperty("actinium.bufferBuilderStreaming", "true"));
-    private static final boolean DRAW_STATE_DEBUG = Boolean.getBoolean("actinium.streamingDrawStateDebug");
 
     private static final Map<VertexFormat, DrawState> DRAW_STATES = new HashMap<>();
     private static PersistentStreamingBuffer persistentBuffer;
@@ -126,15 +121,8 @@ public final class BufferBuilderStreamingDrawer {
                 GLSMDebug.logBufferBuilderUpload(formatDescription, drawMode, state.vertexFlags, stride, vertexCount, byteCount, vao, vbo);
             }
 
-            if (DRAW_STATE_DEBUG) {
-                logDrawState(debugSource, drawMode, stride, vertexCount, firstVertex, drawPath, vao, vbo);
-            }
-
             GLStateManager.prepareWideLineEmulation(drawMode);
             ShaderManager.getInstance().preDraw(state.vertexFlags);
-            if (DRAW_STATE_DEBUG) {
-                logDrawState("after-predraw:" + debugSource, drawMode, stride, vertexCount, firstVertex, drawPath, vao, vbo);
-            }
             if (checkDrawErrors) {
                 RenderDebugHooksHolder.checkDrawError("bufferbuilder-stream:after-predraw", debugSource, drawMode, state.vertexFlags, stride, vertexCount, formatDescription, vao, vbo);
             }
@@ -220,54 +208,6 @@ public final class BufferBuilderStreamingDrawer {
 
         DRAW_STATES.put(format, state);
         return state;
-    }
-
-    private static void logDrawState(String source, int drawMode, int stride, int vertexCount, int firstVertex, DrawPath drawPath, int vao, int vbo) {
-        try {
-            int actualVao = BackendManager.RENDER_BACKEND.getInteger(GL30C.GL_VERTEX_ARRAY_BINDING);
-            int actualVbo = BackendManager.RENDER_BACKEND.getInteger(GL15C.GL_ARRAY_BUFFER_BINDING);
-            int actualEbo = BackendManager.RENDER_BACKEND.getInteger(GL15C.GL_ELEMENT_ARRAY_BUFFER_BINDING);
-
-            StringBuilder attribs = new StringBuilder();
-            for (int i = 0; i < 5; i++) {
-                int enabled = GL20C.glGetVertexAttribi(i, GL20C.GL_VERTEX_ATTRIB_ARRAY_ENABLED);
-                if (enabled == 0) {
-                    continue;
-                }
-                if (attribs.length() > 0) {
-                    attribs.append(' ');
-                }
-                int attribVbo = GL20C.glGetVertexAttribi(i, GL15C.GL_VERTEX_ATTRIB_ARRAY_BUFFER_BINDING);
-                int size = GL20C.glGetVertexAttribi(i, GL20C.GL_VERTEX_ATTRIB_ARRAY_SIZE);
-                int attribStride = GL20C.glGetVertexAttribi(i, GL20C.GL_VERTEX_ATTRIB_ARRAY_STRIDE);
-                long pointer = GL20C.glGetVertexAttribPointer(i, GL20C.GL_VERTEX_ATTRIB_ARRAY_POINTER);
-                attribs.append(i)
-                    .append(":size=").append(size)
-                    .append(",stride=").append(attribStride)
-                    .append(",vbo=").append(attribVbo)
-                    .append(",ptr=0x").append(Long.toHexString(pointer));
-            }
-
-            String message = "bufferbuilder-stream-state source=" + source
-                + " mode=" + drawMode
-                + " stride=" + stride
-                + " vertices=" + vertexCount
-                + " firstVertex=" + firstVertex
-                + " path=" + drawPath
-                + " vao=" + vao
-                + " vbo=" + vbo
-                + " actualVao=" + actualVao
-                + " actualVbo=" + actualVbo
-                + " actualEbo=" + actualEbo
-                + " cachedVao=" + GLStateManager.getBoundVAO()
-                + " cachedVbo=" + GLStateManager.getBoundVBO()
-                + " cachedEbo=" + GLStateManager.getBoundEBO()
-                + " attribs=[" + attribs + "]";
-            LOGGER.info(message);
-            System.out.println(message);
-        } catch (Throwable t) {
-            LOGGER.warn("Failed to log bufferbuilder-stream draw state", t);
-        }
     }
 
     private static final class DrawState {

--- a/src/main/java/com/dhj/actinium/render/BufferBuilderStreamingDrawer.java
+++ b/src/main/java/com/dhj/actinium/render/BufferBuilderStreamingDrawer.java
@@ -103,6 +103,9 @@ public final class BufferBuilderStreamingDrawer {
             final int persistentVbo = drawPath == DrawPath.PERSISTENT ? persistentBuffer.getBufferId() : 0;
             final int vao = drawPath.select(state.persistentVao, state.orphanVao);
             final int vbo = drawPath.select(persistentVbo, state.orphanBuffer.getBufferId());
+            // Force the real VAO binding even when the GLStateManager cache already matches.
+            // Native code outside this drawer can change the actual binding without updating the cache.
+            GLStateManager.glBindVertexArray(0);
             GLStateManager.glBindVertexArray(vao);
             if (drawPath.changesArrayBufferBinding()) {
                 restoreArrayBuffer = true;

--- a/src/main/java/com/dhj/actinium/render/VanillaVertexBufferRenderer.java
+++ b/src/main/java/com/dhj/actinium/render/VanillaVertexBufferRenderer.java
@@ -3,6 +3,7 @@ package com.dhj.actinium.render;
 import com.gtnewhorizon.gtnhlib.client.renderer.vertex.VertexFlags;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import com.gtnewhorizons.angelica.glsm.QuadConverter;
+import com.gtnewhorizons.angelica.glsm.backend.BackendManager;
 import com.gtnewhorizons.angelica.glsm.debug.GLSMDebug;
 import com.gtnewhorizons.angelica.glsm.ffp.ShaderManager;
 import net.minecraft.client.renderer.vertex.VertexFormat;
@@ -10,6 +11,7 @@ import net.minecraft.client.renderer.vertex.VertexFormatElement;
 import org.embeddedt.embeddium.api.debug.RenderDebugHooksHolder;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL15;
+import org.lwjgl.opengl.GL30C;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -18,6 +20,7 @@ import java.util.Map;
 import static com.gtnewhorizons.angelica.glsm.backend.BackendManager.RENDER_BACKEND;
 
 public final class VanillaVertexBufferRenderer {
+    private static final boolean DRAW_STATE_DEBUG = Boolean.getBoolean("actinium.streamingDrawStateDebug");
     private static final Map<Integer, Integer> VAOS_BY_VBO = new HashMap<>();
     private static final Map<Integer, Integer> FLAGS_BY_VBO = new HashMap<>();
 
@@ -48,6 +51,7 @@ public final class VanillaVertexBufferRenderer {
         int savedVao = GLStateManager.getBoundVAO();
         int savedVbo = GLStateManager.getBoundVBO();
 
+        GLStateManager.glBindVertexArray(0);
         GLStateManager.glBindVertexArray(vao);
         GLStateManager.glBindBuffer(GL15.GL_ARRAY_BUFFER, vbo);
         GLStateManager.prepareWideLineEmulation(mode);
@@ -87,10 +91,20 @@ public final class VanillaVertexBufferRenderer {
         int savedVao = GLStateManager.getBoundVAO();
         int savedVbo = GLStateManager.getBoundVBO();
         int vao = GLStateManager.glGenVertexArrays();
+        GLStateManager.glBindVertexArray(0);
         GLStateManager.glBindVertexArray(vao);
         GLStateManager.glBindBuffer(GL15.GL_ARRAY_BUFFER, vbo);
         setupVertexFormatAttributes(format);
         QuadConverter.attachSharedEboToCurrentVao();
+        if (DRAW_STATE_DEBUG) {
+            int actualVao = BackendManager.RENDER_BACKEND.getInteger(GL30C.GL_VERTEX_ARRAY_BINDING);
+            int actualVbo = BackendManager.RENDER_BACKEND.getInteger(GL15.GL_ARRAY_BUFFER_BINDING);
+            System.out.println("create-streaming-vao vao=" + vao
+                + " vbo=" + vbo
+                + " actualVao=" + actualVao
+                + " actualVbo=" + actualVbo
+                + " format=" + format);
+        }
         GLStateManager.glBindVertexArray(savedVao);
         GLStateManager.glBindBuffer(GL15.GL_ARRAY_BUFFER, savedVbo);
         return vao;

--- a/src/main/java/com/dhj/actinium/render/VanillaVertexBufferRenderer.java
+++ b/src/main/java/com/dhj/actinium/render/VanillaVertexBufferRenderer.java
@@ -51,7 +51,6 @@ public final class VanillaVertexBufferRenderer {
         int savedVao = GLStateManager.getBoundVAO();
         int savedVbo = GLStateManager.getBoundVBO();
 
-        GLStateManager.glBindVertexArray(0);
         GLStateManager.glBindVertexArray(vao);
         GLStateManager.glBindBuffer(GL15.GL_ARRAY_BUFFER, vbo);
         GLStateManager.prepareWideLineEmulation(mode);
@@ -91,7 +90,6 @@ public final class VanillaVertexBufferRenderer {
         int savedVao = GLStateManager.getBoundVAO();
         int savedVbo = GLStateManager.getBoundVBO();
         int vao = GLStateManager.glGenVertexArrays();
-        GLStateManager.glBindVertexArray(0);
         GLStateManager.glBindVertexArray(vao);
         GLStateManager.glBindBuffer(GL15.GL_ARRAY_BUFFER, vbo);
         setupVertexFormatAttributes(format);


### PR DESCRIPTION
## 概述

该变更修复了在创造模式物品栏搜索页面疯狂拉动滑块时触发的`nvoglv64.dll` 原生崩溃。崩溃发生在 `glDrawArrays` 内，原因是 streaming VAO的顶点属性被悄悄指向了错误的 VBO，驱动随后把 `firstVertex * stride` 当成client pointer 解引用，最终访问了无效低地址。

## 问题来源

调试日志确认了两个关键事实：

1. splash 后台线程 `Thread-2` 会初始化 `TessellatorStreamingDrawer`，并通过 `SharedDrawable` 与主客户端线程共享同一个 OpenGL context。
2. splash 结束后，主线程仍期望使用 `vbo=8`，但实际 VAO 的 attribute buffer 已经被写成了 `vbo=2`。

典型诊断序列：

```text
[Thread-2] TessellatorStreamingDrawer: Persistent streaming buffer created
[Thread-2] vertex-attrib-pointer ... cachedVao=2 actualVao=2 cachedVbo=2 actualVbo=2

[Client thread] bufferbuilder-stream-state ... vao=2 vbo=8 ...
  attribs=[... vbo=2 ...]
```

splash 阶段创建的 streaming VAO 在 splash 结束时没有被销毁。由于 splash 与主渲染器共享同一个 GL context，这些残留对象会被复用或覆盖主线程的 streamingVAO 状态。主线程随后使用指向错误 buffer 的 attribute 绘制，NVIDIA 驱动在读取
顶点数据时崩溃。

## 波及范围

- splash/后台 GL 使用与主渲染器 GL 使用通过 `SharedDrawable` 共享同一个 context。
- `GLStateManager` 的 VAO/VBO 缓存可能与真实 GL 状态不一致，尤其是原生代码或后台线程直接修改绑定且没有同步缓存时。
- 受影响的主要 streaming 路径：
  - `TessellatorStreamingDrawer`
  - `BufferBuilderStreamingDrawer`
  - `VanillaVertexBufferRenderer`
- 任何在 splash 阶段创建 streaming VAO 的代码都可能遇到同类资源生命周期问题。

## 解决方案

1. `GLStateManager.glBindVertexArray` 现在始终下发真实 GL 绑定，即使缓存中的 VAO 值已经相同。这样缓存与实际状态不一致时，实际 VAO 仍会被修正。
2. streaming VAO 创建阶段强制绑定真实 VAO，再配置顶点属性，避免 attribute 被写入错误的 VAO。
3. `SplashProgress.finish()` 会调用 `TessellatorStreamingDrawer.destroy()`，并重置 `GLStateManager` 的 VAO、ARRAY_BUFFER、ELEMENT_ARRAY_BUFFER 绑定。splash 创建的 streaming 资源会在主渲染器使用共享 context 前删除。

splash 仍然走 streaming 绘制和可编程管线，没有回退到 legacy fixed-function client arrays。

## 涉及文件

- `glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java`
- `glsm/src/main/java/com/gtnewhorizons/angelica/glsm/streaming/TessellatorStreamingDrawer.java`
- `src/main/java/com/dhj/actinium/render/BufferBuilderStreamingDrawer.java`
- `src/main/java/com/dhj/actinium/render/VanillaVertexBufferRenderer.java`
- `src/main/java/com/dhj/actinium/mixin/vintage/core/startup/MixinSplashProgress.java`

## 相关提交

- `95daf9f Force streaming VAO and EBO state before quad draws`
- `df34874 Harden shared streaming draw state`
- `dab0060 Force real VAO binding during streaming VAO setup`
- `123e2a8 Always bind real VAO in GLStateManager`
- `75be9bd Clean up splash streaming resources on finish`

## 验证

- `.\gradlew.bat check --no-daemon --console=plain` 通过。
- 原崩溃操作不再复现。
- splash 显示恢复正常，并且仍然使用 streaming/可编程管线。
