### PR TITLE
fix(shader): tolerate non-numeric version prefixes and disable shaders without a pack

### DIFF
--- a/shader/src/main/java/net/coderbot/iris/config/IrisConfig.java
+++ b/shader/src/main/java/net/coderbot/iris/config/IrisConfig.java
@@ -55,6 +55,11 @@ public class IrisConfig {
 	 */
 	public void initialize() throws IOException {
 		load();
+		// With no shader pack selected there is nothing to render, so keep the
+		// enable switch off instead of inheriting the "enabled by default" state.
+		if (shaderPackName == null) {
+			enableShaders = false;
+		}
 		if (!Files.exists(propertiesPath)) {
 			save();
 		}

--- a/shader/src/main/java/net/coderbot/iris/gl/shader/StandardMacros.java
+++ b/shader/src/main/java/net/coderbot/iris/gl/shader/StandardMacros.java
@@ -45,18 +45,36 @@ public class StandardMacros {
 
     private static String makeActiniumVersion()
     {
+        // The version may carry a non-numeric prefix (e.g. "alpha-0.0.1-2dc019e") and the
+        // build appends a git sha, so locate the first dotted numeric triplet instead of
+        // assuming the string starts with digits.
         String[] parts = Tags.VERSION.split("[.-]");
-        int major = Integer.parseInt(parts[0]);
-        int minor = Integer.parseInt(parts[1]);
-        int patch = Integer.parseInt(parts[2]);
+        int numericStart = -1;
+        for (int i = 0; i < parts.length; i++) {
+            if (!parts[i].isEmpty() && parts[i].chars().allMatch(Character::isDigit)) {
+                numericStart = i;
+                break;
+            }
+        }
+        if (numericStart < 0 || numericStart + 2 >= parts.length) {
+            // Keep the define numeric so shader packs can still compare against it.
+            return "0";
+        }
+        int major = Integer.parseInt(parts[numericStart]);
+        int minor = Integer.parseInt(parts[numericStart + 1]);
+        int patch = Integer.parseInt(parts[numericStart + 2]);
         int sub = 0;
 
-        // Handle optional prerelease (like beta62)
-        if (parts.length > 3) {
-            String pre = parts[3];
-            String num = pre.replaceAll("\\D+", ""); // remove all non-digits
-            if (!num.isEmpty())
-                sub = Integer.parseInt(num);
+        // Handle optional prerelease (like beta62). The segment must start with a
+        // letter so a trailing git sha (e.g. "00e287f") is not mistaken for a
+        // prerelease number.
+        if (numericStart + 3 < parts.length) {
+            String pre = parts[numericStart + 3];
+            if (!pre.isEmpty() && Character.isLetter(pre.charAt(0))) {
+                String num = pre.replaceAll("\\D+", ""); // remove all non-digits
+                if (!num.isEmpty())
+                    sub = Integer.parseInt(num);
+            }
         }
         return String.format("%d%02d%02d%03d", major, minor, patch, sub);
     }


### PR DESCRIPTION
Fixes two shader-pack loading issues introduced by the new version scheme (`alpha-0.0.1-<sha>`).

## Changes

**1. `StandardMacros.makeActiniumVersion` no longer crashes on non-numeric version prefixes**

The build version is now `<base>-<git sha>` (e.g. `alpha-0.0.1-00e287f`). The old parser assumed the string starts with digits and `Integer.parseInt("alpha")` threw `NumberFormatException`, which made every shader pack fail to load.

- Locates the first dotted numeric triplet instead of assuming a leading number.
- The prerelease segment (e.g. `beta62`) is only used when it starts with a letter, so the trailing git sha can no longer leak digits into the `ACTINIUM_VERSION` define.
- Old formats keep their previous values (`2.4.0-dev-2dc019e` → `20400000`).

**2. `IrisConfig.initialize` keeps the shader switch off when no pack is selected**

`enableShaders` defaulted to `true` even with no shader pack selected, so the shaders button appeared as enabled while nothing could load. With no selected pack the switch now starts off; selecting a pack still enables shaders as before.

## Verification

- `:check` passes (tests + remap/bridge/module-boundary verification).
- Dev-run regression: shader pack (BSL) loads normally; button shows disabled state with no pack selected.