### PR TITLE
fix(compat): serialize unsafe modded block rendering

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,6 +119,8 @@ GTNHLib ← glsm ← celeritas-common ← shader ← 根项目 src/main（compil
 
 - **`compat/` 根**：`MixinReEntranceLockFix` —— DH mixin 配置入队前的 re-entrance lock
   清理与类预加载修复。
+- **`compat/blockrender/`**：`ModdedBlockRenderCompat` —— 为异步区块构建中已知的第三方
+  非线程安全方块 renderer 缓存提供按 renderer 归属划分的串行化边界。
 - **`compat/ccl/`**：`GlStateTrackerSnapshot` —— CCL 状态跟踪快照（配 `mixin/mod/ccl`）。
 - **`compat/dh/`**：`DistantHorizonsCompat`（DH 接入渲染桥）、`ActiniumDHIrisCompat` /
   `ActiniumDHIrisAccessor` / `DistantHorizonsIrisAccessorState`（Iris 访问器与状态）。

--- a/docs/compat/extrautils2.md
+++ b/docs/compat/extrautils2.md
@@ -1,0 +1,62 @@
+# 异步区块构建中的第三方方块渲染兼容
+
+最后更新：2026-08-19。相关 issue：[Actinium #36](https://github.com/DHJComical/Actinium/issues/36)。
+
+## 问题
+
+Issue #36 报告 Extra Utilities 2 的 drum 在异步区块网格构建期间崩溃。历史堆栈指向
+`HashMap.computeIfAbsent` 与 `com.rwtema.extrautils2.backend.XUBlockStatic$3.getQuads`，
+表现为第三方模型的惰性缓存被多个 chunk-builder worker 同时修改。
+
+Issue 中引用的 mclo.gs 日志目前已过期，因此本文只保留从 XU2 与 AgriCraft 字节码/源码
+确认的缓存结构，不把这些地址作为当前可复查的日志证据。
+
+## 根因
+
+Extra Utilities 2 的 `XUBlockStatic` 为每个静态方块实例维护普通 `HashMap`：
+
+- `layerMap` 缓存 `canRenderInLayer` 的结果；
+- `cachedModels` / `cachedInvModels` 缓存模型；
+- `XUBlockStatic$3.cachedLists` 以方块状态、面方向和 render layer 为键，使用三级
+  `HashMap.computeIfAbsent` 缓存 baked quads。
+
+原版区块构建主要在单线程中访问这些缓存。Actinium 的 `ChunkBuilder` 使用多个 worker，
+所以同一个 XU2 block 的模型初始化会产生并发 `HashMap` 访问。
+
+AgriCraft 的 `BlockCrop` 也暴露了相同类别的问题：`RenderCrop` 持有 renderer 级别的
+非线程安全 crop-quad 缓存。它不能按 block 实例分别加锁，必须使用共享 renderer 锁。
+
+## 修复
+
+`ModdedBlockRenderCompat` 是异步区块构建调用侧的统一边界：
+
+- XU2 通过 `Loader.isModLoaded("extrautils2")` 和类名前缀门控，并按 block 实例加锁；
+- AgriCraft 通过 `Loader.isModLoaded("agricraft")` 和类名前缀门控，并使用共享锁保护
+  renderer 级缓存；
+- 模组状态在实际调用时查询，不在可能过早加载的静态初始化阶段缓存；
+- `VintageBlockRenderer.renderBlock` 的完整生命周期在同一锁内执行，覆盖模型查询及其
+  后续 quad 处理；
+- `canRenderInLayer`、vanilla `BlockRendererDispatcher.renderBlock` 和 Fluidlogged API
+  路径均经过同一兼容层；
+- BetterFoliage 的调用侧 Mixin 目标同步到新的兼容入口，保留其自身的渲染包装逻辑。
+
+锁只作用于已加载且类名匹配的第三方 renderer；普通 Minecraft 方块不进入兼容锁。
+
+## 验证
+
+已完成：
+
+- `ModdedBlockRenderCompatTest` 直接调用锁边界，用两个 worker、`HashMap.computeIfAbsent`
+  和 barrier 验证共享 renderer/cache 不会并发进入；
+- XU2、AgriCraft 类名识别及无关类排除测试；
+- 根项目 `:test --tests com.dhj.actinium.compat.blockrender.ModdedBlockRenderCompatTest`；
+- 根项目 `test`、`compileJava`、`check`、`build`、`verifyCompatBridgeJar`、
+  `verifyModuleBoundaries` 和 `verifyRemapJar`；
+- 2026-08-19 dev 实测：加载 `extrautils2@1.0`，启动日志显示 10 个 chunk-builder worker，
+  进入已有世界并触发区块重载；未出现 `ConcurrentModificationException` 或
+  `XUBlockStatic` 错误，客户端正常退出。
+
+待完成：
+
+- 在包含 AgriCraft crop 的实例中触发相同路径；
+- 记录 AgriCraft 的实际运行版本、模组列表和日志。

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -1,6 +1,6 @@
 # Actinium 兼容性矩阵
 
-最后更新：2026-08-18。
+最后更新：2026-08-19。
 
 状态定义：`已验证` 表示在记录的版本和场景中通过；`部分` 表示能运行但存在已知缺口；
 `无法启用` 表示光影包不能成功开启；`未验证` 不代表不兼容。更新记录时必须填写 Actinium commit、
@@ -57,6 +57,8 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 | Snow! Real Magic! | 已验证 | 兼容门控（SRM 的 snow_layer 块退回 vanilla dispatcher 路径） | 0.7.4：带雪栅栏不渲染已修复（SRM 把被覆盖方块替换为带 SnowTile 的雪层、仅在 `BlockRendererDispatcher.renderBlock` 内重绘，快速区块路径已绕过）；`6aee395`，dev 运行验证通过（MakeUp Ultra Fast 下无光影 + 光影各验一次） |
 | Modern Splash    | 部分 | 无侵入（替换类与 mixin 注入天然兼容）+ splash 字体 color=0 修复 | 1.5.3（629058:8487408）dev 运行通过（coremod 加载、mixin 注入保留、字体颜色按配置生效）；光影场景回归待做，详见 [docs/compat/modern-splash.md](compat/modern-splash.md) |
 | Reese's Sodium Options（内嵌） | 代码支持 | 内嵌移植 UI（`me.flashyreese.mods.reeses_sodium_options`，MIT）+ embeddium 选项数据层（`org.embeddedt.embeddium.api.options.*` 自研扩展） | RSO 界面作为视频设置入口（`MixinGuiOptions` 拦截按钮 101，`enabled=false` 回退原版 `GuiVideoSettings`）；`net.caffeinemc` 设置界面与配置模型已整体删除；编译与 349 项单元测试通过，**运行期视觉对比待人工验证**，详见 [docs/rso-port.md](rso-port.md) |
+| Extra Utilities 2 | 已验证 | `ModdedBlockRenderCompat` 在完整 block-render 生命周期内按 block 实例串行化 | `extrautils2@1.0`：Java 25 dev 客户端启动 10 个 chunk-builder worker，进入已有世界并触发区块重载后未复现 Issue #36 的 CME；代码提交 `44f4295`，详见 [docs/compat/extrautils2.md](compat/extrautils2.md) |
+| AgriCraft | 部分 | `ModdedBlockRenderCompat` 使用共享 renderer 锁保护 crop 缓存 | 与 XU2 相同的异步第三方缓存访问模式已加入兼容层；dev 运行验证待补，详见 [docs/compat/extrautils2.md](compat/extrautils2.md) |
 
 ## 验证记录模板
 

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -79,6 +79,7 @@ dependencies {
     modCompileOnly 'curse.maven:gibbed-1480667:7737413'
     modImplementation 'curse.maven:stellarcore-1064321:8406201'
     modImplementation 'curse.maven:modern-splash-629058:8487408'
+    modImplementation 'curse.maven:extra-utilities-2-225561:2678374'
 
     // Draconic Evolution
     modCompileOnly 'maven.modrinth:draconic-evolution:2.3.28.354'

--- a/src/main/java/com/dhj/actinium/compat/blockrender/ModdedBlockRenderCompat.java
+++ b/src/main/java/com/dhj/actinium/compat/blockrender/ModdedBlockRenderCompat.java
@@ -1,0 +1,117 @@
+package com.dhj.actinium.compat.blockrender;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.renderer.BlockRendererDispatcher;
+import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.renderer.block.model.IBakedModel;
+import net.minecraft.util.BlockRenderLayer;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.fml.common.Loader;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Serializes chunk-builder access to known modded block renderers with non-thread-safe caches.
+ *
+ * <p>Extra Utilities 2 stores lazy model and render-layer caches on each block instance. AgriCraft
+ * stores crop quads in a renderer-wide cache. Both renderers are normally called from vanilla's
+ * single-threaded chunk builder, while Actinium calls them from multiple worker threads.</p>
+ */
+public final class ModdedBlockRenderCompat {
+    private static final String EXTRA_UTILITIES_2_MOD_ID = "extrautils2";
+    private static final String EXTRA_UTILITIES_2_PACKAGE = "com.rwtema.extrautils2.";
+    private static final String AGRICRAFT_MOD_ID = "agricraft";
+    private static final String AGRICRAFT_PACKAGE = "com.infinityraider.agricraft.";
+
+    /** AgriCraft's RenderCrop cache is shared by all crop block instances. */
+    private static final Object AGRICRAFT_RENDER_LOCK = new Object();
+
+    private ModdedBlockRenderCompat() {
+    }
+
+    /**
+     * Runs a complete block-render lifecycle under the lock required by the block's renderer.
+     */
+    public static void renderBlock(Block block, Runnable render) {
+        if (isUnsafeBlock(block)) {
+            runWithBlockLock(lockFor(block), render);
+        } else {
+            render.run();
+        }
+    }
+
+    /**
+     * Calls a block-render operation while preserving its return value and exception behavior.
+     */
+    public static <T> T callWithBlockLock(Block block, Supplier<T> operation) {
+        if (isUnsafeBlock(block)) {
+            return callWithLock(lockFor(block), operation);
+        }
+        return operation.get();
+    }
+
+    /**
+     * Serializes a block layer query for a known unsafe renderer.
+     */
+    public static boolean canRenderInLayer(Block block, IBlockState state, BlockRenderLayer layer) {
+        return callWithBlockLock(block, () -> block.canRenderInLayer(state, layer));
+    }
+
+    /**
+     * Serializes a baked-model query for a known unsafe renderer.
+     */
+    public static List<BakedQuad> getQuads(Block block, IBakedModel model, IBlockState state,
+                                           EnumFacing side, long rand) {
+        return callWithBlockLock(block, () -> model.getQuads(state, side, rand));
+    }
+
+    /**
+     * Renders through the vanilla dispatcher while holding the block renderer's compatibility lock.
+     */
+    public static void renderBlock(BlockRendererDispatcher dispatcher, IBlockState state,
+                                   BlockPos pos, IBlockAccess access, BufferBuilder buffer) {
+        renderBlock(state.getBlock(), () -> dispatcher.renderBlock(state, pos, access, buffer));
+    }
+
+    /**
+     * Provides the deterministic locking seam used by the concurrency regression test.
+     */
+    static void runWithBlockLock(Object lock, Runnable operation) {
+        synchronized (lock) {
+            operation.run();
+        }
+    }
+
+    static boolean isUnsafeBlockClassName(String name) {
+        return name != null && (name.startsWith(EXTRA_UTILITIES_2_PACKAGE)
+                || name.startsWith(AGRICRAFT_PACKAGE));
+    }
+
+    private static boolean isUnsafeBlock(Block block) {
+        String className = block.getClass().getName();
+        if (className.startsWith(EXTRA_UTILITIES_2_PACKAGE)) {
+            return Loader.isModLoaded(EXTRA_UTILITIES_2_MOD_ID);
+        }
+        if (className.startsWith(AGRICRAFT_PACKAGE)) {
+            return Loader.isModLoaded(AGRICRAFT_MOD_ID);
+        }
+        return false;
+    }
+
+    private static Object lockFor(Block block) {
+        return block.getClass().getName().startsWith(AGRICRAFT_PACKAGE)
+                ? AGRICRAFT_RENDER_LOCK
+                : block;
+    }
+
+    private static <T> T callWithLock(Object lock, Supplier<T> operation) {
+        synchronized (lock) {
+            return operation.get();
+        }
+    }
+}

--- a/src/main/java/com/dhj/actinium/compat/fluidlogged/FluidloggedCompat.java
+++ b/src/main/java/com/dhj/actinium/compat/fluidlogged/FluidloggedCompat.java
@@ -2,6 +2,7 @@ package com.dhj.actinium.compat.fluidlogged;
 
 import git.jbredwards.fluidlogged_api.api.block.IFluidloggable;
 import git.jbredwards.fluidlogged_api.api.util.FluidState;
+import com.dhj.actinium.compat.blockrender.ModdedBlockRenderCompat;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.BlockRendererDispatcher;
 import net.minecraft.util.BlockRenderLayer;
@@ -29,12 +30,12 @@ public class FluidloggedCompat {
             var block = renderState.getBlock();
 
             for (BlockRenderLayer layer : VintageChunkBuildContext.LAYERS) {
-                if (block.canRenderInLayer(renderState, layer)) {
+                if (ModdedBlockRenderCompat.canRenderInLayer(block, renderState, layer)) {
                     ForgeHooksClient.setRenderLayer(layer);
                     var buffer = context.getBufferForLayer(layer);
                     context.beginVanillaFluidRender(buffer, pos, renderState);
                     try {
-                        dispatcher.renderBlock(renderState, pos, blockAccess, buffer);
+                        ModdedBlockRenderCompat.renderBlock(dispatcher, renderState, pos, blockAccess, buffer);
                     } finally {
                         context.endVanillaRender(buffer);
                     }

--- a/src/main/java/com/dhj/actinium/mixin/mod/betterfoliage/MixinChunkBuilderMeshingTaskBetterFoliage.java
+++ b/src/main/java/com/dhj/actinium/mixin/mod/betterfoliage/MixinChunkBuilderMeshingTaskBetterFoliage.java
@@ -37,9 +37,10 @@ public abstract class MixinChunkBuilderMeshingTaskBetterFoliage {
             method = EXECUTE_METHOD,
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/block/Block;canRenderInLayer("
-                            + "Lnet/minecraft/block/state/IBlockState;Lnet/minecraft/util/BlockRenderLayer;)Z",
-                    remap = true
+                    target = "Lcom/dhj/actinium/compat/blockrender/ModdedBlockRenderCompat;canRenderInLayer("
+                            + "Lnet/minecraft/block/Block;Lnet/minecraft/block/state/IBlockState;"
+                            + "Lnet/minecraft/util/BlockRenderLayer;)Z",
+                    remap = false
             )
     )
     private boolean actinium$betterFoliageCanRenderInLayer(
@@ -127,24 +128,28 @@ public abstract class MixinChunkBuilderMeshingTaskBetterFoliage {
             method = EXECUTE_METHOD,
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/client/renderer/BlockRendererDispatcher;renderBlock("
+                    target = "Lcom/dhj/actinium/compat/blockrender/ModdedBlockRenderCompat;renderBlock("
+                            + "Lnet/minecraft/client/renderer/BlockRendererDispatcher;"
                             + "Lnet/minecraft/block/state/IBlockState;Lnet/minecraft/util/math/BlockPos;"
                             + "Lnet/minecraft/world/IBlockAccess;"
-                            + "Lnet/minecraft/client/renderer/BufferBuilder;)Z",
-                    remap = true
+                            + "Lnet/minecraft/client/renderer/BufferBuilder;)V",
+                    remap = false
             )
     )
-    private boolean actinium$betterFoliageWrapVanillaRenderBlock(
+    private void actinium$betterFoliageWrapVanillaRenderBlock(
             BlockRendererDispatcher dispatcher,
             IBlockState state,
             BlockPos pos,
             IBlockAccess blockAccess,
             BufferBuilder buffer,
-            Operation<Boolean> original,
+            Operation<Void> original,
             @Local(name = "layer") BlockRenderLayer layer
     ) {
         Boolean result = RenderingHandler.wrapRenderBlock(
-                () -> original.call(dispatcher, state, pos, blockAccess, buffer),
+                () -> {
+                    original.call(dispatcher, state, pos, blockAccess, buffer);
+                    return Boolean.TRUE;
+                },
                 state,
                 pos,
                 blockAccess,
@@ -152,8 +157,7 @@ public abstract class MixinChunkBuilderMeshingTaskBetterFoliage {
                 layer
         );
         if (result == null) {
-            return original.call(dispatcher, state, pos, blockAccess, buffer);
+            original.call(dispatcher, state, pos, blockAccess, buffer);
         }
-        return result;
     }
 }

--- a/src/main/java/com/dhj/actinium/render/terrain/compile/pipeline/VintageBlockRenderer.java
+++ b/src/main/java/com/dhj/actinium/render/terrain/compile/pipeline/VintageBlockRenderer.java
@@ -1,6 +1,7 @@
 package com.dhj.actinium.render.terrain.compile.pipeline;
 
 import com.dhj.actinium.api.render.terrain.BlockQuadTransformerHolder;
+import com.dhj.actinium.compat.blockrender.ModdedBlockRenderCompat;
 import net.coderbot.iris.debug.ShaderRegressionDebug;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
@@ -100,6 +101,12 @@ public class VintageBlockRenderer {
     }
 
     public void renderBlock(IBlockState state, BlockPos pos, ActiniumBlockAccess blockAccess, BlockRenderLayer layer, boolean allowRenderPassOptimization) {
+        ModdedBlockRenderCompat.renderBlock(state.getBlock(), () -> this.renderBlockInternal(
+                state, pos, blockAccess, layer, allowRenderPassOptimization));
+    }
+
+    private void renderBlockInternal(IBlockState state, BlockPos pos, ActiniumBlockAccess blockAccess,
+                                     BlockRenderLayer layer, boolean allowRenderPassOptimization) {
         int defaultFlags = BakedQuadGroupAnalyzer.USE_ALL_THINGS;
         if (!this.useRenderPassOptimization || !allowRenderPassOptimization) {
             defaultFlags &= ~BakedQuadGroupAnalyzer.USE_RENDER_PASS_OPTIMIZATION;
@@ -148,7 +155,7 @@ public class VintageBlockRenderer {
         );
 
         for (var dir : EnumFacing.VALUES) {
-            var quads = model.getQuads(state, dir, rand);
+            var quads = ModdedBlockRenderCompat.getQuads(state.getBlock(), model, state, dir, rand);
 
             if (quads.isEmpty() || !state.shouldSideBeRendered(blockAccess, pos, dir)) {
                 continue;
@@ -164,7 +171,7 @@ public class VintageBlockRenderer {
             renderQuadList(buffer, buffers, material, pos, dir, lighter, colorProvider, offset, quads);
         }
 
-        var quads = model.getQuads(state, null, rand);
+        var quads = ModdedBlockRenderCompat.getQuads(state.getBlock(), model, state, null, rand);
 
         if (!quads.isEmpty()) {
             quads = BlockQuadTransformerHolder.transform(

--- a/src/main/java/com/dhj/actinium/render/terrain/compile/task/ChunkBuilderMeshingTask.java
+++ b/src/main/java/com/dhj/actinium/render/terrain/compile/task/ChunkBuilderMeshingTask.java
@@ -33,6 +33,7 @@ import org.joml.Vector3d;
 import org.embeddedt.embeddium.api.shader.BlockRenderLayer;
 import org.embeddedt.embeddium.api.shader.ShaderProvider;
 import org.embeddedt.embeddium.api.shader.ShaderProviderHolder;
+import com.dhj.actinium.compat.blockrender.ModdedBlockRenderCompat;
 import com.dhj.actinium.compat.fluidlogged.FluidloggedCompat;
 import com.dhj.actinium.compat.snowrealmagic.SnowRealMagicCompat;
 import com.dhj.actinium.runtime.ActiniumRuntime;
@@ -123,21 +124,21 @@ public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> 
                         if (shaderLayerOverride != null) {
                             net.minecraft.util.BlockRenderLayer layer = shaderLayerOverride.toVanillaLayer();
                             ForgeHooksClient.setRenderLayer(layer);
-                            block.canRenderInLayer(blockState, layer);
+                            ModdedBlockRenderCompat.canRenderInLayer(block, blockState, layer);
                             if (blockState.getRenderType() == EnumBlockRenderType.MODEL && ActiniumRuntime.options().performance.useFastBlockRenderer && !SnowRealMagicCompat.shouldForceVanillaRender(block)) {
                                 buildContext.getBlockRenderer().renderBlock(blockState, blockPos, slice, layer, false);
                             } else {
                                 var buffer = buildContext.getBufferForLayer(layer);
                                 buildContext.beginVanillaBlockRender(buffer, blockPos, blockState);
                                 try {
-                                    dispatcher.renderBlock(blockState, blockPos, slice, buffer);
+                                    ModdedBlockRenderCompat.renderBlock(dispatcher, blockState, blockPos, slice, buffer);
                                 } finally {
                                     buildContext.endVanillaRender(buffer);
                                 }
                             }
                         } else {
                             for (net.minecraft.util.BlockRenderLayer layer : VintageChunkBuildContext.LAYERS) {
-                                if (block.canRenderInLayer(blockState, layer)) {
+                                if (ModdedBlockRenderCompat.canRenderInLayer(block, blockState, layer)) {
                                     ForgeHooksClient.setRenderLayer(layer);
                                     if (blockState.getRenderType() == EnumBlockRenderType.MODEL && ActiniumRuntime.options().performance.useFastBlockRenderer && !SnowRealMagicCompat.shouldForceVanillaRender(block)) {
                                         buildContext.getBlockRenderer().renderBlock(blockState, blockPos, slice, layer);
@@ -145,7 +146,7 @@ public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> 
                                         var buffer = buildContext.getBufferForLayer(layer);
                                         buildContext.beginVanillaBlockRender(buffer, blockPos, blockState);
                                         try {
-                                            dispatcher.renderBlock(blockState, blockPos, slice, buffer);
+                                            ModdedBlockRenderCompat.renderBlock(dispatcher, blockState, blockPos, slice, buffer);
                                         } finally {
                                             buildContext.endVanillaRender(buffer);
                                         }

--- a/src/test/java/com/dhj/actinium/compat/blockrender/ModdedBlockRenderCompatTest.java
+++ b/src/test/java/com/dhj/actinium/compat/blockrender/ModdedBlockRenderCompatTest.java
@@ -1,0 +1,127 @@
+package com.dhj.actinium.compat.blockrender;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ModdedBlockRenderCompatTest {
+    @Test
+    void recognizesKnownUnsafeRendererClasses() {
+        assertTrue(ModdedBlockRenderCompat.isUnsafeBlockClassName(
+                "com.rwtema.extrautils2.backend.XUBlockStatic$3"));
+        assertTrue(ModdedBlockRenderCompat.isUnsafeBlockClassName(
+                "com.infinityraider.agricraft.blocks.BlockCrop"));
+    }
+
+    @Test
+    void rejectsUnrelatedRendererClasses() {
+        assertFalse(ModdedBlockRenderCompat.isUnsafeBlockClassName("net.minecraft.block.Block"));
+        assertFalse(ModdedBlockRenderCompat.isUnsafeBlockClassName("com.rwtema.extrautils1.backend.XUBlock"));
+        assertFalse(ModdedBlockRenderCompat.isUnsafeBlockClassName(null));
+    }
+
+    @Test
+    void serializesSharedRendererCacheAccess() throws Exception {
+        Object block = new Object();
+        Map<Integer, Integer> cache = new HashMap<>();
+        AtomicInteger activeMappings = new AtomicInteger();
+        AtomicBoolean concurrentMappings = new AtomicBoolean();
+        CountDownLatch firstMappingStarted = new CountDownLatch(1);
+        CountDownLatch secondRenderStarted = new CountDownLatch(1);
+        CountDownLatch releaseFirstMapping = new CountDownLatch(1);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            var first = executor.submit(() -> renderCachedValue(
+                    block,
+                    cache,
+                    1,
+                    activeMappings,
+                    concurrentMappings,
+                    firstMappingStarted,
+                    null,
+                    releaseFirstMapping
+            ));
+
+            assertTrue(firstMappingStarted.await(5, TimeUnit.SECONDS));
+
+            var second = executor.submit(() -> renderCachedValue(
+                    block,
+                    cache,
+                    2,
+                    activeMappings,
+                    concurrentMappings,
+                    null,
+                    secondRenderStarted,
+                    releaseFirstMapping
+            ));
+
+            assertFalse(secondRenderStarted.await(100, TimeUnit.MILLISECONDS));
+            releaseFirstMapping.countDown();
+
+            first.get(5, TimeUnit.SECONDS);
+            second.get(5, TimeUnit.SECONDS);
+            assertFalse(concurrentMappings.get());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static void renderCachedValue(
+            Object block,
+            Map<Integer, Integer> cache,
+            int key,
+            AtomicInteger activeMappings,
+            AtomicBoolean concurrentMappings,
+            CountDownLatch firstMappingStarted,
+            CountDownLatch secondRenderStarted,
+            CountDownLatch releaseFirstMapping
+    ) {
+        ModdedBlockRenderCompat.runWithBlockLock(block, () -> {
+            if (secondRenderStarted != null) {
+                secondRenderStarted.countDown();
+            }
+
+            cache.computeIfAbsent(key, ignored -> {
+                if (firstMappingStarted != null) {
+                    firstMappingStarted.countDown();
+                }
+
+                int active = activeMappings.incrementAndGet();
+                if (active > 1) {
+                    concurrentMappings.set(true);
+                }
+
+                try {
+                    if (releaseFirstMapping != null && firstMappingStarted != null) {
+                        await(releaseFirstMapping);
+                    }
+                    return key;
+                } finally {
+                    activeMappings.decrementAndGet();
+                }
+            });
+        });
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            if (!latch.await(5, TimeUnit.SECONDS)) {
+                throw new AssertionError("Timed out waiting for the first cache mapping");
+            }
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Interrupted while waiting for the first cache mapping", ex);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Serialize known non-thread-safe Extra Utilities 2 and AgriCraft block-renderer caches across Actinium's asynchronous chunk-building path.
- Keep the compatibility boundary outside mixins and cover layer checks, baked-model queries, vanilla dispatcher rendering, and the full Vintage block-render lifecycle.
- Add a deterministic concurrency regression test and record the XU2 dev-world reload validation.

## Root cause

Actinium builds chunk meshes with multiple workers, while Extra Utilities 2 keeps lazy model, render-layer, and baked-quad caches in ordinary `HashMap` instances on its static block renderer. Two workers can therefore enter `HashMap.computeIfAbsent` for the same XU2 block and trigger the issue #36 `ConcurrentModificationException`. AgriCraft exposes the same class of race through a renderer-wide crop-quad cache.

## Fix

- Add `ModdedBlockRenderCompat` with call-time mod-presence and class-prefix gates.
- Lock XU2 operations on the block instance; lock AgriCraft operations on a shared renderer lock.
- Serialize the complete `VintageBlockRenderer` lifecycle so quad processing remains inside the same boundary.
- Route `ChunkBuilderMeshingTask`, Fluidlogged API rendering, and BetterFoliage's wrapped calls through the compatibility entry points.

## Validation

- `.\gradlew.bat :test --tests com.dhj.actinium.compat.blockrender.ModdedBlockRenderCompatTest --no-daemon -g D:/gradle`
- `.\gradlew.bat test compileJava check build verifyCompatBridgeJar verifyModuleBoundaries verifyRemapJar --no-daemon -g D:/gradle`
- Java 25 (`D:/Program Files/Zulu/zulu-25`) with Gradle cache `D:/gradle`.
- Dev client: loaded `extrautils2@1.0`, started 10 chunk-builder workers, entered an existing world, and triggered a chunk reload. No `ConcurrentModificationException` or `XUBlockStatic` error appeared, and the client exited normally.
- AgriCraft has no manual runtime validation yet and remains marked as partially verified.

Fixes #36
