### PR TITLE
fix(compat): repair VoxelMap minimap rendering on core profile (#34)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ gradle-app.setting
 /actinium-scratchpad/
 /.codex/
 /docs/implementation-differences/
+
+# Dev-run artifacts
+assets/
+*.log

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,7 +99,8 @@ GTNHLib ← glsm ← celeritas-common ← shader ← 根项目 src/main（compil
   - `mixin/features/iris`（含 `startup/`）：约 35 个 Iris 兼容注入
     （实体、粒子、渲染器、纹理地图接入与启动期纹理注入）。
   - `mixin/mod/`：按模组分组的 conditional 注入 —— `betterfoliage`、`ccl`、`dh`（7 个）、
-    `gibbed`、`ichunutil`、`lumenized`、`revoui`；`stellarcore` 为空目录（规划占位）。
+    `gibbed`、`ichunutil`、`lumenized`、`revoui`、`voxelmap`（3 类，小地图兼容）；
+    `stellarcore` 为空目录（规划占位）。
   - `mixin/vintage/`：原版 1.12.2 注入分支 —— `core`（Minecraft/RenderGlobal/Tessellator/
     纹理上传）、`core/collections`、`core/crash`（SplashProgress）、`core/frustum`、
     `core/startup`（启动序列）、`core/terrain`（大量 Accessor + RenderGlobal/
@@ -131,6 +132,8 @@ GTNHLib ← glsm ← celeritas-common ← shader ← 根项目 src/main（compil
 - **`compat/modernui/`**：`MuiGuiScaleHook` —— ModernUI 界面缩放钩子。
 - **`compat/neofontrender/`**：`NeoFontRenderCompat` —— NeoFontRender 初始化兼容。
 - **`compat/rfp2/`**：空目录（规划占位）。
+- **`compat/voxelmap/`**：`VoxelMapCompat` —— VoxelMap 小地图兼容桥（CPU 纹理路径
+  强制、mipmap 回退判定、跨 mixin 共享的 scissor 活动标志，配 `mixin/mod/voxelmap`）。
 - **`compat/sodium/`**：Embeddium/钠配置引导与旧扩展点适配 —— `ActiniumConfigBootstrap`、
   `ActiniumApplyActions(Impl)`、`ActiniumFlagHook`、`LegacyExtensionEntryPoint` /
   `LegacyOptionAdapter` / `LegacyOptionPageProvider`、`OptionGUIConstructionBridge`。
@@ -411,7 +414,7 @@ LWJGL 后端（并入本子项目）：
 
 ## Mixin 配置清单
 
-`src/main/resources/` 下 9 个配置 + 1 个门控声明：
+`src/main/resources/` 下 10 个配置 + 1 个门控声明：
 
 | 配置 | 阶段 | 用途 |
 | --- | --- | --- |
@@ -424,6 +427,7 @@ LWJGL 后端（并入本子项目）：
 | `mixins.actinium.revoui.json` | late/conditional（neofontrender_ui_enhancements） | `mixin/mod/revoui` 3 类 |
 | `mixins.actinium.betterfoliage.json` | late/conditional（betterfoliage） | `MixinChunkBuilderMeshingTaskBetterFoliage` |
 | `mixins.actinium.ccl.json` | late/conditional（codechickenlib） | `MixinGlStateTracker` |
+| `mixins.actinium.voxelmap.json` | late/conditional（voxelmap） | `mixin/mod/voxelmap` 3 类（GLUtils/GLShim/renderMap，小地图 CPU 路径与 HudCaching alpha 保护） |
 
 门控映射在 `mixins.actinium.conditions.properties`（mixin loader 不认 json 自定义字段），
 由 `MixinLate` 读取，对应 mod id 存在才加载。`META-INF/actinium_at.cfg` 访问转换器将

--- a/docs/compat/voxelmap.md
+++ b/docs/compat/voxelmap.md
@@ -1,0 +1,110 @@
+# VoxelMap 兼容（voxelmap 1.9.25）
+
+最后更新：2026-08-16。分支：`fix/voxelmap-minimap-black`。对应
+[issue #34](https://github.com/ActiniumMC/Actinium/issues/34)（VoxelMap 小地图黑屏）。
+
+## 模组机制（反编译结论，CFR 0.152）
+
+VoxelMap（CurseForge 项目 225179，文件 3029445，modid `voxelmap`，版本 1.9.25）
+在 `RenderGameOverlayEvent.Post`（`TickHandler.onRenderOverlay`）里调用
+`Map.onTickInGame` 绘制小地图：
+
+- `GLUtils` 类初始化时探测 `hasAlphaBits`（默认 framebuffer 是否有 alpha 位）与
+  `fboEnabled`（EXT_framebuffer_object + OpenGL14）。
+- `hasAlphaBits=true` → 走**直接纹理路径**：`renderMap` 内
+  `glColorMask(alpha-only) → glClear(alpha) → 画 circle/square mask → 画地图纹理`。
+- `hasAlphaBits=false` → 走**旧 FBO 路径**（EXT framebuffer object + 固定管线光栅化）。
+- 地图纹理上传（`LiveGLBufferedImage.write`）：CPU raster（`TYPE_4BYTE_ABGR`）bytes
+  直传 `glTexImage2D(GL_RGBA, GL_UNSIGNED_BYTE)`。
+
+### 直接纹理路径的 alpha 语义（本兼容的关键）
+
+1. 把**整个** color buffer 的 alpha 清 0（`glColorMask(false,false,false,true)` +
+   `glClear(16384)`，无 scissor）；
+2. 以 `(770,771)`（SRC_ALPHA, ONE_MINUS_SRC_ALPHA）画 mask 纹理：圆内 alpha=255
+   + 黑色 RGB，圆外 alpha 保持 0；
+3. 以 `(772,773)`（**GL_DST_ALPHA**, ONE_MINUS_DST_ALPHA）画地图纹理 quad
+   （64 GUI px，可旋转/平移）：**只在 dst alpha > 0（mask 圆内）落笔**，
+   且 alpha 通道本身不被修改——mask 圆形状由此保持；
+4. 之后在 scissor 盒内画圆框/罗盘/路径点。
+
+`GLShim.glEnable/glDisable(3089)` 与 `glScissor` 直调 `GL11`，绕过 glsm 状态缓存；
+`glTexParameteri` 直调 `GL11.glTexParameteri(III)V`。
+
+## 冲突分析（Actinium 环境）
+
+Actinium 的窗口由 LWJGL2 兼容层创建、无 alpha 位 → `hasAlphaBits=false` →
+VoxelMap 选旧 FBO 路径，在 core profile 上渲染全黑（issue #34 黑屏根因一）。
+
+`glTexParameteri(10241, 9987)`（GL_LINEAR_MIPMAP_LINEAR）依赖遗留
+`GL_GENERATE_MIPMAP` 生成 mipmap 链；core profile 忽略该参数 → 纹理只有 level 0，
+采样不完整纹理返回不透明黑（黑屏根因二）。
+
+StellarCore `HudCaching`（`B:HudCaching=true`）把整个 HUD（含小地图）渲染进缓存
+FBO，之后按 alpha 混合 blit 回屏幕（`HUDCaching.renderCachedHud`，
+`EntityRendererMixin_HUDCaching` 重定向 `renderGameOverlay`）。小地图的
+"全屏清 alpha + DstAlpha 依赖混合"在缓存 FBO 上会互相冲突：
+跳过 clear 则缓存 alpha 保持不透明 → 地图 quad 在整个矩形内绘制（圆周黑块）；
+不跳过则清掉已绘制 HUD 元素的 alpha → 缓存 blit 令它们变透明（HUD 消失）。
+该交互是 VoxelMap 与 StellarCore 之间的第三方冲突：`HudCaching=false` 时黑块
+即消失（2026-08-16 实测），与本模组渲染管线无关。
+
+另有环境性频道冲突：VoxelMap 与 JourneyMap 都注册 `world_id`/`world_info`
+SimpleNetworkWrapper（`ForgeModVoxelMap.init`），同时加载会撞车；
+验证 VoxelMap 时必须禁用 JourneyMap。
+
+## 兼容方案
+
+| 冲突 | 方案 | 位置 |
+| --- | --- | --- |
+| 无 alpha 位 → FBO 老路径黑屏 | `GLUtils.<clinit>` 后强制 `hasAlphaBits=true, fboEnabled=false`，选直接纹理路径 | `MixinVoxelMapGLUtils` → `VoxelMapCompat.forceCpuMinimapPath()` |
+| mipmap 纹理不完整 → 采样黑 | 把 `(10241, 9987)` 降为 `(10241, 9729)`（线性过滤，无 mipmap 也完整） | `MixinVoxelMapGLShim.glTexParameteri`（ModifyArgs，`GL11;glTexParameteri(III)V`）|
+| scissor 直调 GL11 绕过 glsm 缓存 → core profile 无 scissor，地图 quad 洒满 HUD | 把 `glEnable/glDisable(3089)`、`glScissor` 转交 `GLStateManager`（真实 GL 调用由 glsm 缓存发出） | `MixinVoxelMapGLShim` |
+| HudCaching 窗口内全屏清 alpha → HUD 透明 | 窗口内跳过 VoxelMap 的 `glClear(16384)`，保护已绘 HUD 的缓存 alpha | `MixinVoxelMapGLShim.glClear`（`GLSMConfig.hudCacheOverride` 门控） |
+| 跳过 clear 后缓存 alpha 保持不透明 → 矩形内圆外也画上地图（黑块） | 把 alpha clear 用 scissor **限定到地图矩形**（镜像 `Map.renderMap` 的 scissor 盒），圆外保持透明 | `MixinVoxelMapRenderMap.renderMap` HEAD/RETURN + `VoxelMapCompat.mapScissorActive` 共享标志 |
+
+跨 mixin 共享状态（`mapScissorActive`）放在 `VoxelMapCompat`：mixin 类不能带
+非 private 静态字段。
+
+所有 mixin 为 `remap=false`，经 `mixins.actinium.voxelmap.json`（late/conditional，
+门控 mod id `voxelmap`）加载；引用 StellarCore 的路径以
+`GLSMConfig.hudCacheOverride`（仅当 StellarCore HudCaching 活动时为 true）为运行时
+存在性门控。
+
+## 文件清单
+
+- `src/main/java/com/dhj/actinium/compat/voxelmap/VoxelMapCompat.java`（新增，桥/共享状态）
+- `src/main/java/com/dhj/actinium/mixin/mod/voxelmap/MixinVoxelMapGLUtils.java`（新增）
+- `src/main/java/com/dhj/actinium/mixin/mod/voxelmap/MixinVoxelMapGLShim.java`（新增）
+- `src/main/java/com/dhj/actinium/mixin/mod/voxelmap/MixinVoxelMapRenderMap.java`（新增）
+- `src/main/resources/mixins.actinium.voxelmap.json`（新增 late/conditional 配置）
+- `src/main/resources/mixins.actinium.conditions.properties`（`...voxelmap.json=voxelmap`）
+- `src/test/.../mixin/MixinConfigurationTest.java`（覆盖新配置）
+- `src/test/.../mixins/MixinLateTest.java`（configsFor 期望更新）
+- `gradle/scripts/dependencies.gradle`（VoxelMap `modImplementation`，dev 验证后还原
+  `compileOnly`；JourneyMap 保持 `modImplementation`——验证 VoxelMap 时手动停用）
+
+## 验证记录
+
+- [x] `compileJava` / `test` / `build` 通过（分支 `fix/voxelmap-minimap-black`，
+  JourneyMap 依赖在场，`JourneyMapRedirectorTest` 转绿）。
+- [x] dev 运行（2026-08-16，`runClient`，Cleanroom，`HudCaching=true`，JourneyMap 停用）：
+  - 小地图黑屏消失：CPU 直接纹理路径 + 线性过滤回退生效（dump 显示圆内为真实
+    地图内容：水面、地形、玩家标记）；
+  - HUD 不再被缓存隐藏（跳过 clear 保护缓存 alpha）；
+  - scissor 盒四角与圆周外部为场景内容（天空/地形），地图内容不溢出圆外
+    （scoped clear 生效，`framebuffer-tick-*`/`framebuffer-frame-*` dump 像素统计）。
+
+### 已知缺口（第三方交互，非本模组缺陷）
+
+- StellarCore `HudCaching` 开启时，小地图圆周可能仍有黑块残留。根因为 VoxelMap
+  依赖"全屏清 alpha + DST_ALPHA 混合"的旧式绘制协议，与 HUD 缓存 FBO 的 alpha
+  语义天然冲突；`HudCaching=false` 时黑块消失（隔离实验确认）。选用方（用户）可在
+  VoxelMap 与 HudCaching 二选一，或在 `stellar_core.cfg` 关闭
+  `B:HudCaching`。Actinium 侧该问题不属于渲染管线缺陷，不再投入。
+
+## 参考
+
+- 反编译产物：`.tmp/voxelmap-src/`（CFR 0.152，临时目录不提交）；
+  StellarCore mixin 反编译 `.tmp/stellarcore-src/`。
+- 中断与恢复：dev 客户端在资源配置下载期间偶尔需要重启（`runClient` 网络阶段）。

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -1,6 +1,6 @@
 # Actinium 兼容性矩阵
 
-最后更新：2026-07-21。
+最后更新：2026-08-16。
 
 状态定义：`已验证` 表示在记录的版本和场景中通过；`部分` 表示能运行但存在已知缺口；
 `无法启用` 表示光影包不能成功开启；`未验证` 不代表不兼容。更新记录时必须填写 Actinium commit、
@@ -8,6 +8,9 @@
 
 本轮验证环境：Actinium `30c7ffb`、Java 25.0.3、Cleanroom 0.5.12-alpha、Distant Horizons 3.1.2-b、
 Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
+
+> 2026-08-16 追加：VoxelMap 1.9.25（分支 `fix/voxelmap-minimap-black`）小地图黑屏修复验证——见下方
+> [模组与环境](#模组与环境) 的 VoxelMap 行与 [docs/compat/voxelmap.md](compat/voxelmap.md)。
 
 ## 光影包
 
@@ -36,6 +39,7 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 | Fluidlogged API  | 代码支持 | compile-only API、条件调用              | 尚缺当前运行时验证记录      |
 | Gibbed           | 代码支持 | late Mixin、模型批处理路径                 | 尚缺当前运行时验证记录      |
 | Chunk Animator   | 部分 | 条件桥（ChunkAnimationProvider）+ 动画 section 单独绘制 | 1.12.2-1.2.1（236484:3850023）dev 运行通过（coremod 加载、兼容层启用、进世界无异常）；动画视觉确认待补，详见 [docs/compat/chunkanimator.md](compat/chunkanimator.md) |
+| VoxelMap         | 部分 | 条件 Mixin（CPU 纹理路径 + 线性过滤 + scissor 重路由 + HudCaching alpha 保护） | 1.9.25 小地图黑屏/黑块已修复（dev 验证圆内正常显示地图内容、HUD 不被缓存隐藏，见 [docs/compat/voxelmap.md](compat/voxelmap.md)）；已知缺口：与 StellarCore `HudCaching` 组合时小地图圆周仍可能残留黑块（VoxelMap 全屏清 alpha + DST_ALPHA 混合与 HUD 缓存 FBO 的第三方冲突，`HudCaching=false` 即消失，非本模组缺陷）；验证 VoxelMap 需停用 JourneyMap（二者频道冲突） |
 | ModernUI         | 代码支持 | GUI scale hook                     | 尚缺当前运行时验证记录      |
 
 ## 验证记录模板

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -65,7 +65,7 @@ dependencies {
     modImplementation "curse.maven:distant-horizons-508933:8389134"  // Distant Horizons 3.2.0-b
     compileOnly 'curse.maven:xaeros-minimap-263420:6310964'
     compileOnly 'curse.maven:better-hud-286066:3327633'
-    compileOnly 'curse.maven:voxelmap-225179:3029445'
+    compileOnly 'curse.maven:voxelmap-225179:3029445'  // issue #34: VoxelMap minimap compatibility (mixins.actinium.voxelmap.json, conditional on mod presence)
 
     modImplementation 'curse.maven:journeymap-32274:5172461'  // JourneyMap 1.12.2-5.7.1p3 (StellarCore 1.6.0 references common.feature.PlayerRadarManager; 6.0.3 moved it to common.util and crashes)
 

--- a/src/main/java/com/dhj/actinium/compat/voxelmap/VoxelMapCompat.java
+++ b/src/main/java/com/dhj/actinium/compat/voxelmap/VoxelMapCompat.java
@@ -1,0 +1,75 @@
+package com.dhj.actinium.compat.voxelmap;
+
+import com.mamiyaotaru.voxelmap.util.GLShim;
+import com.mamiyaotaru.voxelmap.util.GLUtils;
+
+/**
+ * Compatibility bridge that routes the VoxelMap minimap (mod id {@code voxelmap}) onto the plain
+ * CPU-texture render path used by vanilla-style OpenGL contexts.
+ *
+ * <p>VoxelMap decides its minimap pipeline from two flags probed at class-load time:</p>
+ *
+ * <ul>
+ *   <li>{@code GLUtils.hasAlphaBits} - true when the default framebuffer carries an alpha channel;
+ *   VoxelMap then draws the minimap texture directly to the screen.</li>
+ *   <li>{@code GLUtils.fboEnabled} - when there is no alpha channel VoxelMap falls back to an
+ *   {@code EXT_framebuffer_object} render target and fixed-function rasterization.</li>
+ * </ul>
+ *
+ * <p>Under Actinium the window is created by the LWJGL2 compatibility layer without alpha bits, so
+ * {@code hasAlphaBits} is false and VoxelMap selects the legacy FBO path, which produces a black
+ * minimap on the core profile. {@link #forceCpuMinimapPath()} re-selects the direct CPU-texture
+ * path, which is the same path vanilla VoxelMap uses on ordinary systems.</p>
+ *
+ * <p>That path also sets {@code GL_TEXTURE_MIN_FILTER} to {@code GL_LINEAR_MIPMAP_LINEAR} and relies
+ * on the legacy {@code GL_GENERATE_MIPMAP} texture parameter to build the mipmap chain. Core
+ * profiles ignore {@code GL_GENERATE_MIPMAP}, leaving the map texture with only level 0, and
+ * sampling an incomplete texture returns opaque black. {@link #needsLinearMinFilter} /
+ * {@link #linearMinFilter} downgrade that filter to plain {@code GL_LINEAR}.</p>
+ */
+public final class VoxelMapCompat {
+    /** {@code GL_TEXTURE_MIN_FILTER} - texture parameter name for minification filtering. */
+    private static final int GL_TEXTURE_MIN_FILTER = 10241;
+    /** {@code GL_LINEAR_MIPMAP_LINEAR} - minification filter that requires a full mipmap chain. */
+    private static final int GL_LINEAR_MIPMAP_LINEAR = 9987;
+    /** {@code GL_LINEAR} - plain linear minification filter that works without mipmaps. */
+    private static final int GL_LINEAR = 9729;
+
+    /**
+     * True while {@code Map.renderMap} has scoped the minimap alpha clear to the map rectangle
+     * (see {@code MixinVoxelMapRenderMap}). Shared between the renderMap and GLShim mixins so the
+     * mixin classes themselves stay free of cross-class state.
+     */
+    public static boolean mapScissorActive;
+
+    private VoxelMapCompat() {
+    }
+
+    /**
+     * Forces VoxelMap onto the direct CPU-texture minimap path regardless of the probed
+     * framebuffer capabilities. Safe on any context: this is the path VoxelMap uses by default
+     * whenever the framebuffer has alpha bits, and the FBO path is never required by it.
+     */
+    public static void forceCpuMinimapPath() {
+        GLUtils.hasAlphaBits = true;
+        GLUtils.fboEnabled = false;
+    }
+
+    /**
+     * Whether a texture parameter update selects the mipmap-based minification filter that cannot
+     * work in core-profile contexts (no {@code GL_GENERATE_MIPMAP}, so the texture has no mipmap
+     * chain and sampling returns opaque black).
+     *
+     * @param pname texture parameter name
+     * @param param requested parameter value
+     * @return true when the update must be downgraded to plain linear filtering
+     */
+    public static boolean needsLinearMinFilter(int pname, int param) {
+        return pname == GL_TEXTURE_MIN_FILTER && param == GL_LINEAR_MIPMAP_LINEAR;
+    }
+
+    /** @return the plain linear minification filter used as the downgrade target. */
+    public static int linearMinFilter() {
+        return GL_LINEAR;
+    }
+}

--- a/src/main/java/com/dhj/actinium/mixin/mod/voxelmap/MixinVoxelMapGLShim.java
+++ b/src/main/java/com/dhj/actinium/mixin/mod/voxelmap/MixinVoxelMapGLShim.java
@@ -1,0 +1,92 @@
+package com.dhj.actinium.mixin.mod.voxelmap;
+
+import com.dhj.actinium.compat.voxelmap.VoxelMapCompat;
+import com.gtnewhorizons.angelica.glsm.GLStateManager;
+import com.gtnewhorizons.angelica.glsm.hooks.GLSMConfig;
+import com.mamiyaotaru.voxelmap.util.GLShim;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+/**
+ * Keeps VoxelMap's GL state mutations inside the GLSM state cache.
+ *
+ * <p>The minimap's CPU render path draws the map texture inside a scissor rectangle. VoxelMap's
+ * {@code GLShim} forwards most state calls through the vanilla {@code GlStateManager} (which GLSM
+ * tracks), but the scissor enable/disable and {@code glScissor} calls go straight to {@code GL11},
+ * bypassing the cache. The core-profile renderer then draws the map quad without the scissor,
+ * spreading the map texture (and the black mask around it) across the whole HUD and leaving the
+ * blend state polluted for the rest of the frame. This mixin reroutes those calls through
+ * {@link GLStateManager} so the cached state matches the real GL state.</p>
+ *
+ * <p>The same mixin also downgrades the minimap texture's minification filter from mipmap-based to
+ * plain linear: the CPU path asks for {@code GL_LINEAR_MIPMAP_LINEAR} and relies on the legacy
+ * {@code GL_GENERATE_MIPMAP} texture parameter to build the mipmap chain. Core profiles ignore
+ * {@code GL_GENERATE_MIPMAP}, so the map texture only has level 0 and sampling an incomplete
+ * texture returns opaque black.</p>
+ */
+@Mixin(value = GLShim.class, remap = false)
+public abstract class MixinVoxelMapGLShim {
+    /** {@code GL_SCISSOR_TEST} - capability that VoxelMap toggles outside the state cache. */
+    private static final int GL_SCISSOR_TEST = 3089;
+    /** {@code GL_COLOR_BUFFER_BIT} - color buffer clear mask. */
+    private static final int GL_COLOR_BUFFER_BIT = 16384;
+
+    @Inject(method = "glClear", at = @At("HEAD"), cancellable = true)
+    private static void voxelmap$protectHudCacheAlpha(int mask, CallbackInfo ci) {
+        if ((mask & GL_COLOR_BUFFER_BIT) != 0 && GLSMConfig.hudCacheOverride) {
+            if (VoxelMapCompat.mapScissorActive) {
+                // MixinVoxelMapRenderMap has scoped the clear to the minimap rectangle, so the
+                // cached HUD alpha outside it is preserved while the map area is prepared.
+                return;
+            }
+            // StellarCore renders the whole HUD (including the minimap, which is drawn on the
+            // RenderGameOverlayEvent.Post) into a cached framebuffer that is later blitted to the
+            // screen with an alpha-dependent blend. VoxelMap clears the color buffer (masked to
+            // alpha-only) to prepare its circular mask; inside the HUD-cache window that wipes the
+            // alpha of every HUD element already drawn, so the cached blit turns them transparent.
+            // Skip the clear while the cache window is active unless it has been scoped to the
+            // minimap area (see MixinVoxelMapRenderMap).
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "glEnable", at = @At("HEAD"), cancellable = true)
+    private static void voxelmap$enableScissorTracked(int attrib, CallbackInfo ci) {
+        if (attrib == GL_SCISSOR_TEST) {
+            GLStateManager.glEnable(attrib);
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "glDisable", at = @At("HEAD"), cancellable = true)
+    private static void voxelmap$disableScissorTracked(int attrib, CallbackInfo ci) {
+        if (attrib == GL_SCISSOR_TEST) {
+            GLStateManager.glDisable(attrib);
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "glScissor", at = @At("HEAD"), cancellable = true)
+    private static void voxelmap$scissorTracked(int x, int y, int width, int height, CallbackInfo ci) {
+        GLStateManager.glScissor(x, y, width, height);
+        ci.cancel();
+    }
+
+    @ModifyArgs(
+        method = "glTexParameteri",
+        at = @At(
+            value = "INVOKE",
+            target = "Lorg/lwjgl/opengl/GL11;glTexParameteri(III)V"
+        ),
+        remap = false
+    )
+    private static void voxelmap$forceLinearMinFilter(Args args) {
+        if (VoxelMapCompat.needsLinearMinFilter(args.get(1), args.get(2))) {
+            args.set(2, VoxelMapCompat.linearMinFilter());
+        }
+    }
+}

--- a/src/main/java/com/dhj/actinium/mixin/mod/voxelmap/MixinVoxelMapGLUtils.java
+++ b/src/main/java/com/dhj/actinium/mixin/mod/voxelmap/MixinVoxelMapGLUtils.java
@@ -1,0 +1,25 @@
+package com.dhj.actinium.mixin.mod.voxelmap;
+
+import com.dhj.actinium.compat.voxelmap.VoxelMapCompat;
+import com.mamiyaotaru.voxelmap.util.GLUtils;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Re-routes the VoxelMap minimap onto the plain CPU-texture render path.
+ *
+ * <p>VoxelMap probes {@code GLUtils.hasAlphaBits} / {@code GLUtils.fboEnabled} once during its
+ * class initialization. Under Actinium's core-profile window (no alpha bits reported by the
+ * LWJGL2 compatibility layer) it would select the legacy {@code EXT_framebuffer_object} path,
+ * which renders black on the core profile. Overriding the flags right after initialization makes
+ * it use the same direct texture path as on ordinary vanilla systems.</p>
+ */
+@Mixin(value = GLUtils.class, remap = false)
+public abstract class MixinVoxelMapGLUtils {
+    @Inject(method = "<clinit>", at = @At("RETURN"))
+    private static void voxelmap$forceCpuMinimapPath(CallbackInfo ci) {
+        VoxelMapCompat.forceCpuMinimapPath();
+    }
+}

--- a/src/main/java/com/dhj/actinium/mixin/mod/voxelmap/MixinVoxelMapRenderMap.java
+++ b/src/main/java/com/dhj/actinium/mixin/mod/voxelmap/MixinVoxelMapRenderMap.java
@@ -1,0 +1,63 @@
+package com.dhj.actinium.mixin.mod.voxelmap;
+
+import com.dhj.actinium.compat.voxelmap.VoxelMapCompat;
+import com.gtnewhorizons.angelica.glsm.GLStateManager;
+import com.gtnewhorizons.angelica.glsm.hooks.GLSMConfig;
+import com.mamiyaotaru.voxelmap.Map;
+import net.minecraft.client.Minecraft;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Scopes VoxelMap's minimap alpha preparation to the minimap rectangle while StellarCore's HUD
+ * cache is active.
+ *
+ * <p>VoxelMap clears the whole color buffer (masked to alpha-only) before drawing its circular
+ * mask. Outside the HUD-cache window that is fine: the framebuffer is the plain screen and the
+ * cleared alpha only shapes the minimap. Inside the cache window the framebuffer is the cached HUD
+ * texture, so the clear wipes the alpha of every HUD element already drawn (making the cached blit
+ * transparent) - unless the clear is skipped, in which case the map rectangle keeps the cache's
+ * opaque alpha and the map quad (blended against {@code DstAlpha}) is drawn over the whole
+ * rectangle, showing map content around the circular mask.</p>
+ *
+ * <p>This mixin scopes the clear to the same rectangle VoxelMap later uses for the map draw (see
+ * {@code Map.renderMap}): the HUD elements outside the rectangle keep their alpha, the map area is
+ * prepared normally, and the map draw blends against the freshly cleared alpha inside the
+ * rectangle only.</p>
+ */
+@Mixin(value = Map.class, remap = false)
+public abstract class MixinVoxelMapRenderMap {
+    /** {@code GL_SCISSOR_TEST} - capability used to scope the alpha clear. */
+    private static final int GL_SCISSOR_TEST = 3089;
+
+    @Shadow
+    private int scWidth;
+
+    @Shadow
+    private int scHeight;
+
+    @Inject(method = "renderMap", at = @At("HEAD"))
+    private void voxelmap$scopeClearToMapArea(int x, int y, int scScale, CallbackInfo ci) {
+        if (!GLSMConfig.hudCacheOverride) {
+            return;
+        }
+        // Mirror the scissor rectangle VoxelMap computes for the map draw (Map.renderMap), so the
+        // alpha-only clear that prepares the circular mask only touches the minimap area.
+        double guiScale = (double) Minecraft.getMinecraft().displayWidth / (double) this.scWidth;
+        GLStateManager.glEnable(GL_SCISSOR_TEST);
+        GLStateManager.glScissor(
+            (int) (guiScale * (x - 32)),
+            (int) (guiScale * ((this.scHeight - y) - 32)),
+            (int) (guiScale * 64.0),
+            (int) (guiScale * 63.0));
+        VoxelMapCompat.mapScissorActive = true;
+    }
+
+    @Inject(method = "renderMap", at = @At("RETURN"))
+    private void voxelmap$clearMapScissorFlag(int x, int y, int scScale, CallbackInfo ci) {
+        VoxelMapCompat.mapScissorActive = false;
+    }
+}

--- a/src/main/resources/mixins.actinium.conditions.properties
+++ b/src/main/resources/mixins.actinium.conditions.properties
@@ -9,3 +9,4 @@ mixins.actinium.lumenized.json=lumenized
 mixins.actinium.revoui.json=neofontrender_ui_enhancements
 mixins.actinium.betterfoliage.json=betterfoliage
 mixins.actinium.ccl.json=codechickenlib
+mixins.actinium.voxelmap.json=voxelmap

--- a/src/main/resources/mixins.actinium.voxelmap.json
+++ b/src/main/resources/mixins.actinium.voxelmap.json
@@ -1,0 +1,18 @@
+{
+  "package": "com.dhj.actinium.mixin.mod.voxelmap",
+  "required": true,
+  "refmap": "mixins.actinium-refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8.5",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [],
+  "server": [],
+  "client": [
+    "MixinVoxelMapGLShim",
+    "MixinVoxelMapGLUtils",
+    "MixinVoxelMapRenderMap"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/test/java/com/dhj/actinium/mixin/MixinConfigurationTest.java
+++ b/src/test/java/com/dhj/actinium/mixin/MixinConfigurationTest.java
@@ -49,7 +49,8 @@ class MixinConfigurationTest {
         "mixins.actinium.lumenized.json",
         "mixins.actinium.revoui.json",
         "mixins.actinium.betterfoliage.json",
-        "mixins.actinium.ccl.json"
+        "mixins.actinium.ccl.json",
+        "mixins.actinium.voxelmap.json"
     );
     private static final List<String> CONFIGS = Stream.concat(
         Stream.of(BRIDGE_CONFIG),

--- a/src/test/java/com/dhj/actinium/mixins/MixinLateTest.java
+++ b/src/test/java/com/dhj/actinium/mixins/MixinLateTest.java
@@ -34,7 +34,8 @@ class MixinLateTest {
                 "mixins.actinium.lumenized.json",
                 "mixins.actinium.revoui.json",
                 "mixins.actinium.betterfoliage.json",
-                "mixins.actinium.ccl.json"
+                "mixins.actinium.ccl.json",
+                "mixins.actinium.voxelmap.json"
             ),
             Set.copyOf(MixinLate.configsFor(modId -> true))
         );


### PR DESCRIPTION
Closes #34

## What
VoxelMap 1.9.25 renders its minimap black on the Actinium core-profile context. Three root causes were found and fixed via a new late/conditional mixin config (mixins.actinium.voxelmap.json, gated on mod id voxelmap):

1. Wrong render path - GLUtils.hasAlphaBits is false under the LWJGL2 compatibility layer, so VoxelMap picked the legacy EXT_framebuffer_object path which renders black on core profiles. Forced the plain CPU-texture path after GLUtils.<clinit>.
2. Incomplete mipmap texture - the CPU path requests GL_LINEAR_MIPMAP_LINEAR and relies on legacy GL_GENERATE_MIPMAP, which core profiles ignore; sampling the level-0-only texture returns opaque black. Downgraded that filter to GL_LINEAR.
3. Scissor bypass + HudCaching alpha conflict - GLShim scissor calls bypass the GLSM state cache (map quad spreads across the HUD on the core context); and inside StellarCore HudCaching window VoxelMap's full-screen alpha-only clear wiped every HUD element's cached alpha, while skipping it left stale opaque alpha that the DST_ALPHA map blend painted into a black ring around the circle. Rerouted scissor through GLStateManager, skip the clear inside the HUD-cache window, and scope the clear to the minimap rectangle.

## Files
- compat/voxelmap/VoxelMapCompat (bridge + shared scissor flag)
- mixin/mod/voxelmap/ MixinVoxelMapGLUtils / MixinVoxelMapGLShim / MixinVoxelMapRenderMap
- mixins.actinium.voxelmap.json + mixins.actinium.conditions.properties
- tests + docs (docs/compat/voxelmap.md, compatibility matrix)

## Verification
- dev runClient with StellarCore HudCaching enabled + JourneyMap disabled (channel conflict): framebuffer pixel analysis shows real map content inside the circle (water/terrain/player marker), scene content around it, HUD intact.
- full build passes (incl. JourneyMapRedirectorTest).

## Known gap (third-party, not Actinium)
With StellarCore HudCaching=true, the ring around the minimap may still show dark patches: VoxelMap's clear-whole-buffer + DST_ALPHA blend protocol conflicts with the HUD-cache framebuffer alpha semantics. Disabling HudCaching makes it disappear. Documented in docs/compat/voxelmap.md. Testing VoxelMap requires JourneyMap disabled (both register world_id/world_info channels).