### PR TITLE
refactor: drop mods field from conditional mixin configs

### DIFF
--- a/src/main/resources/mixins.actinium.betterfoliage.json
+++ b/src/main/resources/mixins.actinium.betterfoliage.json
@@ -10,7 +10,6 @@
   "client": [
     "MixinChunkBuilderMeshingTaskBetterFoliage"
   ],
-  "mods": ["betterfoliage"],
   "injectors": {
     "defaultRequire": 1
   }

--- a/src/main/resources/mixins.actinium.ccl.json
+++ b/src/main/resources/mixins.actinium.ccl.json
@@ -10,7 +10,6 @@
   "client": [
     "MixinGlStateTracker"
   ],
-  "mods": ["codechickenlib"],
   "injectors": {
     "defaultRequire": 1
   }

--- a/src/main/resources/mixins.actinium.dh.json
+++ b/src/main/resources/mixins.actinium.dh.json
@@ -16,7 +16,6 @@
     "MixinLodRenderer",
     "MixinRenderUtil"
   ],
-  "mods": ["distanthorizons"],
   "injectors": {
     "defaultRequire": 1
   }

--- a/src/main/resources/mixins.actinium.gibbed.json
+++ b/src/main/resources/mixins.actinium.gibbed.json
@@ -10,7 +10,6 @@
   "client": [
     "BasicGibMixin"
   ],
-  "mods": ["gibbed"],
   "injectors": {
     "defaultRequire": 1
   }

--- a/src/main/resources/mixins.actinium.ichunutil.json
+++ b/src/main/resources/mixins.actinium.ichunutil.json
@@ -12,7 +12,6 @@
     "MixinRenderGlobalProxy",
     "MixinWorldPortalRenderer"
   ],
-  "mods": ["ichunutil"],
   "injectors": {
     "defaultRequire": 1
   }

--- a/src/main/resources/mixins.actinium.lumenized.json
+++ b/src/main/resources/mixins.actinium.lumenized.json
@@ -13,7 +13,6 @@
     "MixinShadersDepthTest",
     "MixinDepthTextureUtil"
   ],
-  "mods": ["lumenized"],
   "injectors": {
     "defaultRequire": 1
   }

--- a/src/main/resources/mixins.actinium.revoui.json
+++ b/src/main/resources/mixins.actinium.revoui.json
@@ -12,7 +12,6 @@
     "MixinScreenEffectsGradientRelocation",
     "ScreenEffectsRendererInvoker"
   ],
-  "mods": ["neofontrender_ui_enhancements"],
   "injectors": {
     "defaultRequire": 1
   }


### PR DESCRIPTION
Removes the `mods` field from all seven conditional mixin configs (`mixins.actinium.{betterfoliage,ccl,dh,gibbed,ichunutil,lumenized,revoui}.json`).

## Why

- `mods` is a MixinBooter extension, not part of the standard Mixin 0.8 config schema, so IDE mixin tooling cannot resolve these configs.
- Conditional loading is already handled by `MixinLate` through `mixins.actinium.conditions.properties` (a config is only loaded when all of its mod ids are present). The `mods` field was a redundant second gate that the IDE cannot parse.

## Verification

- `:check` passes (MixinConfigurationTest validates every declared mixin class exists; MixinLateTest validates the conditions gating).