### PR TITLE
fix(font): honor splash font current-color semantics for Modern Splash

### DIFF
--- a/docs/compat/modern-splash.md
+++ b/docs/compat/modern-splash.md
@@ -1,0 +1,85 @@
+# Modern Splash 兼容（modernsplash 1.5.3）
+
+最后更新：2026-08-15。分支：`feat/modern-splash-compat`。
+
+## 模组机制（反编译结论）
+
+Modern Splash（CurseForge 项目 629058，文件 8487408，modid `modernsplash`，gkappa 出品）是
+纯 ASM coremod，用高版本风格 Mojang logo 启动画面替换 Forge/Cleanroom 的 SplashProgress：
+
+- `FMLCorePlugin`：`gkappa.modernsplash.MSLoadingPlugin`，注册
+  `ReplaceSplashTransformer`（`IClassTransformer`）。
+- 对 `net.minecraftforge.fml.client.SplashProgress*` 前缀类：从
+  `gkappa.modernsplash.CustomSplash*` 读取字节码，用 `SplashRemapper` 把类名映射为
+  `SplashProgress*` 后整体替换——运行时 `SplashProgress` 实际是 `CustomSplash` 的代码。
+- `CustomSplash` 提供与原版 SplashProgress 完全对齐的静态 API
+  （`start/pause/resume/finish/confirm/getMaxTextureSize/drawVanillaScreen/
+  clearVanillaResources/isDisplayVSyncForced/mutex`），保证 FML/Minecraft 的反射调用继续有效；
+  渲染用直接 GL11（SharedDrawable 线程），自带字体（`SplashFontRenderer extends FontRenderer`）、
+  logo、进度条、内存条与日夜双套配色（`config/modernsplash.cfg`）。
+
+## 与 Actinium 的交互（实测结论）
+
+- **替换与 mixin 顺序**：实测（mixin.debug.export 导出最终字节码）mixin transformer
+  在 ReplaceSplashTransformer **之后**应用——`MixinSplashProgress` 的三个注入
+  （`celeritas$getMaxTextureSize/initSplashTessellator/finishSplash`）与
+  `MixinSplashProgressCallable`（`checkContext`）全部保留在替换后的类中；StellarCore 的
+  `injectFinish` 同样保留。dev 运行：coremod 加载、启动画面正常、主菜单正常、无异常。
+- **FontStrategist** 已内置 `CustomSplash$SplashFontRenderer` 识别（替换后实际命中
+  `SplashProgress$SplashFontRenderer`），splash 字体走 `BatchingFontRenderer` 的
+  `isSplash` 专用路径。
+
+## 字体颜色修复（本分支新增）
+
+**问题**：Modern Splash 1.5.3 的 `CustomSplash` 调用 `fontRenderer.drawString(text, 0, 0, 0)`
+（颜色参数恒为 **0**），意图是"使用 drawString 前 `glColor4f(fontColor)` 设置的 GL 当前色"。
+但 1.12.2 `FontRenderer.renderString` 对 color=0 会补全为 `0xFF000000` 并
+`GlStateManager.color(0,0,0,1)`——**无论配置 `font`（白天 `0xFFFFFF`）还是 `fontDark`
+（夜间 `0xF3F5F8`）都渲染为纯黑**。原版 Forge/Cleanroom SplashProgress 的对应调用传的是
+`0xFFFFFF`（已反编译对比确认），因此这是 Modern Splash 自身的缺陷（原版同样黑，且颜色配置
+完全不生效）。
+
+**修复**（Actinium 侧，splash 字体专属路径，不影响其他渲染）：
+
+- `BatchingFontRenderer.floatsToArgb`：GL 归一化分量 → ARGB（`Math.round` 四舍五入）；
+- `BatchingFontRenderer.readCurrentGlColorAsArgb`：从 **GLSM 状态缓存
+  `GLStateManager.getColor()`** 读取当前色——CustomSplash 的 `glColor*` 调用被 GLSM
+  重定向并更新缓存，`GL_CURRENT_COLOR` 的 GL 查询在 core profile 下不是有效状态
+  （实测返回垃圾值/滞后值）；
+- `MixinFontRenderer.angelica$drawStringBatched`：当颜色参数为 `0xFF000000`（调用方传 0）
+  且目标渲染器是 splash 字体（`BatchingFontRenderer.isSplash()`）时，改用当前色
+  （含淡出 alpha）——恢复"color=0 使用当前色"的 fixed-pipeline 语义；非 splash 字体
+  行为不变；
+- `MixinFontRenderer.actinium$isFontBatcherDisabled`：`font-batcher-check` 调试日志改为
+  仅状态变化时打印（原实现每字符一条，fontDebug 开启时刷爆日志）。
+
+**排查记录**（避免回归）：曾先后尝试 `GL11.glGetFloatv(GL_CURRENT_COLOR)` 与
+`RenderBackend.getFloat` 查询，均因 core profile 下该状态不可查询而返回垃圾值
+（实测 `0x0`/`0xff89ea00`/`0xff031600` 等杂色）；`GLStateManager.getColor()` 缓存才是
+正确来源（`font-flush-end` 日志的 `restoreColor=[1.0,1.0,1.0,1.0]` 佐证）。中间另修复了
+调试日志优化引入的 `Boolean` 拆箱 NPE（splash 线程连锁崩溃）。
+
+## 文件清单
+
+- `src/main/java/com/gtnewhorizons/angelica/client/font/BatchingFontRenderer.java`
+  （`floatsToArgb`/`readCurrentGlColorAsArgb`/`isSplash()`）
+- `src/main/java/com/dhj/actinium/mixin/vintage/fontrenderer/MixinFontRenderer.java`
+  （splash 字体 color=0 修复 + 调试日志刷屏修复）
+- `src/test/java/com/gtnewhorizons/angelica/client/font/BatchingFontRendererColorTest.java`
+  （新增，5 用例）
+- `gradle/scripts/dependencies.gradle`（`modImplementation curse.maven:modern-splash-629058:8487408`）
+
+## 验证记录
+
+- [x] `compileJava` / `test` / `build` 通过。
+- [x] dev 运行：Modern Splash coremod 加载、启动画面正常、mixin 注入保留
+  （`mixin.debug.export` 字节码确认）、主菜单正常、无异常。
+- [x] 字体颜色修复人工确认（白天 `0xFFFFFF` 白 / 夜间 `0xF3F5F8` 浅灰白生效；
+  `font-draw-zero` 调试日志确认全部 splash 文字 `glColor=0xffffffff`）。
+- [ ] 光影开启场景回归（启动画面阶段不涉及光影，待确认无副作用）。
+
+## 参考
+
+- 反编译产物：`.tmp/modern-splash-src/`（CFR 0.152，临时目录不提交）。
+- 对比基准：Cleanroom 0.6.7 原版 `SplashProgress` 的字体调用为
+  `drawString(String, 0, 0, 0xFFFFFF)`（反编译 `SplashProgress$2` 确认）。

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -36,6 +36,7 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 | Fluidlogged API  | 代码支持 | compile-only API、条件调用              | 尚缺当前运行时验证记录      |
 | Gibbed           | 代码支持 | late Mixin、模型批处理路径                 | 尚缺当前运行时验证记录      |
 | ModernUI         | 代码支持 | GUI scale hook                     | 尚缺当前运行时验证记录      |
+| Modern Splash    | 部分 | 无侵入（替换类与 mixin 注入天然兼容）+ splash 字体 color=0 修复 | 1.5.3（629058:8487408）dev 运行通过（coremod 加载、mixin 注入保留、字体颜色按配置生效）；光影场景回归待做，详见 [docs/compat/modern-splash.md](compat/modern-splash.md) |
 
 ## 验证记录模板
 

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -78,6 +78,7 @@ dependencies {
 //    modRuntimeOnly 'curse.maven:unseens-nether-backport-1109447:7694245'
     modCompileOnly 'curse.maven:gibbed-1480667:7737413'
     modImplementation 'curse.maven:stellarcore-1064321:8406201'
+    modImplementation 'curse.maven:modern-splash-629058:8487408'
 
     // Draconic Evolution
     modCompileOnly 'maven.modrinth:draconic-evolution:2.3.28.354'

--- a/src/main/java/com/dhj/actinium/mixin/vintage/fontrenderer/MixinFontRenderer.java
+++ b/src/main/java/com/dhj/actinium/mixin/vintage/fontrenderer/MixinFontRenderer.java
@@ -52,11 +52,14 @@ public abstract class MixinFontRenderer implements FontRendererAccessor, IFontPa
         // Recheck while absent: the splash FontRenderer can run before NFR finishes loading.
         if (actinium$neoFontRenderLoaded == null || !actinium$neoFontRenderLoaded) {
             var indexedMods = Loader.instance().getIndexedModList();
-            actinium$neoFontRenderLoaded = indexedMods != null && indexedMods.containsKey("neofontrender");
-            if (Boolean.getBoolean("actinium.fontDebug")) {
+            boolean loaded = indexedMods != null && indexedMods.containsKey("neofontrender");
+            if (Boolean.getBoolean("actinium.fontDebug")
+                && (actinium$neoFontRenderLoaded == null || loaded != actinium$neoFontRenderLoaded)) {
+                // Log only on state transitions; this check runs for every glyph otherwise.
                 actinium$LOGGER.info("font-batcher-check neofontrender={} renderer={}",
-                    actinium$neoFontRenderLoaded, FontRenderer.class.getName());
+                    loaded, FontRenderer.class.getName());
             }
+            actinium$neoFontRenderLoaded = loaded;
         }
         return actinium$neoFontRenderLoaded;
     }
@@ -108,6 +111,22 @@ public abstract class MixinFontRenderer implements FontRendererAccessor, IFontPa
         }
         if ((argb & 0xfc000000) == 0) {
             argb |= 0xff000000;
+        }
+        if (argb == 0xFF000000) {
+            // Splash font renderers (Modern Splash's SplashFontRenderer) pass color 0 to draw
+            // with the fixed-pipeline current color, which they set to their configured font
+            // color beforehand. Vanilla 1.12.2 renderString forces black for color 0; honor the
+            // intended behavior for splash fonts by sampling the GLSM current color instead.
+            // Sampled before the GLStateManager.glColor4f reset below.
+            int currentArgb = BatchingFontRenderer.readCurrentGlColorAsArgb();
+            boolean splash = angelica$getBatcher().isSplash();
+            if (splash) {
+                argb = currentArgb;
+            }
+            if (Boolean.getBoolean("actinium.fontDebug")) {
+                actinium$LOGGER.info("font-draw-zero text='{}' splash={} glColor=0x{} argbOut=0x{}",
+                    text, splash, Integer.toHexString(currentArgb), Integer.toHexString(argb));
+            }
         }
 
         this.red = (argb >> 16 & 255) / 255.0F;

--- a/src/main/java/com/gtnewhorizons/angelica/client/font/BatchingFontRenderer.java
+++ b/src/main/java/com/gtnewhorizons/angelica/client/font/BatchingFontRenderer.java
@@ -70,6 +70,14 @@ public class BatchingFontRenderer {
     final boolean isSGA;
     final boolean isSplash;
 
+    /**
+     * @return {@code true} when this batcher accelerates a splash-screen font renderer
+     *         (Forge/Cleanroom SplashProgress or Modern Splash's SplashFontRenderer)
+     */
+    public boolean isSplash() {
+        return this.isSplash;
+    }
+
     /** For use with modded books. Affects calculations and forces some defaults. */
     @Setter
     boolean bookMode = false;
@@ -238,6 +246,36 @@ public class BatchingFontRenderer {
 
         memFree(data);
 
+    }
+
+    /**
+     * Converts normalized GL color components to an ARGB int.
+     *
+     * @return the packed ARGB value, e.g. (1.0F, 1.0F, 1.0F, 1.0F) becomes {@code 0xFFFFFFFF}
+     */
+    public static int floatsToArgb(float r, float g, float b, float a) {
+        return (Math.round(a * 255.0F) & 0xFF) << 24
+            | (Math.round(r * 255.0F) & 0xFF) << 16
+            | (Math.round(g * 255.0F) & 0xFF) << 8
+            | (Math.round(b * 255.0F) & 0xFF);
+    }
+
+    /**
+     * Reads the current GL color as an ARGB int.
+     *
+     * <p>Splash font renderers (e.g. Modern Splash's SplashFontRenderer) draw text with an
+     * explicit color of 0 while relying on the fixed-pipeline current color, which they set to
+     * their configured font color before drawing. Vanilla 1.12.2 {@code renderString} would
+     * force black for color 0, so the current color is sampled here instead.</p>
+     *
+     * <p>The value comes from the GLSM color state rather than a {@code GL_CURRENT_COLOR} query:
+     * the splash renderer's {@code glColor*} calls are redirected into the GLSM state cache (the
+     * GL context is a core profile where the fixed-pipeline current color is not a real queryable
+     * state).</p>
+     */
+    public static int readCurrentGlColorAsArgb() {
+        Color4 color = GLStateManager.getColor();
+        return floatsToArgb(color.getRed(), color.getGreen(), color.getBlue(), color.getAlpha());
     }
 
     private void ensureCapacity() {

--- a/src/test/java/com/gtnewhorizons/angelica/client/font/BatchingFontRendererColorTest.java
+++ b/src/test/java/com/gtnewhorizons/angelica/client/font/BatchingFontRendererColorTest.java
@@ -1,0 +1,36 @@
+package com.gtnewhorizons.angelica.client.font;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BatchingFontRendererColorTest {
+    @Test
+    void whiteComponentsProduceOpaqueWhite() {
+        assertEquals(0xFFFFFFFF, BatchingFontRenderer.floatsToArgb(1.0F, 1.0F, 1.0F, 1.0F));
+    }
+
+    @Test
+    void zeroComponentsProduceOpaqueBlack() {
+        assertEquals(0xFF000000, BatchingFontRenderer.floatsToArgb(0.0F, 0.0F, 0.0F, 1.0F));
+    }
+
+    @Test
+    void alphaIsPreserved() {
+        assertEquals(0x80FFFFFF, BatchingFontRenderer.floatsToArgb(1.0F, 1.0F, 1.0F, 0.5F));
+    }
+
+    @Test
+    void typicalNightModeFontColor() {
+        // Modern Splash fontDark 0xF3F5F8 normalized
+        assertEquals(0xFFF3F5F8,
+            BatchingFontRenderer.floatsToArgb(243 / 255.0F, 245 / 255.0F, 248 / 255.0F, 1.0F));
+    }
+
+    @Test
+    void channelOrderIsArgbNotRgba() {
+        // A dark-mode background red 0xEF323D must not be confused with a green-dominant value
+        assertEquals(0xFFEF323D,
+            BatchingFontRenderer.floatsToArgb(0xEF / 255.0F, 0x32 / 255.0F, 0x3D / 255.0F, 1.0F));
+    }
+}


### PR DESCRIPTION
## 概述

Modern Splash（`curse.maven:modern-splash-629058:8487408`，即 1.5.3，gkappa 的 ModernSplash）兼容研究与修复。

### 兼容性结论（无需注入改动）

Modern Splash 是纯 ASM coremod：`ReplaceSplashTransformer` 把 `net.minecraftforge.fml.client.SplashProgress*` 类整体替换为 `CustomSplash*` 的字节码（类名映射）。与 Actinium 的交互实测：

- **mixin 注入保留**：mixin transformer 在替换**之后**应用（`mixin.debug.export` 导出最终字节码确认）——`MixinSplashProgress` 三个注入、`MixinSplashProgressCallable`、StellarCore 的 `injectFinish` 全部保留在替换后的类中；
- `CustomSplash` 静态 API 与原版 SplashProgress 完全对齐（`start/pause/resume/finish/confirm/getMaxTextureSize/drawVanillaScreen/clearVanillaResources`），FML/Minecraft 调用不受影响；
- `FontStrategist` 已识别 `CustomSplash$SplashFontRenderer`（替换后实际命中 `SplashProgress$SplashFontRenderer`），splash 字体走 `BatchingFontRenderer.isSplash` 专属路径；
- dev 运行：coremod 加载、启动画面/主菜单正常、无异常。

### 字体颜色修复（本 PR 核心）

**问题**：Modern Splash 1.5.3 的 `CustomSplash` 调用 `fontRenderer.drawString(text, 0, 0, 0)`（颜色参数恒为 0，意图是使用 drawString 前 `glColor4f(fontColor)` 设置的 GL 当前色）。1.12.2 `FontRenderer.renderString` 对 color=0 补全为 `0xFF000000` 并强制 `GlStateManager.color(0,0,0,1)` → **无论 `font`（白天 `0xFFFFFF`）/`fontDark`（夜间 `0xF3F5F8`）配置都渲染纯黑**（原版 Forge/Cleanroom SplashProgress 对应调用传 `0xFFFFFF`，已反编译对比确认——这是 Modern Splash 自身缺陷，原版同样黑）。

**修复**（splash 字体专属路径，非 splash 渲染行为不变）：

- `BatchingFontRenderer`：新增 `floatsToArgb`、`readCurrentGlColorAsArgb`（从 **GLSM 状态缓存** `GLStateManager.getColor()` 读取——`GL_CURRENT_COLOR` 在 core profile context 下不是可查询的有效状态，实测返回垃圾值）、`isSplash()` 访问器；
- `MixinFontRenderer.angelica$drawStringBatched`：颜色参数为 `0xFF000000`（调用方传 0）且目标为 splash 字体时，改用 GLSM 当前色（含淡出 alpha），恢复 "color=0 使用当前色" 的 fixed-pipeline 语义；
- `MixinFontRenderer.actinium$isFontBatcherDisabled`：`font-batcher-check` 调试日志仅在状态变化时打印（原实现每字符一条，fontDebug 开启时刷爆日志）。

### 验证

- `compileJava` / `test` / `build` 通过；新增 `BatchingFontRendererColorTest`（5 用例，含白天 `0xFFFFFF`/夜间 `0xF3F5F8` 精确值）；
- dev 运行实测：`font-draw-zero` 调试日志确认全部 splash 文字 `glColor=0xffffffff`（白色），无崩溃，主菜单正常；
- 字体颜色视觉效果人工确认（白天白色 / 夜间浅灰白，跟随配置）；
- 待办：光影开启场景回归（启动画面阶段不涉及光影管线）。

### 文件清单

- `src/main/java/com/gtnewhorizons/angelica/client/font/BatchingFontRenderer.java`
- `src/main/java/com/dhj/actinium/mixin/vintage/fontrenderer/MixinFontRenderer.java`
- `src/test/java/com/gtnewhorizons/angelica/client/font/BatchingFontRendererColorTest.java`（新增）
- `gradle/scripts/dependencies.gradle`（`modImplementation curse.maven:modern-splash-629058:8487408`）
- `docs/compat/modern-splash.md`（新增研究记录）、`docs/compatibility-matrix.md`
