### PR TITLE
fix(build): derive version prefix from nearest git tag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,14 +56,21 @@ def gitExactTag = { gitRun(['git', 'describe', '--tags', '--exact-match', 'HEAD'
 
 def gitShortSha = { gitRun(['git', 'rev-parse', '--short', 'HEAD']) }
 
+// The most recent tag reachable from HEAD (git describe --tags --abbrev=0), used to keep the
+// version prefix in sync with the latest release tag when HEAD is not exactly on a tag.
+def gitClosestTag = { gitRun(['git', 'describe', '--tags', '--abbrev=0', 'HEAD']) }
+
 def baseVersion = propertyString('mod_version')
 
-// Precedence: explicit -Pversion > git tag > "baseVersion-gitSha" > gradle.properties mod_version.
+// Precedence: explicit -Pversion > exact git tag on HEAD > "<closest tag>-<git sha>"
+// > "baseVersion-gitSha" > gradle.properties mod_version.
 // Appending the sha to the manual base version keeps FML version parsing (required-after
 // comparisons, update checks) working: a bare sha is not a valid version for those consumers.
 def finalVersion = cliProjectProperties.containsKey('version')
     ? cliProjectProperties['version']
-    : (gitExactTag() ?: (gitShortSha() ? baseVersion + "-" + gitShortSha() : baseVersion))
+    : (gitExactTag()
+        ?: (gitShortSha() && gitClosestTag() ? gitClosestTag() + "-" + gitShortSha() : null)
+        ?: (gitShortSha() ? baseVersion + "-" + gitShortSha() : baseVersion))
 version = finalVersion
 group = cliProjectProperties.containsKey('group') ? cliProjectProperties['group'] : propertyString('root_package')
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ show_testing_output = false
 enable_lwjglx = true
 
 # Mod Information
-mod_version = alpha-0.0.1
+mod_version = alpha-0.0.2
 root_package = org.taumc
 mod_id = actinium
 mod_name = Actinium


### PR DESCRIPTION
## 问题

打了 `alpha-0.0.2` 标签后，本地编译产出的 jar 仍是 `alpha-0.0.1-<sha>` 前缀。

## 根因

版本推导（`build.gradle`）只认 **HEAD 上的精确标签**（`git describe --tags --exact-match HEAD`），否则直接回退到 `gradle.properties` 里硬编码的 `mod_version=alpha-0.0.1`。标签打在非 HEAD 的 commit（或后续有提交合并）时，精确匹配失败 → 产出旧版本前缀。

## 修复

版本优先级调整为：

1. `-Pversion=xxx` 显式指定
2. **HEAD 精确标签**（如 `alpha-0.0.2`，发布版无 sha 后缀）
3. **最近可达标签 + sha**（`git describe --tags --abbrev=0` → `alpha-0.0.2-<sha>`）← 新增
4. `mod_version` + sha（git 部分可用时的旧行为）
5. `mod_version`（git 完全不可用时的源码快照兜底）

同时把 `gradle.properties` 的 `mod_version` 同步更新为 `alpha-0.0.2`，保证 git 不可用时兜底版本一致。

## 验证

```
BUILD SUCCESSFUL
build/libs/Actinium-alpha-0.0.2-e8b0e27.jar   ← 0.0.2 前缀 ✓
```
