### PR TITLE
fix(gui): persist fast block renderer option across restarts

### DIFF
--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/gui/SodiumGameOptions.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/gui/SodiumGameOptions.java
@@ -81,6 +81,7 @@ public class SodiumGameOptions implements OptionStorage<SodiumGameOptions> {
         public boolean useNoErrorGLContext = true;
         public int loadingScreenFramerateLimit = 60;
 
+        public boolean useFastBlockRenderer = true;
         public AsyncOcclusionMode asyncOcclusionMode = AsyncOcclusionMode.ONLY_SHADOW;
     }
 

--- a/src/main/java/com/dhj/actinium/gui/ActiniumGameOptionPages.java
+++ b/src/main/java/com/dhj/actinium/gui/ActiniumGameOptionPages.java
@@ -25,7 +25,6 @@ import org.embeddedt.embeddium.api.options.structure.OptionStorage;
 import org.embeddedt.embeddium.api.options.structure.StandardOptions;
 import com.dhj.actinium.compat.modernui.MuiGuiScaleHook;
 import com.dhj.actinium.render.FastLitItemDisplayListCache;
-import com.dhj.actinium.render.terrain.compile.task.ChunkBuilderMeshingTask;
 import com.mitchej123.lwjgl.GLExtension;
 
 import static com.mitchej123.lwjgl.LWJGLServiceProvider.LWJGL;
@@ -347,7 +346,7 @@ public class ActiniumGameOptionPages {
                         .setTooltip(TextComponent.translatable("celeritas.options.fast_block_renderer.tooltip"))
                         .setControl(TickBoxControl::new)
                         .setImpact(OptionImpact.MEDIUM)
-                        .setBinding((opts, value) -> ChunkBuilderMeshingTask.USE_NEW_BLOCK_RENDERER = value, opts -> ChunkBuilderMeshingTask.USE_NEW_BLOCK_RENDERER)
+                        .setBinding((opts, value) -> opts.performance.useFastBlockRenderer = value, opts -> opts.performance.useFastBlockRenderer)
                         .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
                         .build())
                 .build());

--- a/src/main/java/com/dhj/actinium/render/terrain/compile/task/ChunkBuilderMeshingTask.java
+++ b/src/main/java/com/dhj/actinium/render/terrain/compile/task/ChunkBuilderMeshingTask.java
@@ -10,7 +10,6 @@ import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.crash.CrashReport;
 import net.minecraft.crash.CrashReportCategory;
 import net.minecraft.init.Blocks;
-import net.minecraft.launchwrapper.Launch;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumBlockRenderType;
 import net.minecraft.util.EnumFacing;
@@ -35,6 +34,7 @@ import org.embeddedt.embeddium.api.shader.BlockRenderLayer;
 import org.embeddedt.embeddium.api.shader.ShaderProvider;
 import org.embeddedt.embeddium.api.shader.ShaderProviderHolder;
 import com.dhj.actinium.compat.fluidlogged.FluidloggedCompat;
+import com.dhj.actinium.runtime.ActiniumRuntime;
 import com.dhj.actinium.world.WorldSlice;
 import com.dhj.actinium.world.cloned.ActiniumBlockAccess;
 import com.dhj.actinium.world.cloned.ChunkRenderContext;
@@ -43,7 +43,6 @@ import com.dhj.actinium.render.terrain.compile.VintageChunkBuildContext;
 import java.util.*;
 
 public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> {
-    public static boolean USE_NEW_BLOCK_RENDERER = (Boolean)Launch.blackboard.get("fml.deobfuscatedEnvironment") || Boolean.getBoolean("celeritas.useVintageFastBlockRenderer");
     private static final ProxyClassGenerator<WorldSlice, ActiniumBlockAccess> WORLD_SLICE_LOCAL_GENERATOR = new ProxyClassGenerator<>(WorldSlice.class, "WorldSliceLocal", ActiniumBlockAccess.class);
     private final RenderSection render;
     private final int buildTime;
@@ -124,7 +123,7 @@ public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> 
                             net.minecraft.util.BlockRenderLayer layer = shaderLayerOverride.toVanillaLayer();
                             ForgeHooksClient.setRenderLayer(layer);
                             block.canRenderInLayer(blockState, layer);
-                            if (blockState.getRenderType() == EnumBlockRenderType.MODEL && USE_NEW_BLOCK_RENDERER) {
+                            if (blockState.getRenderType() == EnumBlockRenderType.MODEL && ActiniumRuntime.options().performance.useFastBlockRenderer) {
                                 buildContext.getBlockRenderer().renderBlock(blockState, blockPos, slice, layer, false);
                             } else {
                                 var buffer = buildContext.getBufferForLayer(layer);
@@ -139,7 +138,7 @@ public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> 
                             for (net.minecraft.util.BlockRenderLayer layer : VintageChunkBuildContext.LAYERS) {
                                 if (block.canRenderInLayer(blockState, layer)) {
                                     ForgeHooksClient.setRenderLayer(layer);
-                                    if (blockState.getRenderType() == EnumBlockRenderType.MODEL && USE_NEW_BLOCK_RENDERER) {
+                                    if (blockState.getRenderType() == EnumBlockRenderType.MODEL && ActiniumRuntime.options().performance.useFastBlockRenderer) {
                                         buildContext.getBlockRenderer().renderBlock(blockState, blockPos, slice, layer);
                                     } else {
                                         var buffer = buildContext.getBufferForLayer(layer);


### PR DESCRIPTION
The `fast_block_renderer` option ("使用快速方块渲染器") reset to its default after every restart.

## Root cause

The option's binding read/wrote the static field `ChunkBuilderMeshingTask.USE_NEW_BLOCK_RENDERER` directly. Static fields are not part of `SodiumGameOptions`, so the toggle never round-tripped through `actinium-options.json` — on restart it fell back to the default (false in production).

## Changes

Follows the standard option pattern used by every other option:

- **`SodiumGameOptions.PerformanceSettings`**: new persisted field `useFastBlockRenderer` (JSON key `performance.use_fast_block_renderer`, default `false`).
- **`ActiniumGameOptionPages`**: binding now reads/writes the options field directly.
- **`ChunkBuilderMeshingTask`**: removed the static `USE_NEW_BLOCK_RENDERER` switch (and its `Launch` usage); both render paths read `ActiniumRuntime.options().performance.useFastBlockRenderer`.

Note: the legacy dev-only default (enabled in deobfuscated environments) is intentionally dropped — the default is now uniformly `false`, consistent with every other option. The `celeritas.useVintageFastBlockRenderer` system property had no other users and was removed with it.

## Verification

- `:check` passes (tests + remap/bridge/module-boundary verification).
- Dev-run regression: toggling the option survives a restart in both directions.