### PR TITLE
fix(compat): align chunk section reads with CaveBiomesAPI height layout

### DIFF
--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -106,4 +106,10 @@ dependencies {
     modCompileOnly "curse.maven:rebooter-1625784:8518809"
     modCompileOnly "curse.maven:forgelin-continuous-456403:8248535"
     modCompileOnly "curse.maven:rlfoliage-970462:7645701"
+
+    // Caves Not Cliffs [Backported] 2.0.3 + CaveBiomesAPI 1.1.2 (issue #43: underground content renders on the
+    // surface under celeritas; the API extends world height to Y -64..320, which the vanilla-style section indexing
+    // in WorldSlice / ClonedChunkSectionCache does not account for)
+    modImplementation "maven.modrinth:caves-not-cliffs-backported:QeKF1cNG"
+    modImplementation "maven.modrinth:cavebiomesapi:deGq6TZo"
 }

--- a/src/main/java/com/dhj/actinium/compat/cavebiomes/CaveBiomesCompat.java
+++ b/src/main/java/com/dhj/actinium/compat/cavebiomes/CaveBiomesCompat.java
@@ -1,0 +1,74 @@
+package com.dhj.actinium.compat.cavebiomes;
+
+import net.celestiald.cavebiomes.api.WorldHeightAPI;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.Loader;
+
+/**
+ * Compatibility gate for CaveBiomesAPI worlds (Caves Not Cliffs [Backported]).
+ *
+ * <p>CaveBiomesAPI extends the world height to {@code -64..320} by reshaping
+ * {@code Chunk.storageArrays} to 24 sections whose index {@code i} holds world Y
+ * {@code i * 16 + minY}. The reshape happens in {@code Chunk}'s constructor for
+ * every world while the API is installed (its mixin bakes the extended layout
+ * unconditionally), so any code that indexes {@code Chunk.storageArrays} with the
+ * semantic {@code sectionY} ({@code worldY >> 4}) reads the underground storage
+ * in place of surface storage and meshes cave content at surface positions
+ * (issue #43). This is exactly why the API ships its own adapter for the other
+ * modern renderer it supports (Nothirium's {@code getSection} translates the
+ * section Y by the API's minimum section, cf. NothiriumRenderCompat). Reading
+ * chunk data through the API-provided {@code Chunk} methods is safe (the API
+ * rewrites them), so only direct {@code storageArrays} indexing needs the same
+ * translation.</p>
+ *
+ * <p>Whether the API's configured range actually extends below 0 or above 256
+ * ({@code WorldHeightAPI}), the storage layout follows the same rule
+ * {@code sectionY - minSection} and reduces to the identity mapping for the
+ * vanilla range, so the index translation is applied whenever the API is
+ * installed and never otherwise.</p>
+ */
+public final class CaveBiomesCompat {
+    public static final String MODID = "cavebiomesapi";
+
+    /** Whether CaveBiomesAPI is installed. Backs every API-touching call. */
+    public static final boolean IS_LOADED = Loader.isModLoaded(MODID);
+
+    private CaveBiomesCompat() {
+    }
+
+    /**
+     * Whether the given world uses the extended height range (height above 256
+     * or below 0). Kept for callers that gate on the vertical range; the storage
+     * index translation itself does not depend on it because the reshaped
+     * storage layout applies to every world while the API is installed.
+     */
+    public static boolean usesExtendedHeight(World world) {
+        return IS_LOADED && WorldHeightAPI.usesExtendedHeight(world);
+    }
+
+    /**
+     * Maps a semantic section Y (the coordinate the renderer works in) to an
+     * index into {@code Chunk.storageArrays}. With CaveBiomesAPI installed the
+     * layout is shifted by the API's minimum section for every world; without it
+     * the mapping is the identity, matching the vanilla 16-section layout.
+     *
+     * @param sectionY semantic section Y ({@code worldY >> 4}, may be negative
+     *                 for worlds with sections below 0)
+     * @return the storage array index; the caller is responsible for clamping it
+     *         to the array length reported by the chunk
+     */
+    public static int storageSectionIndex(int sectionY) {
+        if (!IS_LOADED) {
+            return sectionY;
+        }
+        return CaveBiomesHeightMapping.storageSectionIndex(WorldHeightAPI.getMinSection(), sectionY);
+    }
+
+    /**
+     * {@link #storageSectionIndex(int)} with the world kept in the signature for
+     * clarity at the call sites; the world does not affect the mapping.
+     */
+    public static int storageSectionIndex(World world, int sectionY) {
+        return storageSectionIndex(sectionY);
+    }
+}

--- a/src/main/java/com/dhj/actinium/compat/cavebiomes/CaveBiomesHeightMapping.java
+++ b/src/main/java/com/dhj/actinium/compat/cavebiomes/CaveBiomesHeightMapping.java
@@ -1,0 +1,46 @@
+package com.dhj.actinium.compat.cavebiomes;
+
+/**
+ * Pure section-index arithmetic for worlds with an extended height range.
+ *
+ * <p>Issue #43: CaveBiomesAPI (dependency of Caves Not Cliffs [Backported]) reshapes
+ * {@code Chunk.storageArrays} so that storage slot {@code i} holds world Y
+ * {@code i * 16 + minY} instead of the vanilla {@code i * 16}. Vanilla-style
+ * render paths index storage arrays with {@code sectionY} ({@code worldY >> 4}),
+ * which lands four sections short in the API's default {@code -64..320} range and
+ * causes the underground content to be meshed at surface positions. Render paths
+ * must translate the semantic section Y to the API's storage index before reading
+ * {@code Chunk.storageArrays}.</p>
+ *
+ * <p>This class deliberately has no dependency on {@code Loader}, CaveBiomesAPI or
+ * any Minecraft class, so the mapping can be unit-tested directly and used by
+ * hot paths without triggering Forge initialization.</p>
+ */
+final class CaveBiomesHeightMapping {
+    private CaveBiomesHeightMapping() {
+    }
+
+    /**
+     * The minimum section used by the API ({@code minY / 16}, {@code -4} for the
+     * default {@code -64..320} range). When the range is vanilla ({@code minSection == 0})
+     * the mapping is the identity, matching the unmodified layout.
+     */
+    static int minSection(int minY) {
+        return minY / 16;
+    }
+
+    /**
+     * Translates a semantic section Y ({@code worldY >> 4}, the coordinate the
+     * renderer still works in) into an index into {@code Chunk.storageArrays}.
+     *
+     * @param minSection the API's minimum section ({@code -4} for {@code -64..320},
+     *                   {@code 0} for the vanilla range); equality with {@code 0}
+     *                   selects the identity mapping
+     * @param sectionY   semantic section Y (may be negative for extended worlds)
+     * @return the storage array index; the caller is responsible for clamping it to
+     *         the array length returned by {@code Chunk#getBlockStorageArray()}
+     */
+    static int storageSectionIndex(int minSection, int sectionY) {
+        return minSection == 0 ? sectionY : sectionY - minSection;
+    }
+}

--- a/src/main/java/com/dhj/actinium/render/terrain/VintageRenderSectionManager.java
+++ b/src/main/java/com/dhj/actinium/render/terrain/VintageRenderSectionManager.java
@@ -31,6 +31,7 @@ import org.embeddedt.embeddium.api.debug.RenderDebugHooksHolder;
 import org.embeddedt.embeddium.api.shader.ShaderProvider;
 import org.embeddedt.embeddium.api.shader.ShaderProviderHolder;
 import com.dhj.actinium.world.WorldSlice;
+import com.dhj.actinium.compat.cavebiomes.CaveBiomesCompat;
 import com.dhj.actinium.world.cloned.ChunkRenderContext;
 import com.dhj.actinium.world.cloned.ClonedChunkSectionCache;
 import com.dhj.actinium.runtime.ActiniumRuntime;
@@ -115,10 +116,13 @@ public class VintageRenderSectionManager extends RenderSectionManager {
             return true;
         }
         var array = chunk.getBlockStorageArray();
-        if (y < 0 || y >= array.length) {
+        // CaveBiomesAPI reshapes storageArrays to its extended layout for every world while
+        // installed, so the semantic section Y must be translated (and clamped) before indexing.
+        int index = CaveBiomesCompat.storageSectionIndex(this.world, y);
+        if (index < 0 || index >= array.length) {
             return true;
         }
-        return array[y] == Chunk.NULL_BLOCK_STORAGE || array[y].isEmpty();
+        return array[index] == Chunk.NULL_BLOCK_STORAGE || array[index].isEmpty();
     }
 
     @Override

--- a/src/main/java/com/dhj/actinium/world/WorldSlice.java
+++ b/src/main/java/com/dhj/actinium/world/WorldSlice.java
@@ -21,6 +21,7 @@ import net.minecraftforge.client.model.pipeline.LightUtil;
 import net.minecraftforge.fml.common.Optional;
 import org.embeddedt.embeddium.impl.util.position.SectionPos;
 import org.jetbrains.annotations.Nullable;
+import com.dhj.actinium.compat.cavebiomes.CaveBiomesCompat;
 import com.dhj.actinium.compat.fluidlogged.FluidloggedCompat;
 import com.dhj.actinium.runtime.ActiniumRuntime;
 import com.dhj.actinium.world.biome.BiomeColorCache;
@@ -105,7 +106,13 @@ public class WorldSlice implements ActiniumBlockAccess {
 
     public static ChunkRenderContext prepare(World world, SectionPos origin, ClonedChunkSectionCache sectionCache) {
         Chunk chunk = world.getChunk(origin.x(), origin.z());
-        ExtendedBlockStorage section = chunk.getBlockStorageArray()[origin.y()];
+        ExtendedBlockStorage[] storageArray = chunk.getBlockStorageArray();
+        int sectionIndex = CaveBiomesCompat.storageSectionIndex(world, origin.y());
+        // CaveBiomesAPI reshapes storageArrays to its extended layout for every world while
+        // installed; clamp to the actual array length after translating the semantic section Y.
+        ExtendedBlockStorage section = sectionIndex >= 0 && sectionIndex < storageArray.length
+                ? storageArray[sectionIndex]
+                : null;
 
         // If the chunk section is absent or empty, simply terminate now. There will never be anything in this chunk
         // section to render, so we need to signal that a chunk render task shouldn't created. This saves a considerable

--- a/src/main/java/com/dhj/actinium/world/cloned/ClonedChunkSection.java
+++ b/src/main/java/com/dhj/actinium/world/cloned/ClonedChunkSection.java
@@ -14,6 +14,7 @@ import net.minecraft.world.chunk.NibbleArray;
 import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 import net.minecraft.world.gen.structure.StructureBoundingBox;
 import org.embeddedt.embeddium.impl.util.position.SectionPos;
+import com.dhj.actinium.compat.cavebiomes.CaveBiomesCompat;
 import com.dhj.actinium.compat.fluidlogged.FluidStateStorage;
 import com.dhj.actinium.compat.fluidlogged.FluidloggedCompat;
 
@@ -48,9 +49,9 @@ public class ClonedChunkSection {
             throw new RuntimeException(String.format("Couldn't retrieve chunk at %d, %d", x, z));
         }
 
-        ExtendedBlockStorage section = getChunkSection(chunk, y);
+        ExtendedBlockStorage section = getChunkSection(world, chunk, y);
 
-        if (section == Chunk.NULL_BLOCK_STORAGE/*ChunkSection.isEmpty(section)*/) {
+        if (section == null || section == Chunk.NULL_BLOCK_STORAGE) {
             section = EMPTY_SECTION;
         }
 
@@ -118,13 +119,14 @@ public class ClonedChunkSection {
         return lightArray != null ? lightArray.get(x, y, z) : type.defaultLightValue;
     }
 
-    private static ExtendedBlockStorage getChunkSection(Chunk chunk, int y) {
+    private static ExtendedBlockStorage getChunkSection(World world, Chunk chunk, int y) {
         ExtendedBlockStorage section = null;
 
         var storageArray = chunk.getBlockStorageArray();
+        int index = CaveBiomesCompat.storageSectionIndex(world, y);
 
-        if (y >= 0 && y < storageArray.length) {
-            section = storageArray[y];
+        if (index >= 0 && index < storageArray.length) {
+            section = storageArray[index];
         }
 
         return section;

--- a/src/test/java/com/dhj/actinium/compat/cavebiomes/CaveBiomesHeightMappingTest.java
+++ b/src/test/java/com/dhj/actinium/compat/cavebiomes/CaveBiomesHeightMappingTest.java
@@ -1,0 +1,52 @@
+package com.dhj.actinium.compat.cavebiomes;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies the semantic-section-to-storage-index arithmetic used when reading
+ * {@code Chunk.storageArrays} in CaveBiomesAPI worlds (issue #43: CaveBiomesAPI
+ * reshapes storage to the extended -64..320 layout, so vanilla indexing meshes
+ * underground sections at surface positions).
+ */
+class CaveBiomesHeightMappingTest {
+    @Test
+    void vanillaRangeIsIdentityMapping() {
+        // No CaveBiomesAPI world: storage index equals the semantic section Y.
+        assertEquals(0, CaveBiomesHeightMapping.storageSectionIndex(0, 0));
+        assertEquals(4, CaveBiomesHeightMapping.storageSectionIndex(0, 4));
+        assertEquals(15, CaveBiomesHeightMapping.storageSectionIndex(0, 15));
+        assertEquals(-4, CaveBiomesHeightMapping.storageSectionIndex(0, -4));
+    }
+
+    @Test
+    void defaultExtendedRangeShiftsByMinSection() {
+        // Default -64..320 range: minSection = -4, storage index = sectionY + 4.
+        // Surface section 0 (world Y 0..15) lives in storage slot 4, not slot 0.
+        assertEquals(4, CaveBiomesHeightMapping.storageSectionIndex(-4, 0));
+        // Surface-at-height section 4 (world Y 64..79) lives in storage slot 8.
+        assertEquals(8, CaveBiomesHeightMapping.storageSectionIndex(-4, 4));
+        // Top semantic section (world Y 240..255) lives in slot 19.
+        assertEquals(19, CaveBiomesHeightMapping.storageSectionIndex(-4, 15));
+        // Underground semantic sections below the vanilla floor map to the leading slots.
+        assertEquals(0, CaveBiomesHeightMapping.storageSectionIndex(-4, -4));
+        assertEquals(3, CaveBiomesHeightMapping.storageSectionIndex(-4, -1));
+        // Highest extended slot (world Y 304..319) is slot 23.
+        assertEquals(23, CaveBiomesHeightMapping.storageSectionIndex(-4, 19));
+        assertEquals(20, CaveBiomesHeightMapping.storageSectionIndex(-4, 16));
+    }
+
+    @Test
+    void otherConfiguredRangesTranslateByTheirOwnMinSection() {
+        assertEquals(2, CaveBiomesHeightMapping.storageSectionIndex(-2, 0));
+        assertEquals(7, CaveBiomesHeightMapping.storageSectionIndex(-2, 5));
+    }
+
+    @Test
+    void minSectionIsDerivedFromMinY() {
+        assertEquals(-4, CaveBiomesHeightMapping.minSection(-64));
+        assertEquals(0, CaveBiomesHeightMapping.minSection(0));
+        assertEquals(-2, CaveBiomesHeightMapping.minSection(-32));
+    }
+}


### PR DESCRIPTION
## 概述 / Summary

修复与 Caves Not Cliffs [Backported]（cavesnotcliffs-2.0.3 + cavebiomesapi-1.1.2）不兼容导致的渲染错位：**地下的内容渲染到了地表**（issue #43）。

Fixes the render misalignment with Caves Not Cliffs [Backported]: **underground content was meshed at surface positions** (issue #43).

## 原因 / Root Cause

CaveBiomesAPI 在安装期间会**无条件**重塑 `Chunk.storageArrays` 为扩展的 `-64..320` 布局（其 `Chunk` mixin 在构造时把数组扩为 24 节，并将存储下标 `i` 映射为世界 Y `i*16+minY`）。凡是以语义 `sectionY`（`worldY >> 4`）直接索引 `storageArrays` 的渲染代码，都会把地下存储当作地表存储读取——平均错位 4 个 section（64 格）。

CaveBiomesAPI 的存储布局偏移与世界类型/配置无关（即使普通世界也偏移）；其作者为同类现代渲染器 Nothirium 提供的适配（`NothiriumRenderCompat.getSection`）同样采用 `sectionY - minSection` 的无条件映射，可作为依据。

While CaveBiomesAPI is installed it unconditionally reshapes `Chunk.storageArrays` to the extended `-64..320` layout: its `Chunk` mixin resizes the array to 24 sections during construction and maps storage index `i` to world Y `i*16+minY`. Any render code indexing `storageArrays` by the semantic `sectionY` (`worldY >> 4`) reads underground storage in place of surface storage — shifted by 4 sections (64 blocks). The shift applies to every world regardless of its `WorldType`; the API's own adapter for the Nothirium renderer (`NothiriumRenderCompat.getSection`) uses the same unconditional `sectionY - minSection` mapping.

## 改动 / Changes

- 新增 `compat/cavebiomes/CaveBiomesCompat.java`：模组存在性门控（`Loader.isModLoaded("cavebiomesapi")`）+ 下标翻译；未装该 mod 时恒为 identity，对 vanilla 环境零影响。
- 新增 `compat/cavebiomes/CaveBiomesHeightMapping.java`：纯 section 下标算术（`sectionY - minSection`，默认 range 下 minSection = -4），不依赖 Forge/API，可直接单测。
- 将三处直接读取 `Chunk.storageArrays` 的路径统一走翻译并做越界 clamp：
  - `WorldSlice#prepare`（空 section 判定）
  - `ClonedChunkSection`（区块克隆数据）
  - `VintageRenderSectionManager#isSectionVisuallyEmpty`
- 新增 `CaveBiomesHeightMappingTest`（4 用例：vanilla identity、默认 `-64..320` 偏移、其它 range、minSection 推导）。
- `gradle/scripts/dependencies.gradle`：加入 `caves-not-cliffs-backported` 与 `cavebiomesapi` dev 依赖（Modrinth）。

## 验证 / Verification

- `./gradlew build --no-daemon`、`./gradlew check --no-daemon` 全部通过；393 个自动化测试 0 失败。
- dev 环境（`runClient`，加载 cavesnotcliffs 2.0.3 + cavebiomesapi 1.1.2）人工回归：新建世界，地表不再混入地下内容，渲染正确。
- 未装 CaveBiomesAPI 的普通环境不受影响（映射为 identity）。

Closes #43