### PR TITLE
feat(compat): Chunk Animator compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -350,6 +350,42 @@ unimined.minecraft {
 }
 
 def compatBridgeRemapOutput = remapCompatBridgeJar.flatMap { it.archiveFile }
+
+/**
+ * Chunk Animator's dev-environment coremod (MCPNames) reads ./../mcp/methods.csv and
+ * ./../mcp/fields.csv relative to the client run directory and crashes at class init when they
+ * are missing. Unimined already downloads and unpacks these MCP stable_39 mappings for its own
+ * remapping/genSources pipeline; copy them into run/mcp so the mod can initialize in dev runs.
+ */
+def chunkAnimatorMcpMappingsDir = layout.projectDirectory.dir('run/mcp').asFile
+
+def prepareChunkAnimatorMcpMappings = tasks.register('prepareChunkAnimatorMcpMappings') {
+    group = 'build'
+    description = 'Copies MCP stable_39 mappings into the run directory for Chunk Animator dev compatibility.'
+    outputs.dir(chunkAnimatorMcpMappingsDir)
+    outputs.upToDateWhen { false }
+
+    doLast {
+        def mcpStableDir = gradle.gradleUserHomeDir.toPath()
+                .resolve('caches/minecraft/de/oceanlabs/mcp/mcp_stable/39')
+                .toFile()
+        def methodsCsv = new File(mcpStableDir, 'methods.csv')
+        def fieldsCsv = new File(mcpStableDir, 'fields.csv')
+        if (!methodsCsv.isFile() || !fieldsCsv.isFile()) {
+            throw new GradleException(
+                "Could not locate MCP stable_39 mappings for Chunk Animator dev compatibility " +
+                "in ${mcpStableDir}. Run the genSources task once so Unimined populates its mappings cache.")
+        }
+        if (!chunkAnimatorMcpMappingsDir.exists() && !chunkAnimatorMcpMappingsDir.mkdirs()) {
+            throw new GradleException("Failed to create MCP mappings directory: ${chunkAnimatorMcpMappingsDir}")
+        }
+        copy {
+            from methodsCsv, fieldsCsv
+            into chunkAnimatorMcpMappingsDir
+        }
+    }
+}
+
 def prepareCompatBridgeRun = tasks.register('prepareCompatBridgeRun') {
     group = 'build'
     description = 'Installs the remapped Celeritas compatibility bridge into the client run directory.'
@@ -379,6 +415,7 @@ def prepareCompatBridgeRun = tasks.register('prepareCompatBridgeRun') {
 tasks.named('preRunClient').configure {
     dependsOn tasks.named('classes')
     dependsOn prepareCompatBridgeRun
+    dependsOn prepareChunkAnimatorMcpMappings
 }
 
 tasks.named('preRunServer').configure {

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/api/render/chunk/ChunkAnimationProvider.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/api/render/chunk/ChunkAnimationProvider.java
@@ -1,0 +1,38 @@
+package org.embeddedt.embeddium.api.render.chunk;
+
+import org.embeddedt.embeddium.impl.render.chunk.RenderSection;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A provider for per-section chunk animations.
+ *
+ * <p>Allows external mods (e.g. Chunk Animator) to apply per-section translations to the terrain
+ * renderer, mirroring the per-RenderChunk {@code glTranslate} offset that vanilla chunk rendering
+ * supports. A provider is queried on the render thread for every visible section on every render
+ * pass; when it reports an offset, the section is removed from its region's multi-draw batch and
+ * drawn separately with the offset added to the region model matrix.</p>
+ *
+ * <p>The vanilla equivalent is the Chunk Animator hook on {@code ChunkRenderContainer#preRenderChunk}
+ * plus {@code RenderChunk#setOrigin}: this interface adapts both to the celeritas pipeline, where
+ * vanilla {@code RenderChunk} objects are not created or drawn.</p>
+ */
+public interface ChunkAnimationProvider {
+    /**
+     * Called on the render thread when a render section is created (i.e. enters the render
+     * distance). Implementations may record the animation start time here; the section itself
+     * serves as the animation identity token.
+     */
+    default void onSectionAdded(@NotNull RenderSection section) {
+    }
+
+    /**
+     * Queries the animation offset for a section on the render thread.
+     *
+     * @param section the render section being drawn
+     * @param out     a 3-element array receiving the offset in world-space blocks; only written
+     *                when this method returns {@code true}
+     * @return {@code true} if the section currently has an animation offset and should be drawn
+     *         separately, {@code false} if it should be drawn as part of the region batch
+     */
+    boolean getSectionOffset(@NotNull RenderSection section, @NotNull float[] out);
+}

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/api/render/chunk/ChunkAnimationProviderHolder.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/api/render/chunk/ChunkAnimationProviderHolder.java
@@ -1,0 +1,33 @@
+package org.embeddedt.embeddium.api.render.chunk;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Static registration point for the single active {@link ChunkAnimationProvider}.
+ *
+ * <p>Follows the same pattern as the shader provider holder: the host mod (Actinium) installs the
+ * provider when a compatible animation mod is present, and the chunk renderer queries it without
+ * holding a compile-time reference to any external mod class.</p>
+ */
+public final class ChunkAnimationProviderHolder {
+    private static ChunkAnimationProvider provider;
+
+    private ChunkAnimationProviderHolder() {
+    }
+
+    /**
+     * Replaces the active animation provider. Passing {@code null} disables per-section chunk
+     * animations.
+     */
+    public static void setProvider(@Nullable ChunkAnimationProvider provider) {
+        ChunkAnimationProviderHolder.provider = provider;
+    }
+
+    /**
+     * @return the active animation provider, or {@code null} if none is installed
+     */
+    @Nullable
+    public static ChunkAnimationProvider getProvider() {
+        return provider;
+    }
+}

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/DefaultChunkRenderer.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/DefaultChunkRenderer.java
@@ -27,9 +27,15 @@ import org.embeddedt.embeddium.impl.render.chunk.terrain.TerrainRenderPass;
 import org.embeddedt.embeddium.impl.render.viewport.CameraTransform;
 import org.embeddedt.embeddium.impl.util.BitwiseMath;
 import org.embeddedt.embeddium.api.debug.RenderDebugHooksHolder;
+import org.embeddedt.embeddium.api.render.chunk.ChunkAnimationProvider;
+import org.embeddedt.embeddium.api.render.chunk.ChunkAnimationProviderHolder;
 import com.mitchej123.lwjgl.GLExtension;
 import org.embeddedt.embeddium.impl.runtime.EmbeddiumRuntimeOptions;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 
 import static com.mitchej123.lwjgl.LWJGLServiceProvider.LWJGL;
 
@@ -38,6 +44,13 @@ public abstract class DefaultChunkRenderer extends ShaderChunkRenderer {
     private static boolean loggedMultiDrawMode;
 
     private final MultiDrawEmitter emitter;
+
+    /**
+     * Dedicated emitter for sections which are currently animating. Animated sections are drawn
+     * one-by-one after the region batch with their own model offset, since a single region
+     * transform cannot express per-section translations.
+     */
+    private final MultiDrawEmitter individualEmitter = new IndividualDrawEmitter();
 
     private final Reference2ReferenceMap<ChunkPrimitiveType, SharedQuadIndexBuffer> sharedIndexBuffers;
 
@@ -145,6 +158,9 @@ public abstract class DefaultChunkRenderer extends ShaderChunkRenderer {
 
             long timestamp = System.nanoTime();
 
+            ChunkAnimationProvider animationProvider = ChunkAnimationProviderHolder.getProvider();
+            float[] animationOffsetBuffer = animationProvider != null ? new float[3] : null;
+
             while (iterator.hasNext()) {
                 ChunkRenderList renderList = iterator.next();
 
@@ -157,38 +173,55 @@ public abstract class DefaultChunkRenderer extends ShaderChunkRenderer {
 
                 regions++;
                 long fillStartNanos = RenderDebugHooksHolder.beginRenderGlobalStageTiming();
-                fillCommandBuffer(this.emitter, region, storage, renderList, occlusionCamera, renderPass, useBlockFaceCulling && !renderPass.isSorted());
+                List<AnimatedSectionDraw> animatedSections = animationProvider != null ? new ArrayList<>() : null;
+                fillCommandBuffer(this.emitter, region, storage, renderList, occlusionCamera, renderPass,
+                        useBlockFaceCulling && !renderPass.isSorted(), animationProvider, animationOffsetBuffer, animatedSections);
                 if (fillStartNanos != 0L) {
                     fillNanos += System.nanoTime() - fillStartNanos;
                 }
 
-                if (this.emitter.isEmpty()) {
-                    continue;
-                }
-                batches++;
-                commands += this.emitter.getCommandCount();
+                GlTessellation tessellation = null;
+                if (!this.emitter.isEmpty()) {
+                    batches++;
+                    commands += this.emitter.getCommandCount();
 
-                if (!renderPass.isSorted()) {
-                   getSharedIndexBuffer(renderPassConfiguration.getPrimitiveTypeForPass(renderPass), commandList).ensureCapacity(commandList, this.emitter.getIndexBufferSize());
+                    if (!renderPass.isSorted()) {
+                       getSharedIndexBuffer(renderPassConfiguration.getPrimitiveTypeForPass(renderPass), commandList).ensureCapacity(commandList, this.emitter.getIndexBufferSize());
+                    }
+
+                    long tessellationStartNanos = RenderDebugHooksHolder.beginRenderGlobalStageTiming();
+                    tessellation = this.prepareTessellation(commandList, region);
+                    if (tessellationStartNanos != 0L) {
+                        tessellationNanos += System.nanoTime() - tessellationStartNanos;
+                    }
+
+                    long uniformsStartNanos = RenderDebugHooksHolder.beginRenderGlobalStageTiming();
+                    setModelMatrixUniforms(shader, region, camera);
+                    shader.setSectionAges(timestamp, region.getSectionLoadTimes());
+                    if (uniformsStartNanos != 0L) {
+                        uniformsNanos += System.nanoTime() - uniformsStartNanos;
+                    }
+
+                    long drawStartNanos = RenderDebugHooksHolder.beginRenderGlobalStageTiming();
+                    this.emitter.executeBatch(commandList, tessellation, primitiveType);
+                    if (drawStartNanos != 0L) {
+                        drawNanos += System.nanoTime() - drawStartNanos;
+                    }
                 }
 
-                long tessellationStartNanos = RenderDebugHooksHolder.beginRenderGlobalStageTiming();
-                var tessellation = this.prepareTessellation(commandList, region);
-                if (tessellationStartNanos != 0L) {
-                    tessellationNanos += System.nanoTime() - tessellationStartNanos;
-                }
-
-                long uniformsStartNanos = RenderDebugHooksHolder.beginRenderGlobalStageTiming();
-                setModelMatrixUniforms(shader, region, camera);
-                shader.setSectionAges(timestamp, region.getSectionLoadTimes());
-                if (uniformsStartNanos != 0L) {
-                    uniformsNanos += System.nanoTime() - uniformsStartNanos;
-                }
-
-                long drawStartNanos = RenderDebugHooksHolder.beginRenderGlobalStageTiming();
-                this.emitter.executeBatch(commandList, tessellation, primitiveType);
-                if (drawStartNanos != 0L) {
-                    drawNanos += System.nanoTime() - drawStartNanos;
+                // Sections currently playing an animation were excluded from the region batch and
+                // must be drawn individually with their per-section offset applied.
+                if (animatedSections != null && !animatedSections.isEmpty()) {
+                    long animatedStartNanos = RenderDebugHooksHolder.beginRenderGlobalStageTiming();
+                    if (tessellation == null) {
+                        tessellation = this.prepareTessellation(commandList, region);
+                    }
+                    setModelMatrixUniforms(shader, region, camera);
+                    shader.setSectionAges(timestamp, region.getSectionLoadTimes());
+                    drawAnimatedSections(animatedSections, shader, region, camera, commandList, tessellation, primitiveType, renderPass);
+                    if (animatedStartNanos != 0L) {
+                        drawNanos += System.nanoTime() - animatedStartNanos;
+                    }
                 }
             }
 
@@ -220,7 +253,10 @@ public abstract class DefaultChunkRenderer extends ShaderChunkRenderer {
                                           ChunkRenderList renderList,
                                           CameraTransform camera,
                                           TerrainRenderPass pass,
-                                          boolean useBlockFaceCulling) {
+                                          boolean useBlockFaceCulling,
+                                          @Nullable ChunkAnimationProvider animationProvider,
+                                          @Nullable float[] animationOffsetBuffer,
+                                          @Nullable List<AnimatedSectionDraw> animatedSections) {
         emitter.clear();
 
         var iterator = renderList.sectionsWithGeometryIterator(pass.isReverseOrder());
@@ -254,9 +290,53 @@ public abstract class DefaultChunkRenderer extends ShaderChunkRenderer {
             slices &= SectionRenderDataUnsafe.getSliceMask(pMeshData);
 
             if (slices != 0) {
+                if (animationProvider != null) {
+                    var section = renderRegion.getSection(sectionIndex);
+                    if (section != null && animationProvider.getSectionOffset(section, animationOffsetBuffer)) {
+                        // Animated sections cannot share the region transform; draw them
+                        // individually after the region batch with their own offset.
+                        animatedSections.add(new AnimatedSectionDraw(sectionIndex, pMeshData, slices,
+                                animationOffsetBuffer[0], animationOffsetBuffer[1], animationOffsetBuffer[2]));
+                        continue;
+                    }
+                }
                 emitter.addDrawCommands(pMeshData, slices, indexPointerMask);
             }
         }
+    }
+
+    /**
+     * Draws sections that are currently animating, one at a time, with the per-section offset
+     * added to the region model offset. The region offset is restored afterwards.
+     */
+    private void drawAnimatedSections(List<AnimatedSectionDraw> animatedSections,
+                                      ChunkShaderInterface shader,
+                                      RenderRegion region,
+                                      CameraTransform camera,
+                                      CommandList commandList,
+                                      GlTessellation tessellation,
+                                      GlPrimitiveType primitiveType,
+                                      TerrainRenderPass pass) {
+        int indexPointerMask = pass.isSorted() ? 0xFFFFFFFF : 0;
+
+        float baseX = getCameraTranslation(region.getOriginX(), camera.intX, camera.fracX);
+        float baseY = getCameraTranslation(region.getOriginY(), camera.intY, camera.fracY);
+        float baseZ = getCameraTranslation(region.getOriginZ(), camera.intZ, camera.fracZ);
+
+        MultiDrawEmitter emitter = this.individualEmitter;
+
+        for (AnimatedSectionDraw draw : animatedSections) {
+            shader.setRegionOffset(baseX + draw.offsetX(), baseY + draw.offsetY(), baseZ + draw.offsetZ());
+            emitter.clear();
+            emitter.addDrawCommands(draw.pMeshData(), draw.slices(), indexPointerMask);
+            emitter.executeBatch(commandList, tessellation, primitiveType);
+        }
+
+        shader.setRegionOffset(baseX, baseY, baseZ);
+    }
+
+    private record AnimatedSectionDraw(int sectionIndex, long pMeshData, int slices,
+                                       float offsetX, float offsetY, float offsetZ) {
     }
 
     private static final int MODEL_UNASSIGNED = ModelQuadFacing.UNASSIGNED.ordinal();
@@ -387,6 +467,7 @@ public abstract class DefaultChunkRenderer extends ShaderChunkRenderer {
 
         this.sharedIndexBuffers.values().forEach(buffer -> buffer.delete(commandList));
         this.emitter.delete();
+        this.individualEmitter.delete();
     }
 }
 

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/RenderSectionManager.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/RenderSectionManager.java
@@ -43,6 +43,8 @@ import org.jetbrains.annotations.Nullable;
 import org.joml.Vector3d;
 import org.joml.Vector3ic;
 import org.embeddedt.embeddium.api.debug.RenderDebugHooksHolder;
+import org.embeddedt.embeddium.api.render.chunk.ChunkAnimationProvider;
+import org.embeddedt.embeddium.api.render.chunk.ChunkAnimationProviderHolder;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -329,6 +331,10 @@ public abstract class RenderSectionManager {
             renderSection.setPendingUpdate(ChunkUpdateType.INITIAL_BUILD);
         }
 
+        ChunkAnimationProvider animationProvider = ChunkAnimationProviderHolder.getProvider();
+        if (animationProvider != null) {
+            animationProvider.onSectionAdded(renderSection);
+        }
 
         this.markGraphDirty();
     }

--- a/docs/compat/chunkanimator.md
+++ b/docs/compat/chunkanimator.md
@@ -1,0 +1,105 @@
+# Chunk Animator 兼容（chunkanimator 1.12.2-1.2.1）
+
+最后更新：2026-08-15。分支：`feat/chunk-animator-compat`。
+
+## 模组机制（反编译结论）
+
+Chunk Animator（CurseForge 项目 236484，文件 3850023，modid `chunkanimator`）是
+Lumien 出品的纯 ASM coremod（无 Mixin）：
+
+- `FMLCorePlugin`：`lumien.chunkanimator.asm.LoadingPlugin`，注册
+  `ClassTransformer`（`IClassTransformer`）。
+- 注入点一：`net.minecraft.client.renderer.chunk.RenderChunk#func_189562_a`
+  （`setOrigin(int,int,int)`）——在方法体内 `func_178585_h`（`setPosition`）调用**之前**
+  插入 `AsmHandler.setOrigin(renderChunk, x, y, z)`，记录该 chunk 的动画开始时间戳
+  （`AnimationHandler` 内部 `WeakHashMap<Object, AnimationData>`，key 为 RenderChunk 实例）。
+- 注入点二：`net.minecraft.client.renderer.ChunkRenderContainer#func_178003_a`
+  （`preRenderChunk(RenderChunk)`）——在方法体内第一个 `GlStateManager.translate`
+  （`func_179109_b`）调用**之后**插入 `AsmHandler.preRenderChunk(renderChunk)`，
+  按动画模式与时间差计算偏移并 `glTranslate`（下方升起/上方落下/径向滑入，支持
+  11 种 easing，时长默认 1000ms）。
+- 动画从 `setOrigin` 起算；首次渲染（`getOffset`）时若时间戳为 -1 则惰性置为当前时间。
+
+## 冲突分析
+
+Actinium 的 celeritas 区块管线接管后：
+
+1. `MixinRenderGlobal.loadRenderers` 将 `GameSettings.renderDistanceChunks` 第二次读取
+   重定向为 0，原版 `BuiltChunkStorage` 不再分配可用的 `RenderChunk` 阵列；
+2. `renderBlockLayer`/`setupTerrain` 被整体替换为 `ActiniumWorldRenderer`，
+   `ChunkRenderContainer.preRenderChunk` 不再被调用。
+
+结论：Chunk Animator 的 ASM 注入仍然加载（不崩溃），但**两个 hook 都不会在渲染路径上
+生效**，动画完全不显示。
+
+## 兼容方案
+
+在 Actinium 区块管线中提供与两个原版 hook 等价的钩子，并直接调用 Chunk Animator 的
+`AnimationHandler`（其 `setOrigin`/`getOffset` 参数均为 `Object` 令牌，可传入 celeritas
+的 `RenderSection`，无需构造 `RenderChunk`）：
+
+| Chunk Animator 原版 hook | Actinium 等价钩子 | 位置 |
+| --- | --- | --- |
+| `RenderChunk.setOrigin` | `ChunkAnimationProvider.onSectionAdded(RenderSection)` | `RenderSectionManager.onSectionAdded`（渲染线程，section 进入渲染距离） |
+| `ChunkRenderContainer.preRenderChunk` | `ChunkAnimationProvider.getSectionOffset(RenderSection, float[3])` | `DefaultChunkRenderer.fillCommandBuffer`（渲染线程，每 pass 每可见 section） |
+
+绘制拆分：动画中的 section 不能共享 region 的批量变换（`u_RegionOffset` 是 region 级
+uniform），因此 `fillCommandBuffer` 将其从 region 多批绘制中排除，region 批绘制结束后用
+独立 `IndividualDrawEmitter` 逐个绘制，绘制前把 region 偏移叠加动画偏移写入
+`shader.setRegionOffset`，绘制后恢复。动画结束后 provider 返回 `false`，section 自动
+回到 region 批，无持续开销。
+
+动画身份令牌直接复用 `RenderSection` 实例；`AnimationHandler` 用 `WeakHashMap` 弱引用
+key，section 销毁后自动回收，无需显式清理。
+
+安装时机：`Actinium.onInit`（FML 保证所有 mod 的 pre-init 先于任意 mod 的 init 完成，
+此时 `ChunkAnimator.INSTANCE.animationHandler` 必已构造）。
+
+## 文件清单
+
+- `celeritas-common/.../api/render/chunk/ChunkAnimationProvider.java`（新增接口）
+- `celeritas-common/.../api/render/chunk/ChunkAnimationProviderHolder.java`（新增静态注册点）
+- `celeritas-common/.../impl/render/chunk/RenderSectionManager.java`（onSectionAdded 通知）
+- `celeritas-common/.../impl/render/chunk/DefaultChunkRenderer.java`（动画拆分单独绘制）
+- `src/main/java/com/dhj/actinium/compat/chunkanimator/ChunkAnimatorCompat.java`（新增桥）
+- `src/main/java/com/dhj/actinium/Actinium.java`（onInit 安装）
+- `gradle/scripts/dependencies.gradle`（`modImplementation curse.maven:chunk-animator-236484:3850023`）
+- `build.gradle`（`prepareChunkAnimatorMcpMappings` 任务，dev 环境 MCP 映射供给）
+- `src/test/java/org/embeddedt/embeddium/api/render/chunk/ChunkAnimationProviderHolderTest.java`
+
+## 行为差异（相对原版）
+
+- 触发时机：原版 `setOrigin` 仅在世界加载（BuiltChunkStorage 构造）与玩家跨 chunk 边界
+  重定位时触发；Actinium 在 section 进入渲染距离时触发，语义一致（区块首次可见时动画）。
+- 阴影 pass：与 Iris 兼容模式一致，动画同样作用于 shadow 渲染。
+- `DisableAroundPlayer`、动画模式、easing、时长等全部由 Chunk Animator 自身配置决定。
+
+## 验证记录
+
+- [x] `compileJava` / `test` / `build` 通过（分支 `feat/chunk-animator-compat`）。
+- [x] dev 运行验证（2026-08-15，`runClient`）：
+  - Chunk Animator coremod 正常加载（`MCPNames` 不再崩溃）；
+  - 日志确认 `Chunk Animator compatibility layer enabled`；
+  - 客户端进入世界、正常退出，无渲染异常。
+- [x] 动画视觉效果确认（区块升起/滑入动画肉眼可见，可切换动画模式验证）。
+
+### dev 环境说明
+
+Chunk Animator 的 `MCPNames` 在 dev 环境（`IN_MCP=true`）静态初始化时读取
+`./../mcp/methods.csv` 与 `./../mcp/fields.csv`（相对 `runClient` 工作目录 `run/client`，
+即 `run/mcp/`），缺失会导致其 coremod 加载崩溃（`ExceptionInInitializerError`，
+2026-08-15 实测）。`prepareChunkAnimatorMcpMappings` 任务会在 `preRunClient` 前把
+Unimined 缓存的 MCP stable_39 映射（`gradleUserHome/caches/minecraft/de/oceanlabs/mcp/
+mcp_stable/39/`，与 genSources 同源）复制到 `run/mcp/`，无需手工干预。
+
+> 注：曾尝试 `fg.deobf(...)` 声明依赖（kappa 版 Unimined 未注册 `fg` 扩展，
+> `Could not get unknown property 'fg'`，已探测确认），最终采用映射复制方案，
+> 效果等同——复用 Unimined 反混淆管线产物。依赖保持 `modImplementation`，
+> dev 运行自动加载 Chunk Animator（生产环境由用户自行安装）。
+
+## 参考
+
+- 反编译产物：`.tmp/chunk-animator-src/`（CFR 0.152，临时目录不提交）。
+- 原版 1.12.2 映射：`RenderChunk.func_189562_a=setOrigin`、
+  `func_178585_h=updateChunkPosition`、`func_178568_j=getPosition`、
+  `ChunkRenderContainer.func_178003_a=preRenderChunk`、`GlStateManager.func_179109_b=translate`。

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -35,6 +35,7 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 | Draconic Evolution | 已验证 | 条件 Mixin（CCL GlStateTracker 兼容桥） | DE 2.3.28.354 在场时云异常/草方块侧面偏绿/主菜单消失；根因为 DE 每帧 HUD 经 CCL GlStateTracker 基于冻结的原版 GlStateManager 字段重置 GL 状态，已由 `mixins.actinium.ccl.json` 兼容桥修复（dev 回归通过，生产整合包全量回归待做），详见 [docs/compat/draconic-evolution.md](compat/draconic-evolution.md) |
 | Fluidlogged API  | 代码支持 | compile-only API、条件调用              | 尚缺当前运行时验证记录      |
 | Gibbed           | 代码支持 | late Mixin、模型批处理路径                 | 尚缺当前运行时验证记录      |
+| Chunk Animator   | 部分 | 条件桥（ChunkAnimationProvider）+ 动画 section 单独绘制 | 1.12.2-1.2.1（236484:3850023）dev 运行通过（coremod 加载、兼容层启用、进世界无异常）；动画视觉确认待补，详见 [docs/compat/chunkanimator.md](compat/chunkanimator.md) |
 | ModernUI         | 代码支持 | GUI scale hook                     | 尚缺当前运行时验证记录      |
 
 ## 验证记录模板

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -90,6 +90,8 @@ dependencies {
     modRuntimeOnly "curse.maven:celeritas-extra-1451214:8362538"
     modRuntimeOnly "curse.maven:celeritasleafculling-1449111:7550650"
 
+    modImplementation 'curse.maven:chunk-animator-236484:3850023'
+
     modCompileOnly "curse.maven:ichunutil-229060:2801262"
     modCompileOnly "curse.maven:mobdismemberment-229067:2487081"
 

--- a/src/main/java/com/dhj/actinium/Actinium.java
+++ b/src/main/java/com/dhj/actinium/Actinium.java
@@ -1,5 +1,6 @@
 package com.dhj.actinium;
 
+import com.dhj.actinium.compat.chunkanimator.ChunkAnimatorCompat;
 import com.dhj.actinium.compat.dh.ActiniumDHIrisCompat;
 import com.dhj.actinium.compat.dh.DistantHorizonsCompat;
 import com.dhj.actinium.compat.neofontrender.NeoFontRenderCompat;
@@ -164,6 +165,7 @@ public class Actinium {
         if (Loader.isModLoaded("neofontrender")) {
             NeoFontRenderCompat.initialize();
         }
+        ChunkAnimatorCompat.install();
 
         if ((Boolean) Launch.blackboard.get("fml.deobfuscatedEnvironment")) {
             ClientCommandHandler.instance.registerCommand(new TogglePassCommand());

--- a/src/main/java/com/dhj/actinium/compat/chunkanimator/ChunkAnimatorCompat.java
+++ b/src/main/java/com/dhj/actinium/compat/chunkanimator/ChunkAnimatorCompat.java
@@ -1,0 +1,88 @@
+package com.dhj.actinium.compat.chunkanimator;
+
+import com.dhj.actinium.runtime.ActiniumRuntime;
+import lumien.chunkanimator.ChunkAnimator;
+import lumien.chunkanimator.handler.AnimationHandler;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.fml.common.Loader;
+import org.embeddedt.embeddium.api.render.chunk.ChunkAnimationProvider;
+import org.embeddedt.embeddium.api.render.chunk.ChunkAnimationProviderHolder;
+import org.embeddedt.embeddium.impl.render.chunk.RenderSection;
+import org.lwjgl.util.vector.Vector3f;
+
+import java.util.Objects;
+
+/**
+ * Bridges the vanilla-oriented Chunk Animator (mod id {@code chunkanimator}) into the celeritas
+ * chunk pipeline.
+ *
+ * <p>Chunk Animator is an ASM coremod that hooks {@code RenderChunk#setOrigin} to record an
+ * animation start timestamp per chunk and {@code ChunkRenderContainer#preRenderChunk} to translate
+ * the chunk while rendering. With Actinium, vanilla {@code RenderChunk} objects are never drawn and
+ * {@code ChunkRenderContainer#preRenderChunk} is never invoked, so both hooks become inert. This
+ * class re-attaches the same two calls to the celeritas section lifecycle:</p>
+ *
+ * <ul>
+ *   <li>{@link #onSectionAdded} mirrors {@code RenderChunk#setOrigin}: the section enters the
+ *   render distance, so Chunk Animator starts its animation clock.</li>
+ *   <li>{@link #getSectionOffset} mirrors {@code ChunkRenderContainer#preRenderChunk}: the section
+ *   is drawn with Chunk Animator's current offset applied.</li>
+ * </ul>
+ *
+ * <p>The section itself is used as the animation identity token; {@link AnimationHandler} keys its
+ * timestamps by object identity through a {@code WeakHashMap}, so disposed sections are reclaimed
+ * automatically.</p>
+ */
+public final class ChunkAnimatorCompat implements ChunkAnimationProvider {
+    public static final String MOD_ID = "chunkanimator";
+
+    private final AnimationHandler animationHandler;
+
+    private ChunkAnimatorCompat(AnimationHandler animationHandler) {
+        this.animationHandler = Objects.requireNonNull(animationHandler, "animationHandler");
+    }
+
+    /**
+     * Installs the compatibility provider when Chunk Animator is loaded. Must be called after Chunk
+     * Animator's pre-init has run (i.e. from the host mod's init phase), so that its animation
+     * handler is already constructed.
+     */
+    public static void install() {
+        if (!Loader.isModLoaded(MOD_ID)) {
+            return;
+        }
+
+        ChunkAnimator instance = ChunkAnimator.INSTANCE;
+        if (instance == null || instance.animationHandler == null) {
+            ActiniumRuntime.logger().error(
+                "Chunk Animator is loaded but its animation handler is unavailable; chunk animations will not be applied");
+            return;
+        }
+
+        ChunkAnimationProviderHolder.setProvider(new ChunkAnimatorCompat(instance.animationHandler));
+        ActiniumRuntime.logger().info("Chunk Animator compatibility layer enabled");
+    }
+
+    @Override
+    public void onSectionAdded(RenderSection section) {
+        // Mirrors RenderChunk#setOrigin: record the animation start for a section that has just
+        // entered the render distance.
+        this.animationHandler.setOrigin(section,
+            new BlockPos(section.getOriginX(), section.getOriginY(), section.getOriginZ()));
+    }
+
+    @Override
+    public boolean getSectionOffset(RenderSection section, float[] out) {
+        // Mirrors ChunkRenderContainer#preRenderChunk: query the current animation offset and let
+        // the renderer draw this section translated by it.
+        Vector3f offset = this.animationHandler.getOffset(section,
+            new BlockPos(section.getOriginX(), section.getOriginY(), section.getOriginZ()));
+        if (offset == null) {
+            return false;
+        }
+        out[0] = offset.x;
+        out[1] = offset.y;
+        out[2] = offset.z;
+        return true;
+    }
+}

--- a/src/test/java/org/embeddedt/embeddium/api/render/chunk/ChunkAnimationProviderHolderTest.java
+++ b/src/test/java/org/embeddedt/embeddium/api/render/chunk/ChunkAnimationProviderHolderTest.java
@@ -1,0 +1,60 @@
+package org.embeddedt.embeddium.api.render.chunk;
+
+import org.embeddedt.embeddium.impl.render.chunk.RenderSection;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ChunkAnimationProviderHolderTest {
+    @AfterEach
+    void clearProvider() {
+        ChunkAnimationProviderHolder.setProvider(null);
+    }
+
+    @Test
+    void returnsNullWhenNothingIsRegistered() {
+        assertNull(ChunkAnimationProviderHolder.getProvider());
+    }
+
+    @Test
+    void returnsRegisteredProvider() {
+        ChunkAnimationProvider provider = noopProvider();
+
+        ChunkAnimationProviderHolder.setProvider(provider);
+
+        assertSame(provider, ChunkAnimationProviderHolder.getProvider());
+    }
+
+    @Test
+    void replacementOverwritesPreviousProvider() {
+        ChunkAnimationProvider first = noopProvider();
+        ChunkAnimationProvider second = noopProvider();
+        ChunkAnimationProviderHolder.setProvider(first);
+
+        ChunkAnimationProviderHolder.setProvider(second);
+
+        assertSame(second, ChunkAnimationProviderHolder.getProvider());
+    }
+
+    @Test
+    void clearingNullsProvider() {
+        ChunkAnimationProviderHolder.setProvider(noopProvider());
+
+        ChunkAnimationProviderHolder.setProvider(null);
+
+        assertNull(ChunkAnimationProviderHolder.getProvider());
+    }
+
+    private static ChunkAnimationProvider noopProvider() {
+        return new ChunkAnimationProvider() {
+            @Override
+            public boolean getSectionOffset(RenderSection section, float[] out) {
+                return false;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 概述

让 Actinium 兼容 **Chunk Animator**（`curse.maven:chunk-animator-236484:3850023`，即 1.12.2-1.2.1，Lumien 的纯 ASM coremod）。

### 背景

Chunk Animator 通过两个 ASM 注入点工作：
- `RenderChunk#setOrigin`（`func_189562_a`）：记录区块动画开始时间戳；
- `ChunkRenderContainer#preRenderChunk`（`func_178003_a`）：渲染时按动画模式/easing 对区块 `glTranslate` 偏移。

Actinium 接管区块渲染后，`RenderChunk` 不再被创建/绘制，`ChunkRenderContainer.preRenderChunk` 不再被调用——两个 hook 均失效，动画完全不显示（模组本身不崩溃）。

### 方案

在 celeritas 管线中提供与原版两个 hook 等价的桥接，直接调用 Chunk Animator 公开的 `AnimationHandler`（其 `setOrigin`/`getOffset` 参数为 `Object` 令牌，直接复用 celeritas 的 `RenderSection` 作为动画身份，`WeakHashMap` 弱引用自动回收）：

- **celeritas-common**（通用钩子，不引用任何外部模组类）：
  - 新增 `api/render/chunk/ChunkAnimationProvider` + `ChunkAnimationProviderHolder`（静态注册点，仿 `ShaderProviderHolder` 模式）；
  - `RenderSectionManager.onSectionAdded` 通知动画开始（渲染线程）；
  - `DefaultChunkRenderer`：动画中的 section 从 region 多批绘制（MultiDraw）中拆出，region 批绘制后用独立 `IndividualDrawEmitter` 逐个绘制，绘制前将 region 偏移叠加动画偏移写入 `u_RegionOffset`，绘制后恢复；动画结束自动回归批次，零持续开销。
- **根项目**：新增 `compat/chunkanimator/ChunkAnimatorCompat`（模组存在性门控，`Actinium.onInit` 安装——FML 保证 Chunk Animator pre-init 已完成）；
- **构建**：`modImplementation curse.maven:chunk-animator-236484:3850023`（dev 运行加载，与 DH/JourneyMap 同模式）。

### dev 环境修复

Chunk Animator 的 `MCPNames` 在 dev 环境（`IN_MCP=true`）静态初始化读取 `./../mcp/methods.csv` + `fields.csv`，缺失会导致其 coremod 加载崩溃（实测 `ExceptionInInitializerError` → `ClassNotFoundException: ChunkRenderContainer`）。新增 `prepareChunkAnimatorMcpMappings` 任务（挂 `preRunClient`）将 Unimined 缓存的 MCP stable_39 映射（与 genSources 同源）复制到 `run/mcp/`。

> 说明：曾尝试 `fg.deobf(...)` 声明依赖，但 kappa 版 Unimined（1.4.26-kappa）未注册 `fg` 扩展（已探测确认），最终采用映射复制方案，效果等同——复用 Unimined 反混淆管线产物。

### 验证

- `compileJava` / `test` / `build`（含 remap jar 与模块边界验证）全部通过；
- 新增 `ChunkAnimationProviderHolderTest`（4 用例）；
- dev 运行实测（`runClient`）：Chunk Animator coremod 正常加载、日志确认 `Chunk Animator compatibility layer enabled`、进入世界/退出无异常；
- 动画视觉效果已人工确认（区块升起/滑入动画正常）。

### 行为差异（相对原版）

- 触发时机：原版 `setOrigin` 仅在世界加载与玩家跨 chunk 边界时触发；Actinium 在 section 进入渲染距离时触发，语义一致（区块首次可见时动画）；
- 阴影 pass：与 Iris 兼容模式一致，动画同样作用于 shadow 渲染；
- 动画模式/easing/时长/`DisableAroundPlayer` 全部由 Chunk Animator 自身配置决定。

### 文件清单

- `celeritas-common/.../api/render/chunk/ChunkAnimationProvider.java`、`ChunkAnimationProviderHolder.java`（新增）
- `celeritas-common/.../impl/render/chunk/RenderSectionManager.java`、`DefaultChunkRenderer.java`
- `src/main/java/com/dhj/actinium/compat/chunkanimator/ChunkAnimatorCompat.java`（新增）
- `src/main/java/com/dhj/actinium/Actinium.java`
- `gradle/scripts/dependencies.gradle`、`build.gradle`
- `src/test/java/org/embeddedt/embeddium/api/render/chunk/ChunkAnimationProviderHolderTest.java`（新增）
- `docs/compat/chunkanimator.md`（新增研究记录）、`docs/compatibility-matrix.md`
