### PR TITLE
fix(startup): persist compatibility profile after core context creation

### DIFF
--- a/src/main/java/com/dhj/actinium/debug/CoreProfileContextAttributes.java
+++ b/src/main/java/com/dhj/actinium/debug/CoreProfileContextAttributes.java
@@ -1,6 +1,9 @@
 package com.dhj.actinium.debug;
 
 import net.minecraftforge.common.ForgeEarlyConfig;
+import net.minecraftforge.common.config.ConfigManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.lwjgl.opengl.ContextAttribs;
 
 import java.util.function.Consumer;
@@ -10,6 +13,8 @@ import java.util.function.Consumer;
  * Keeping this logic outside every Mixin configuration package allows transformed classes to load it normally.
  */
 public final class CoreProfileContextAttributes {
+    private static final Logger LOGGER = LogManager.getLogger("Celeritas");
+
     /**
      * Prevents instantiation because context attribute construction is stateless.
      */
@@ -73,6 +78,28 @@ public final class CoreProfileContextAttributes {
         ForgeEarlyConfig.OPENGL_VERSION_MINOR = originalMinor;
         ForgeEarlyConfig.OPENGL_COMPAT_PROFILE = true;
         ForgeEarlyConfig.OPENGL_DEBUG_CONTEXT = originalDebug;
+    }
+
+    /**
+     * Persists the restored compatibility profile back to {@code forge_early.cfg}.
+     *
+     * <p>LWJGLXX calls {@code ConfigManager.sync(ForgeEarlyConfig.class)} while creating the
+     * core-profile context, which writes the in-memory core-profile request (compatibility profile
+     * disabled) to the file before {@link #restoreForgeEarlyCompatProfile} can undo it in memory.
+     * Without this follow-up sync the file stays on the core profile and a later launch without
+     * Actinium creates a core context whose fixed-pipeline startup code (SplashProgress texture
+     * setup) fails with {@code GL_INVALID_ENUM}, kills the splash thread, and aborts the JVM on the
+     * first {@code glAlphaFunc}. Sync again now that the fields are restored so the file always
+     * matches the compatibility profile.</p>
+     */
+    public static void persistForgeEarlyCompatProfile() {
+        try {
+            ConfigManager.sync(ForgeEarlyConfig.class);
+        } catch (RuntimeException syncFailure) {
+            // The in-memory state is already restored and this run is unaffected; only the file
+            // would keep the core-profile request and break the next launch without Actinium.
+            LOGGER.error("Failed to persist the restored compatibility profile to forge_early.cfg", syncFailure);
+        }
     }
 
     /**

--- a/src/main/java/com/dhj/actinium/mixin/vintage/core/startup/MixinMinecraftCoreProfileDisplay.java
+++ b/src/main/java/com/dhj/actinium/mixin/vintage/core/startup/MixinMinecraftCoreProfileDisplay.java
@@ -39,7 +39,10 @@ public abstract class MixinMinecraftCoreProfileDisplay {
         } finally {
             // Don't leave the core-profile request persisted in forge_early.cfg: without Actinium,
             // Cleanroom's default path expects the compatibility profile and fails to create a context.
+            // LWJGLXX syncs the request to the file while creating the context, so restore the fields
+            // and sync them back (see CoreProfileContextAttributes.persistForgeEarlyCompatProfile).
             CoreProfileContextAttributes.restoreForgeEarlyCompatProfile(originalMajor, originalMinor, originalDebug);
+            CoreProfileContextAttributes.persistForgeEarlyCompatProfile();
         }
     }
 


### PR DESCRIPTION
## 问题

开启 Actinium 的实例在**关闭 Actinium 后再启动会崩溃**（JVM abort）：

```
FATAL ERROR in native method: No context is current or a function that is
not available in the current context was called. The JVM will abort execution.
    at org.lwjgl.opengl.GL11.glAlphaFunc(Native Method)
    at net.minecraft.client.renderer.GlStateManager.func_179092_a(SourceFile:97)
    at net.minecraft.client.Minecraft.func_71384_a(Minecraft.java:495)
```

## 根因

1. Actinium 启动时把 `ForgeEarlyConfig` 字段临时改为 core profile（`OPENGL_COMPAT_PROFILE=false`），供 Cleanroom 的 LWJGLXX 创建 core 上下文（`MixinMinecraftCoreProfileDisplay`）
2. **LWJGLXX 在创建上下文后调用 `ConfigManager.sync(ForgeEarlyConfig.class)`，把当时的字段值（含 `COMPAT_PROFILE=false`）持久化写入 `forge_early.cfg`**
3. Actinium 的 finally 块只恢复了内存字段，**文件残留 core profile 配置**
4. 卸载 Actinium 后启动：Cleanroom 读到 `OPENGL_COMPAT_PROFILE=false` → 创建 **core profile** 上下文 → **SplashProgress 的固定管线调用报 `GL_INVALID_ENUM`**（core 下 `glEnable(GL_TEXTURE_2D)` 等非法）→ Splash 线程异常死亡 → 上下文状态被破坏 → 主线程首个 `glAlphaFunc` 报 "No context is current" → JVM abort

Cleanroom `ForgeEarlyConfig` 默认 `OPENGL_COMPAT_PROFILE=true`（兼容 profile），文件被改写成 `false` 是无 Actinium 时启动失败的直接原因。

## 修复

- `CoreProfileContextAttributes` 新增 `persistForgeEarlyCompatProfile()`：恢复字段后**再次 `ConfigManager.sync`**，把兼容 profile 配置写回 `forge_early.cfg`（覆盖 LWJGLXX 的写入）
- `MixinMinecraftCoreProfileDisplay` 的 finally 中在恢复字段后调用它
- sync 失败记录 ERROR 日志（内存状态已恢复，本次运行不受影响，仅文件残留会影响下次无 Actinium 启动）

## 验证

- runClient 带 Actinium 启动后：`run/client/config/forge_early.cfg` 的 `OPENGL_COMPAT_PROFILE` 恢复为 `true`，无持久化失败日志，游戏正常
- 全套测试 + `check`（编译/测试/remap 验证）通过
- 用户实例（crl_t）的残留 `false` 已手动修复，无 Actinium 启动恢复正常
