### PR TITLE
fix(compat): deep StellarCore HudCaching compatibility

### DIFF
--- a/docs/compat/stellarcore.md
+++ b/docs/compat/stellarcore.md
@@ -1,14 +1,14 @@
 # StellarCore 兼容性说明
 
-兼容状态：**已验证**（GUI/HUD 症状实为 Draconic Evolution 引起，与 StellarCore 无关）
-最后更新：2026-08-12
+兼容状态：**部分**（HudCaching 与 Actinium 渲染管线已深度兼容，见下文）
+最后更新：2026-08-14
 
 ## 验证范围
 
-- 版本：1.5.22（`StellarCore-1.5.22.jar`）
+- 版本：1.6.0（`stellarcore-1064321-8406201`）；历史记录含 1.5.22
 - 整合包：NovaEngineering-World-cleanroom
-- 相关功能：HUD 缓存与 InGameInfoXML HUD framebuffer
-- 初始排查日期：2026-07-21；归因修正：2026-08-12
+- 相关功能：HUD 缓存（HudCaching）
+- 初始排查日期：2026-07-21；归因修正：2026-08-12；HudCaching 冲突确认与修复：2026-08-14
 
 ## 历史记录：GUI 闪烁或 Esc 菜单消失
 
@@ -31,8 +31,7 @@ A/B 验证将两个选项同时设为 `false` 后症状恢复，当时归因于 
 **实测表明 GUI 闪烁 / Esc 菜单消失 / 背包与 JEI 闪烁 / 左上角 HUD 异常均不是
 StellarCore 引起**，而是 Draconic Evolution 的渲染污染（DE 每帧 HUD 经 CCL
 `GlStateTracker` 基于冻结的原版 `GlStateManager` 字段重置 GL 状态，见
-[draconic-evolution.md](draconic-evolution.md)）。DE 兼容桥修复后，HUD 症状消失；
-StellarCore 的两个 HUD 选项（`HudCaching`、`HUDFramebuffer`）无需再关闭。
+[draconic-evolution.md](draconic-evolution.md)）。DE 兼容桥修复后，HUD 症状消失。
 
 ### 当时的排除验证（保留备查）
 
@@ -40,19 +39,69 @@ StellarCore 的两个 HUD 选项（`HudCaching`、`HUDFramebuffer`）无需再�
 整包，云层消失/草方块侧面颜色异常均无变化——该排除结论仍有效（这些症状最终
 归因于 DE，见 draconic-evolution.md）。
 
+## HudCaching 与 JourneyMap 小地图冲突（2026-08-14）
+
+### 现象
+
+`HudCaching=true` 时（默认），JourneyMap 小地图上的**半透明元素**渲染异常：
+
+- 网格线（区块分割线）、玩家准心、东南西北方向标显示为**全透明**，直接透出
+  小地图 GUI 看到游戏场景；
+- 无 Actinium 的对照实例（JourneyMap + StellarCore 1.6.0 + HudCaching=true）
+  显示正常，确认是 Actinium 侧的交互缺陷。
+
+### 机制
+
+StellarCore 的 `GlStateManagerMixin_HUDCaching`（`mixins.stellar_core_hudcaching.json`）
+在 HUD 缓存渲染期间（`HUDCaching.renderingCacheOverride=true`）拦截原版
+`GlStateManager.blendFunc/tryBlendFuncSeparate`，强制 alpha 混合因子
+`(ONE, ONE_MINUS_SRC_ALPHA)` 并经 `OpenGlHelper.glBlendFuncSeparate` 直接调用。
+
+Actinium 的 `GLSMRedirector`（AngelicaRedirectorTransformer）会把 HUD 元素
+（journeymap 等）对原版 `GlStateManager` 的调用重定向到 angelica `GLStateManager`
+（`glBlendFunc` 等只更新缓存状态），**StellarCore 的 mixin 钩子不再被触发**，
+HUD 缓存帧缓冲（非主 framebuffer）上的混合状态与 actinium 缓存不一致，导致
+HUD 缓存帧缓冲的 alpha 通道为 0，blit 到屏幕后元素区域透明。
+
+### 修复：GLSM 状态镜像（2026-08-14）
+
+Actinium 侧实现等价覆盖，镜像 StellarCore 的拦截窗口：
+
+- `GLSMConfig.hudCacheOverride` / `GLSMConfig.hudCacheBlendEnabled`：GLSM 的
+  blend/color 路径在 `hudCacheOverride=true` 期间应用与 StellarCore 相同的
+  覆盖（`enableBlend/disableBlend` 记录混合开关；混合关闭时
+  `changeColor` 强制 alpha=1；`tryBlendFuncSeparate` 强制
+  `(ONE, ONE_MINUS_SRC_ALPHA)` 因子）；
+- `StellarCoreHudCachingCompatTransformer`（launchwrapper transformer，
+  注册于 `MixinEarly.getASMTransformerClass`）：重写
+  `HUDCaching.renderCachedHud`，在 `renderingCacheOverride` 每次赋值后镜像到
+  `GLSMConfig.hudCacheOverride`，并在缓存渲染的 `GuiIngame.renderGameOverlay`
+  调用前恢复 HUD 基线（alpha test `GREATER/0.1` 等）；
+- `GuiGlStateBoundary.restoreHudBaseline` 承担基线恢复（原由
+  `EntityRenderer.updateCameraAndRender` 的注入点负责，但 StellarCore 的
+  `@Redirect` 替换了该调用点）。
+
+**为什么用 transformer 而不是 mixin**：`HUDCaching` 类由 StellarCore 自己的
+early mixin loader 在 tweak 引导阶段加载，早于任何 mixin prepare 阶段；无论
+early 还是 late 注册，mixin 都会抛 `MixinTargetAlreadyLoadedException`（实测
+确认）。launchwrapper transformer 在类 define 前介入，与加载时机无关。
+
+单元测试：`StellarCoreHudCachingCompatTransformerTest`（用依赖 jar 的真实
+`HUDCaching` 字节码验证镜像窗口与基线恢复的注入结果）。
+
+### 验证
+
+- `HudCaching=true` + `JourneyMap 5.7.1p3`：小地图网格线、玩家准心、方向标
+  正常可见（2026-08-14 实测通过）。
+
 ## 推荐配置
 
-不再需要关闭 StellarCore 的 HUD 缓存选项。可恢复：
-
-```text
-general.performance.vanilla.HudCaching=true
-general.performance.ingameinfoxml.HUDFramebuffer=true
-```
-
-恢复后建议按下方验证范围重测一次（DE 在场场景），确认 HUD 缓存与 Actinium
-GUI 管线共存无回归。
+**HudCaching 保持开启**（默认值，已深度兼容）；`HUDFramebuffer`（InGameInfoXML）
+与 Actinium GUI 管线共存无已知问题。
 
 ## 残余限制
 
-- 归因修正基于 DE 兼容桥修复后的生产实测；StellarCore 版本升级后需重测。
+- 归因修正基于 DE 兼容桥修复后的生产实测；StellarCore 版本升级后需重测
+  （`HUDCaching.renderCachedHud` 字节码结构变化会使 transformer 匹配失败并
+  记录 WARN，需同步更新）。
 - 本说明不代表 StellarCore 的其他功能均已验证。

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -1253,6 +1253,9 @@ public class GLStateManager {
             bh.deferBlendModeToggle(true);
             return;
         }
+        if (GLSMConfig.hudCacheOverride) {
+            GLSMConfig.hudCacheBlendEnabled = true;
+        }
         blendMode.enable();
     }
 
@@ -1268,6 +1271,9 @@ public class GLStateManager {
         if (bh != null && bh.isBlendLocked()) {
             bh.deferBlendModeToggle(false);
             return;
+        }
+        if (GLSMConfig.hudCacheOverride) {
+            GLSMConfig.hudCacheBlendEnabled = false;
         }
         blendMode.disable();
     }
@@ -1597,6 +1603,15 @@ public class GLStateManager {
 
     private static boolean changeColor(float red, float green, float blue, float alpha) {
         // Helper function for glColor*
+        // Mirrors StellarCore's HudCaching color interceptor: while rendering into the
+        // HUD cache framebuffer with blending disabled, translucent colors would write
+        // their own alpha into the cache buffer; the cached-HUD blit blends RGB by alpha,
+        // so those areas would show through as fully transparent. StellarCore forces
+        // alpha to 1 in that window; GLSM's redirect path must apply the same override
+        // because StellarCore's own mixin can no longer intercept the call.
+        if (GLSMConfig.hudCacheOverride && !GLSMConfig.hudCacheBlendEnabled && alpha < 1.0F) {
+            alpha = 1.0F;
+        }
         final boolean caching = isCachingEnabled();
         if (BYPASS_CACHE || !caching || red != color.getRed() || green != color.getGreen() || blue != color.getBlue() || alpha != color.getAlpha()) {
             if (caching) {
@@ -1618,8 +1633,13 @@ public class GLStateManager {
     private static final Color4 DirtyColor = new Color4(-1.0F, -1.0F, -1.0F, -1.0F);
 
     public static void clearCurrentColor() {
-        // Marks the cache dirty, doesn't actually reset the color
+        // Marks the cache dirty, doesn't actually reset the color.
+        // The -1 sentinel forces the next real glColor call to bypass the cache,
+        // and bumps the generation so FFP emulation re-uploads the default color
+        // (GL current color semantics: resetColor restores opaque white).
+        // FFP uniform uploads must normalize the sentinel (see Uniforms.sanitizeUniformColor).
         color.set(DirtyColor);
+        colorGeneration++;
     }
 
     public static void glColorMask(boolean red, boolean green, boolean blue, boolean alpha) {

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/Uniforms.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/Uniforms.java
@@ -2,6 +2,7 @@ package com.gtnewhorizons.angelica.glsm.ffp;
 
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import com.gtnewhorizons.angelica.glsm.states.ClipPlaneState;
+import com.gtnewhorizons.angelica.glsm.states.Color4;
 import com.gtnewhorizons.angelica.glsm.states.FogState;
 import com.gtnewhorizons.angelica.glsm.states.LightState;
 import com.gtnewhorizons.angelica.glsm.states.MaterialState;
@@ -294,7 +295,7 @@ public class Uniforms {
     private void uploadCurrentColor(Program program) {
         if (program.locCurrentColor == -1) return;
         // Upload the current color from GLSM
-        final var color = GLStateManager.getColor();
+        final Color4 color = sanitizeUniformColor(GLStateManager.getColor());
         vec4Buf.clear();
         vec4Buf.put(color.getRed());
         vec4Buf.put(color.getGreen());
@@ -302,6 +303,23 @@ public class Uniforms {
         vec4Buf.put(color.getAlpha());
         vec4Buf.flip();
         RENDER_BACKEND.uniform4(program.locCurrentColor, vec4Buf);
+    }
+
+    /**
+     * Normalizes the GLSM current color for FFP uniform upload.
+     *
+     * <p>{@link GLStateManager#clearCurrentColor()} marks the cached color with a
+     * (-1,-1,-1,-1) sentinel so the next real {@code glColor*} call bypasses the cache.
+     * That sentinel must never reach a shader uniform: a negative alpha clamps to 0 in
+     * GLSL, making every vertex-color-less draw (e.g. JourneyMap map tiles/grids)
+     * fully transparent. Per GL semantics the current color defaults to opaque white,
+     * so the sentinel is normalized back to (1,1,1,1) here.</p>
+     */
+    static Color4 sanitizeUniformColor(Color4 color) {
+        if (color.getRed() < 0.0F || color.getGreen() < 0.0F || color.getBlue() < 0.0F || color.getAlpha() < 0.0F) {
+            return new Color4(1.0F, 1.0F, 1.0F, 1.0F);
+        }
+        return color;
     }
 
     private void uploadCurrentTexCoord(Program program) {

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/hooks/GLSMConfig.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/hooks/GLSMConfig.java
@@ -6,7 +6,17 @@ public final class GLSMConfig {
     public static float lastBrightnessX;
     public static float lastBrightnessY;
 
+    // True while StellarCore renders HUD content into its cached framebuffer
+    // (HUDCaching.renderingCacheOverride). Mirrors the alpha-factor override
+    // StellarCore applies through its vanilla GlStateManager mixins, which are
+    // bypassed by the GLSM redirector.
     public static boolean hudCacheOverride;
+
+    // Blend enabled/disabled as seen inside the HUD cache rendering window;
+    // mirrors StellarCore's HUDCaching blendEnabled bookkeeping used by its
+    // color interceptor (translucent colors are forced opaque when blending is
+    // disabled so the cache buffer alpha stays intact).
+    public static boolean hudCacheBlendEnabled;
 
     private GLSMConfig() {}
 }

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -66,6 +66,9 @@ dependencies {
     compileOnly 'curse.maven:xaeros-minimap-263420:6310964'
     compileOnly 'curse.maven:better-hud-286066:3327633'
     compileOnly 'curse.maven:voxelmap-225179:3029445'
+
+    modImplementation 'curse.maven:journeymap-32274:5172461'  // JourneyMap 1.12.2-5.7.1p3 (StellarCore 1.6.0 references common.feature.PlayerRadarManager; 6.0.3 moved it to common.util and crashes)
+
     compileOnly 'curse.maven:scalingguis-319656:5150678'
     compileOnly 'curse.maven:quark-243121:2924091'
     compileOnly 'curse.maven:valkyrie-874067:5235356'

--- a/src/main/java/com/dhj/actinium/loading/fml/transformers/StellarCoreHudCachingCompatTransformer.java
+++ b/src/main/java/com/dhj/actinium/loading/fml/transformers/StellarCoreHudCachingCompatTransformer.java
@@ -1,0 +1,180 @@
+package com.dhj.actinium.loading.fml.transformers;
+
+import net.minecraft.launchwrapper.IClassTransformer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+
+/**
+ * Bridges StellarCore's HudCaching with the GLSM state cache.
+ *
+ * <p>StellarCore renders the HUD into a cached framebuffer while
+ * {@code HUDCaching.renderingCacheOverride} is true, and its own mixins
+ * intercept the vanilla {@code GlStateManager} blend/color calls during that
+ * window to force alpha factors {@code (ONE, ONE_MINUS_SRC_ALPHA)} and opaque
+ * colors. Under Actinium those callers are redirected to the GLSM cache
+ * instead, so StellarCore's interceptors never run; without the same overrides
+ * the cache buffer ends up with per-element alpha (e.g. 0.3 for the JourneyMap
+ * grid, 0 for the reticle) and the cached-HUD blit — whose RGB blend depends
+ * on alpha — shows those areas as fully transparent, revealing the scene
+ * behind the map GUI.</p>
+ *
+ * <p>{@code HUDCaching} is loaded by StellarCore's own early mixin loader
+ * during tweak bootstrap, before any mixin prepare phase can run; a mixin
+ * targeting it fails with {@code MixinTargetAlreadyLoadedException} no matter
+ * how early the config is registered. A launchwrapper transformer is the only
+ * hook that runs before the class is defined regardless of when it is loaded,
+ * so this transformer rewrites {@code renderCachedHud} directly:</p>
+ *
+ * <ul>
+ *   <li>after each {@code renderingCacheOverride} store, mirror the value onto
+ *       {@code GLSMConfig.hudCacheOverride} so the GLSM blend/color paths apply
+ *       the same overrides StellarCore would have applied;</li>
+ *   <li>right before the {@code GuiIngame.renderGameOverlay} call inside the
+ *       override window, restore the HUD baseline (alpha test {@code GREATER/0.1}
+ *       etc.), since the call site that normally carries the baseline
+ *       restoration in {@code EntityRenderer.updateCameraAndRender} is replaced
+ *       by StellarCore's {@code @Redirect}.</li>
+ * </ul>
+ */
+public final class StellarCoreHudCachingCompatTransformer implements IClassTransformer {
+    private static final Logger LOGGER = LogManager.getLogger("Actinium");
+
+    private static final String TARGET_CLASS =
+        "github.kasuminova.stellarcore.client.hudcaching.HUDCaching";
+    private static final String TARGET_METHOD = "renderCachedHud";
+    private static final String TARGET_METHOD_DESC =
+        "(Lnet/minecraft/client/renderer/EntityRenderer;Lnet/minecraft/client/gui/GuiIngame;F)V";
+
+    private static final String OVERRIDE_OWNER = TARGET_CLASS.replace('.', '/');
+    private static final String OVERRIDE_FIELD = "renderingCacheOverride";
+    private static final String OVERRIDE_DESC = "Z";
+
+    private static final String GLSM_CONFIG_OWNER =
+        "com/gtnewhorizons/angelica/glsm/hooks/GLSMConfig";
+    private static final String GLSM_CONFIG_FIELD = "hudCacheOverride";
+    private static final String GLSM_CONFIG_DESC = "Z";
+
+    private static final String BOUNDARY_OWNER = "com/dhj/actinium/render/GuiGlStateBoundary";
+    private static final String BOUNDARY_METHOD = "restoreHudBaseline";
+    private static final String BOUNDARY_DESC = "()V";
+
+    private static final String GAME_OVERLAY_OWNER = "net/minecraft/client/gui/GuiIngame";
+    private static final String GAME_OVERLAY_METHOD = "renderGameOverlay";
+    private static final String GAME_OVERLAY_DESC = "(F)V";
+
+    @Override
+    public byte[] transform(String name, String transformedName, byte[] basicClass) {
+        if (basicClass == null || !TARGET_CLASS.equals(transformedName)) {
+            return basicClass;
+        }
+
+        ClassReader classReader = new ClassReader(basicClass);
+        ClassNode classNode = new ClassNode();
+        classReader.accept(classNode, 0);
+        boolean transformed = false;
+
+        for (MethodNode method : classNode.methods) {
+            if (!TARGET_METHOD.equals(method.name) || !TARGET_METHOD_DESC.equals(method.desc)) {
+                continue;
+            }
+            transformed = rewriteRenderCachedHud(method);
+            break;
+        }
+
+        if (!transformed) {
+            LOGGER.warn(
+                "Could not find the expected HudCaching instructions in {}; "
+                    + "StellarCore's cached HUD may render incorrectly",
+                TARGET_CLASS
+            );
+            return basicClass;
+        }
+
+        // No branches are added and the stack balance is unchanged, so the
+        // original stack map frames stay valid; copying them avoids resolving
+        // classes while this class is still being defined.
+        ClassWriter writer = new ClassWriter(classReader, 0);
+        classNode.accept(writer);
+        return writer.toByteArray();
+    }
+
+    private static boolean rewriteRenderCachedHud(MethodNode method) {
+        boolean transformed = false;
+        boolean insideOverrideWindow = false;
+
+        for (AbstractInsnNode instruction = method.instructions.getFirst();
+             instruction != null;
+             instruction = instruction.getNext()) {
+
+            if (instruction.getOpcode() == Opcodes.PUTSTATIC
+                && isOverrideStore((FieldInsnNode) instruction)) {
+                AbstractInsnNode pushed = instruction.getPrevious();
+                int value = pushed != null ? constantValue(pushed) : -1;
+                if (value < 0) {
+                    LOGGER.warn("renderingCacheOverride store without a constant push in {}; aborting", TARGET_CLASS);
+                    return false;
+                }
+                // The pushed constant was consumed by the original store, so
+                // re-push it for the mirrored store (net stack change: zero).
+                // InsnList has no "insert after", so anchor on the next node.
+                AbstractInsnNode anchor = instruction.getNext();
+                InsnList mirror = new InsnList();
+                mirror.add(new InsnNode(value == 1 ? Opcodes.ICONST_1 : Opcodes.ICONST_0));
+                mirror.add(new FieldInsnNode(
+                    Opcodes.PUTSTATIC, GLSM_CONFIG_OWNER, GLSM_CONFIG_FIELD, GLSM_CONFIG_DESC));
+                if (anchor == null) {
+                    method.instructions.add(mirror);
+                } else {
+                    method.instructions.insertBefore(anchor, mirror);
+                }
+                insideOverrideWindow = value == 1;
+                transformed = true;
+                continue;
+            }
+
+            if (insideOverrideWindow
+                && instruction.getOpcode() == Opcodes.INVOKEVIRTUAL
+                && isGameOverlayCall((MethodInsnNode) instruction)) {
+                method.instructions.insertBefore(
+                    instruction,
+                    new MethodInsnNode(Opcodes.INVOKESTATIC, BOUNDARY_OWNER, BOUNDARY_METHOD, BOUNDARY_DESC, false)
+                );
+                transformed = true;
+            }
+        }
+
+        return transformed;
+    }
+
+    private static boolean isOverrideStore(FieldInsnNode field) {
+        return OVERRIDE_OWNER.equals(field.owner)
+            && OVERRIDE_FIELD.equals(field.name)
+            && OVERRIDE_DESC.equals(field.desc);
+    }
+
+    private static boolean isGameOverlayCall(MethodInsnNode call) {
+        return GAME_OVERLAY_OWNER.equals(call.owner)
+            && GAME_OVERLAY_METHOD.equals(call.name)
+            && GAME_OVERLAY_DESC.equals(call.desc);
+    }
+
+    private static int constantValue(AbstractInsnNode instruction) {
+        if (instruction.getOpcode() == Opcodes.ICONST_0) {
+            return 0;
+        }
+        if (instruction.getOpcode() == Opcodes.ICONST_1) {
+            return 1;
+        }
+        return -1;
+    }
+}

--- a/src/main/java/com/dhj/actinium/mixins/MixinEarly.java
+++ b/src/main/java/com/dhj/actinium/mixins/MixinEarly.java
@@ -1,6 +1,7 @@
 package com.dhj.actinium.mixins;
 
 import com.dhj.actinium.loading.fml.transformers.MacDisplayForwardCompatTransformer;
+import com.dhj.actinium.loading.fml.transformers.StellarCoreHudCachingCompatTransformer;
 import net.minecraft.launchwrapper.Launch;
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
 import org.jetbrains.annotations.Nullable;
@@ -8,14 +9,13 @@ import org.spongepowered.asm.mixin.MixinEnvironment;
 import zone.rong.mixinbooter.IEarlyMixinLoader;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 @IFMLLoadingPlugin.Name("Actinium")
 @IFMLLoadingPlugin.MCVersion("1.12.2")
 public class MixinEarly implements IFMLLoadingPlugin, IEarlyMixinLoader {
-    private static final List<String> MIXIN_CONFIGS = Arrays.asList(
+    private static final List<String> MIXIN_CONFIGS = List.of(
         "mixins.actinium.vintage.json",
         "mixins.actinium.iris.json"
     );
@@ -29,6 +29,7 @@ public class MixinEarly implements IFMLLoadingPlugin, IEarlyMixinLoader {
     public @Nullable String[] getASMTransformerClass() {
         return new String[] {
             MacDisplayForwardCompatTransformer.class.getName(),
+            StellarCoreHudCachingCompatTransformer.class.getName(),
             "com.gtnewhorizons.angelica.loading.fml.transformers.EarlyRedirectorTransformer"
         };
     }

--- a/src/test/java/com/dhj/actinium/loading/fml/transformers/StellarCoreHudCachingCompatTransformerTest.java
+++ b/src/test/java/com/dhj/actinium/loading/fml/transformers/StellarCoreHudCachingCompatTransformerTest.java
@@ -1,0 +1,142 @@
+package com.dhj.actinium.loading.fml.transformers;
+
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that {@link StellarCoreHudCachingCompatTransformer} mirrors
+ * StellarCore's {@code renderingCacheOverride} window onto
+ * {@code GLSMConfig.hudCacheOverride} and restores the HUD baseline right
+ * before the cached {@code renderGameOverlay} call, using the real
+ * {@code HUDCaching} class bytes from the StellarCore dependency.
+ */
+class StellarCoreHudCachingCompatTransformerTest {
+    private static final String HUD_CACHING_RESOURCE =
+        "github/kasuminova/stellarcore/client/hudcaching/HUDCaching.class";
+    private static final String HUD_CACHING_CLASS =
+        "github.kasuminova.stellarcore.client.hudcaching.HUDCaching";
+    private static final String OVERRIDE_OWNER =
+        "github/kasuminova/stellarcore/client/hudcaching/HUDCaching";
+    private static final String GLSM_CONFIG_OWNER =
+        "com/gtnewhorizons/angelica/glsm/hooks/GLSMConfig";
+    private static final String BOUNDARY_OWNER =
+        "com/dhj/actinium/render/GuiGlStateBoundary";
+
+    @Test
+    void transformMirrorsOverrideWindowAndRestoresBaseline() throws IOException {
+        byte[] original = readHudCachingClass();
+        byte[] transformed = new StellarCoreHudCachingCompatTransformer()
+            .transform(HUD_CACHING_CLASS, HUD_CACHING_CLASS, original);
+
+        assertNotNull(transformed);
+        assertNotSame(original, transformed, "target class must be rewritten");
+        assertTrue(transformed.length > original.length,
+            "mirrored stores and baseline restore must add instructions");
+
+        List<String> events = collectRenderCachedHudEvents(transformed);
+        assertEquals(List.of(
+            "renderGameOverlay",                    // non-cached early path, no restore
+            "override=true",
+            "mirror=true",
+            "restoreHudBaseline",
+            "renderGameOverlay",                    // cached render, restore applied
+            "override=false",
+            "mirror=false"
+        ), events);
+    }
+
+    @Test
+    void transformLeavesUnrelatedClassesUntouched() throws IOException {
+        byte[] original = readHudCachingClass();
+        StellarCoreHudCachingCompatTransformer transformer = new StellarCoreHudCachingCompatTransformer();
+
+        assertArrayEquals(original, transformer.transform("a.b.C", "a.b.C", original));
+        assertArrayEquals(original, transformer.transform(null, "some.other.Class", original));
+        assertNull(transformer.transform(HUD_CACHING_CLASS, HUD_CACHING_CLASS, null));
+    }
+
+    private static byte[] readHudCachingClass() throws IOException {
+        try (InputStream stream = StellarCoreHudCachingCompatTransformerTest.class
+            .getClassLoader().getResourceAsStream(HUD_CACHING_RESOURCE)) {
+            assertNotNull(stream,
+                "StellarCore must be on the test classpath to provide " + HUD_CACHING_RESOURCE);
+            return stream.readAllBytes();
+        }
+    }
+
+    private static List<String> collectRenderCachedHudEvents(byte[] classBytes) {
+        ClassNode node = new ClassNode();
+        new ClassReader(classBytes).accept(node, 0);
+
+        MethodNode renderCachedHud = node.methods.stream()
+            .filter(method -> "renderCachedHud".equals(method.name))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("renderCachedHud not found"));
+
+        List<String> events = new ArrayList<>();
+        for (AbstractInsnNode instruction = renderCachedHud.instructions.getFirst();
+             instruction != null;
+             instruction = instruction.getNext()) {
+
+            if (instruction.getOpcode() == Opcodes.PUTSTATIC) {
+                FieldInsnNode field = (FieldInsnNode) instruction;
+                if (OVERRIDE_OWNER.equals(field.owner) && "renderingCacheOverride".equals(field.name)) {
+                    int value = constantBefore(instruction);
+                    events.add("override=" + (value == 1));
+                    assertEquals(value == 1 ? Opcodes.ICONST_1 : Opcodes.ICONST_0,
+                        instruction.getPrevious().getOpcode(),
+                        "original override store must still be preceded by its constant");
+                } else if (GLSM_CONFIG_OWNER.equals(field.owner) && "hudCacheOverride".equals(field.name)) {
+                    int value = constantBefore(instruction);
+                    events.add("mirror=" + (value == 1));
+                    assertEquals(value == 1 ? Opcodes.ICONST_1 : Opcodes.ICONST_0,
+                        instruction.getPrevious().getOpcode(),
+                        "mirrored store must re-push the mirrored constant");
+                }
+            } else if (instruction.getOpcode() == Opcodes.INVOKESTATIC
+                && instruction instanceof MethodInsnNode call
+                && BOUNDARY_OWNER.equals(call.owner)
+                && "restoreHudBaseline".equals(call.name)) {
+                events.add("restoreHudBaseline");
+            } else if (instruction.getOpcode() == Opcodes.INVOKEVIRTUAL
+                && instruction instanceof MethodInsnNode call
+                && "net/minecraft/client/gui/GuiIngame".equals(call.owner)
+                && "renderGameOverlay".equals(call.name)) {
+                events.add("renderGameOverlay");
+            }
+        }
+        return events;
+    }
+
+    private static int constantBefore(AbstractInsnNode instruction) {
+        AbstractInsnNode previous = instruction.getPrevious();
+        if (previous == null) {
+            return -1;
+        }
+        if (previous.getOpcode() == Opcodes.ICONST_1) {
+            return 1;
+        }
+        if (previous.getOpcode() == Opcodes.ICONST_0) {
+            return 0;
+        }
+        return -1;
+    }
+}

--- a/src/test/java/com/dhj/actinium/mixin/MixinConfigurationTest.java
+++ b/src/test/java/com/dhj/actinium/mixin/MixinConfigurationTest.java
@@ -82,7 +82,7 @@ class MixinConfigurationTest {
     void earlyAndLateLoadersCoverEveryMainMixinConfig() throws IOException {
         ClassLoader classLoader = MixinConfigurationTest.class.getClassLoader();
         Set<String> earlyConfigs = compiledMixinConfigs(
-            classLoader, "com/dhj/actinium/mixins/MixinEarly.class", "<clinit>");
+            classLoader, "com/dhj/actinium/mixins/MixinEarly.class");
         // MixinLate loads its configs from mixins.actinium.conditions.properties.
         Set<String> lateConfigs = readConditions(classLoader).keySet().stream()
             .map(String::valueOf)
@@ -132,7 +132,7 @@ class MixinConfigurationTest {
     void conditionalConfigsDeclareModRequirements() throws IOException {
         ClassLoader classLoader = MixinConfigurationTest.class.getClassLoader();
         final Set<String> earlyConfigs = compiledMixinConfigs(
-            classLoader, "com/dhj/actinium/mixins/MixinEarly.class", "<clinit>");
+            classLoader, "com/dhj/actinium/mixins/MixinEarly.class");
         final Set<String> lateConfigs = readConditions(classLoader).keySet().stream()
             .map(String::valueOf)
             .collect(java.util.stream.Collectors.toSet());
@@ -164,19 +164,21 @@ class MixinConfigurationTest {
         }
     }
 
-    private static Set<String> compiledMixinConfigs(
-        ClassLoader classLoader,
-        String resourceName,
-        String methodName
-    ) throws IOException {
+    private static Set<String> compiledMixinConfigs(ClassLoader classLoader, String resourceName)
+        throws IOException {
+        // The loader collects its config strings in <clinit> and any helper
+        // methods it calls; scan every method body so refactors that move the
+        // literals into a builder method keep the test meaningful.
         ClassNode node = readClass(classLoader, resourceName);
-        MethodNode configMethod = node.methods.stream()
-            .filter(method -> methodName.equals(method.name))
-            .findFirst()
-            .orElseThrow(() -> new AssertionError(resourceName + " has no " + methodName + " method"));
         Set<String> configs = new HashSet<>();
+        for (MethodNode method : node.methods) {
+            collectConfigLiterals(method, configs);
+        }
+        return configs;
+    }
 
-        for (var instruction = configMethod.instructions.getFirst(); instruction != null;
+    private static void collectConfigLiterals(MethodNode method, Set<String> configs) {
+        for (var instruction = method.instructions.getFirst(); instruction != null;
              instruction = instruction.getNext()) {
             if (instruction instanceof LdcInsnNode ldc
                 && ldc.cst instanceof String value
@@ -184,7 +186,6 @@ class MixinConfigurationTest {
                 configs.add(value);
             }
         }
-        return configs;
     }
 
     private static JsonObject readConfig(ClassLoader classLoader, String configName) throws IOException {

--- a/src/test/java/com/gtnewhorizons/angelica/glsm/ffp/UniformColorSanitizeTest.java
+++ b/src/test/java/com/gtnewhorizons/angelica/glsm/ffp/UniformColorSanitizeTest.java
@@ -1,0 +1,53 @@
+package com.gtnewhorizons.angelica.glsm.ffp;
+
+import com.gtnewhorizons.angelica.glsm.states.Color4;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Verifies that the GLSM current-color dirty sentinel never leaks into FFP shader
+ * uniforms. {@code GLStateManager.clearCurrentColor()} (the redirect target of
+ * vanilla {@code GlStateManager.resetColor()}) marks the cached color with
+ * (-1,-1,-1,-1); uploading that raw value makes every vertex-color-less draw
+ * fully transparent (negative alpha clamps to 0 in GLSL).
+ *
+ * <p>GLStateManager itself cannot be loaded without a GL context (its static
+ * initializers query the backend), so the sentinel state is reproduced directly.
+ */
+class UniformColorSanitizeTest {
+
+    @Test
+    void dirtySentinelColorIsNormalizedToOpaqueWhite() {
+        Color4 result = Uniforms.sanitizeUniformColor(new Color4(-1.0F, -1.0F, -1.0F, -1.0F));
+
+        assertEquals(1.0F, result.getRed());
+        assertEquals(1.0F, result.getGreen());
+        assertEquals(1.0F, result.getBlue());
+        assertEquals(1.0F, result.getAlpha());
+    }
+
+    @Test
+    void partiallyNegativeSentinelIsNormalizedToOpaqueWhite() {
+        Color4 result = Uniforms.sanitizeUniformColor(new Color4(1.0F, 1.0F, 1.0F, -1.0F));
+
+        assertEquals(1.0F, result.getAlpha());
+        assertEquals(1.0F, result.getRed());
+    }
+
+    @Test
+    void zeroAlphaColorIsNotTreatedAsDirtySentinel() {
+        Color4 result = Uniforms.sanitizeUniformColor(new Color4(0.0F, 0.0F, 0.0F, 0.0F));
+
+        assertSame(result, Uniforms.sanitizeUniformColor(result));
+        assertEquals(0.0F, result.getAlpha());
+    }
+
+    @Test
+    void validColorPassesThroughUnchanged() {
+        Color4 color = new Color4(0.5F, 0.5F, 0.5F, 0.5F);
+
+        assertSame(color, Uniforms.sanitizeUniformColor(color));
+    }
+}

--- a/src/test/java/com/gtnewhorizons/angelica/glsm/redirect/GLSMRedirectorTest.java
+++ b/src/test/java/com/gtnewhorizons/angelica/glsm/redirect/GLSMRedirectorTest.java
@@ -1,0 +1,89 @@
+package com.gtnewhorizons.angelica.glsm.redirect;
+
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that the GLSM redirector rewrites vanilla
+ * {@code net.minecraft.client.renderer.GlStateManager} calls (e.g. the color set
+ * used by JourneyMap's map grid) to the GLSM state cache. This is the mechanism
+ * that keeps the FFP shader's {@code u_CurrentColor} uniform in sync with vanilla
+ * fixed-function color calls on the core-profile context.
+ */
+class GLSMRedirectorTest {
+
+    private static final String VANILLA_GL_STATE_MANAGER = "net/minecraft/client/renderer/GlStateManager";
+    private static final String GLSM_GL_STATE_MANAGER = "com/gtnewhorizons/angelica/glsm/GLStateManager";
+
+    @Test
+    void rewritesVanillaGlStateManagerColorToGlsmCache() {
+        byte[] classBytes = generateClassCallingVanillaColor();
+        GLSMRedirector redirector = new GLSMRedirector();
+
+        assertTrue(redirector.shouldTransform(classBytes), "class referencing GlStateManager.color must be a redirect candidate");
+
+        ClassNode cn = new ClassNode();
+        new ClassReader(classBytes).accept(cn, 0);
+        boolean changed = redirector.transformClassNode("sample/Class", cn);
+        assertTrue(changed, "GlStateManager.color call must be rewritten");
+
+        MethodNode render = cn.methods.stream()
+            .filter(m -> m.name.equals("render"))
+            .findFirst()
+            .orElseThrow();
+        boolean redirected = false;
+        for (AbstractInsnNode node : render.instructions) {
+            if (node instanceof MethodInsnNode call
+                && call.getOpcode() == Opcodes.INVOKESTATIC
+                && call.owner.equals(GLSM_GL_STATE_MANAGER)
+                && call.name.equals("glColor4f")) {
+                redirected = true;
+                break;
+            }
+        }
+        assertTrue(redirected, "call must be redirected to GLSM GLStateManager.glColor4f");
+    }
+
+    @Test
+    void untouchedClassWithoutGlReferencesIsNotTransformed() {
+        ClassWriter cw = new ClassWriter(0);
+        cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, "sample/Plain", null, "java/lang/Object", null);
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "ping", "()I", null, null);
+        mv.visitCode();
+        mv.visitInsn(Opcodes.ICONST_0);
+        mv.visitInsn(Opcodes.IRETURN);
+        mv.visitMaxs(1, 0);
+        mv.visitEnd();
+        cw.visitEnd();
+
+        GLSMRedirector redirector = new GLSMRedirector();
+        assertEquals(false, redirector.shouldTransform(cw.toByteArray()));
+    }
+
+    private static byte[] generateClassCallingVanillaColor() {
+        ClassWriter cw = new ClassWriter(0);
+        cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, "sample/Class", null, "java/lang/Object", null);
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "render", "()V", null, null);
+        mv.visitCode();
+        mv.visitLdcInsn(0.5F);
+        mv.visitLdcInsn(0.5F);
+        mv.visitLdcInsn(0.5F);
+        mv.visitLdcInsn(0.5F);
+        mv.visitMethodInsn(Opcodes.INVOKESTATIC, VANILLA_GL_STATE_MANAGER, "color", "(FFFF)V", false);
+        mv.visitInsn(Opcodes.RETURN);
+        mv.visitMaxs(4, 1);
+        mv.visitEnd();
+        cw.visitEnd();
+        return cw.toByteArray();
+    }
+}

--- a/src/test/java/com/gtnewhorizons/angelica/glsm/redirect/JourneyMapRedirectorTest.java
+++ b/src/test/java/com/gtnewhorizons/angelica/glsm/redirect/JourneyMapRedirectorTest.java
@@ -1,0 +1,71 @@
+package com.gtnewhorizons.angelica.glsm.redirect;
+
+import com.gtnewhorizons.angelica.loading.shared.transformers.AngelicaRedirector;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Spliterators;
+import java.util.stream.StreamSupport;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that JourneyMap's class bytecode (as shipped in the dev runtime,
+ * mapped-mcp names) is rewritten by the Angelica redirector so that vanilla
+ * {@code GlStateManager} calls reach the GLSM state cache. This is what keeps
+ * the FFP shader's {@code u_CurrentColor} uniform in sync with the map grid's
+ * {@code GlStateManager.color(...)} calls on the core-profile context.
+ *
+ * <p>Reads {@code GridSpec.class} straight from the test classpath (the
+ * journeymap modImplementation jar is part of the shared Minecraft compile
+ * classpath) and runs the exact redirect pipeline used at runtime.</p>
+ */
+class JourneyMapRedirectorTest {
+
+    private static final String GLSM_GL_STATE_MANAGER = "com/gtnewhorizons/angelica/glsm/GLStateManager";
+
+    @Test
+    void journeyMapGridSpecColorCallsAreRedirectedToGlsm() throws IOException {
+        byte[] classBytes = readClassBytes("journeymap/client/model/GridSpec.class");
+        assertNotNull(classBytes, "journeymap must be on the test classpath (modImplementation)");
+
+        AngelicaRedirector redirector = new AngelicaRedirector();
+        assertTrue(redirector.shouldTransform(classBytes), "GridSpec references vanilla GlStateManager and must be a redirect candidate");
+
+        ClassNode cn = new ClassNode();
+        new ClassReader(classBytes).accept(cn, 0);
+        boolean changed = redirector.transformClassNode("journeymap.client.model.GridSpec", cn);
+        assertTrue(changed, "GridSpec's GlStateManager calls must be rewritten");
+
+        boolean glColorRedirected = cn.methods.stream()
+            .flatMap(m -> StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(m.instructions.iterator(), 0), false))
+            .filter(MethodInsnNode.class::isInstance)
+            .map(MethodInsnNode.class::cast)
+            .anyMatch(call -> call.owner.equals(GLSM_GL_STATE_MANAGER) && call.name.equals("glColor4f"));
+        assertTrue(glColorRedirected, "GridSpec.color(...) must be redirected to GLSM GLStateManager.glColor4f");
+
+        boolean blendRedirected = cn.methods.stream()
+            .flatMap(m -> StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(m.instructions.iterator(), 0), false))
+            .filter(MethodInsnNode.class::isInstance)
+            .map(MethodInsnNode.class::cast)
+            .anyMatch(call -> call.owner.equals(GLSM_GL_STATE_MANAGER) && call.name.equals("enableBlend"));
+        assertTrue(blendRedirected, "GridSpec.enableBlend() must be redirected to GLSM GLStateManager.enableBlend");
+    }
+
+    private static byte[] readClassBytes(String resource) throws IOException {
+        try (InputStream in = JourneyMapRedirectorTest.class.getClassLoader().getResourceAsStream(resource)) {
+            if (in == null) {
+                return null;
+            }
+            return in.readAllBytes();
+        }
+    }
+}


### PR DESCRIPTION
## 概述

修复 StellarCore HudCaching 与 Actinium GLSM 重定向的深度兼容：`HudCaching=true` 时 JourneyMap 小地图半透明元素（网格线/准心/方位标）不再全透明透出场景。

## 变更内容

### 1. `fix(compat): pin JourneyMap to 5.7.1p3 for StellarCore compatibility`

JourneyMap 6.0.3 将 `PlayerRadarManager` 移至 `common.util`，StellarCore 1.6.0 仍引用 `common.feature` 导致 `NoClassDefFoundError`。将依赖固定到与 StellarCore 兼容的最新版本 5.7.1p3（curse file 5172461）。

### 2. `fix(compat): mirror StellarCore HudCaching state in GLSM`

**机制**：StellarCore 在 `HUDCaching.renderCachedHud` 的缓存渲染窗口（`renderingCacheOverride=true`）内经 `GlStateManagerMixin_HUDCaching` 拦截原版 `GlStateManager` blend/color 调用，强制 alpha 混合因子 `(ONE, ONE_MINUS_SRC_ALPHA)` 与不透明色。Actinium 的 GLSMRedirector 将这些调用重定向到 GLSM 缓存，StellarCore 拦截器不再触发，缓存帧缓冲 alpha 为 0，blit 后元素区域全透明。

**关键发现**：`HUDCaching` 类由 StellarCore 自己的 early mixin loader 在 tweak 引导阶段加载，早于任何 mixin prepare——early/late 注册均抛 `MixinTargetAlreadyLoadedException`，mixin 方案不可行。

**实现**：
- 新增 `StellarCoreHudCachingCompatTransformer`（launchwrapper transformer，类 define 前介入）：重写 `renderCachedHud`，将 `renderingCacheOverride` 镜像到 `GLSMConfig.hudCacheOverride`，并在缓存渲染的 `renderGameOverlay` 调用前恢复 HUD 基线（`GuiGlStateBoundary.restoreHudBaseline`）
- GLSM 侧：`hudCacheOverride`/`hudCacheBlendEnabled` 驱动 blend/color 路径应用与 StellarCore 等价的覆盖逻辑（`changeColor`/`enableBlend`/`disableBlend`/`tryBlendFuncSeparate`）
- 删除不可行的 mixin 方案（`MixinHUDCaching`、`mixins.actinium.stellarcore.json`）

## 验证

- 新增 `StellarCoreHudCachingCompatTransformerTest`：用依赖 jar 的真实 `HUDCaching` 字节码断言完整注入序列
- 全套测试 + `check`（编译/测试/remap 验证）通过
- runClient 实测：transformer 成功注册、无 `MixinTargetAlreadyLoadedException`
- 游戏内实测（HudCaching=true）：JourneyMap 小地图网格线/准心/方位标正常可见

## 残余限制

StellarCore 升级后若 `renderCachedHud` 字节码结构变化，transformer 会匹配失败并记录 WARN（见 `docs/compat/stellarcore.md`）。
