### PR TITLE
fix(glsm): mirror GL20 glGetActiveUniform redirect target in GLStateManager

### DIFF
--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -6133,6 +6133,15 @@ public class GLStateManager {
         RENDER_BACKEND.getActiveUniform(program, index, length, size, type, name);
     }
 
+    public static String glGetActiveUniform(int program, int index, int maxLength) {
+        // Legacy convenience form returning the active uniform name. Third-party mods
+        // (e.g. HammerLib) call GL20.glGetActiveUniform(program, index, maxLength) ->
+        // String, which the GL redirector rewrites to this class, so the same signature
+        // must exist here or the call fails with NoSuchMethodError during mod init.
+        IntBuffer sizeType = BufferUtils.createIntBuffer(2);
+        return RENDER_BACKEND.getActiveUniform(program, index, maxLength, sizeType);
+    }
+
     public static void glGetAttachedShaders(int program, IntBuffer count, IntBuffer shaders) {
         RENDER_BACKEND.getAttachedShaders(program, count, shaders);
     }

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -106,4 +106,8 @@ dependencies {
     modCompileOnly "curse.maven:rebooter-1625784:8518809"
     modCompileOnly "curse.maven:forgelin-continuous-456403:8248535"
     modCompileOnly "curse.maven:rlfoliage-970462:7645701"
+
+    // HammerLib 12.2.66 (issue #40: its GL20.glGetActiveUniform(int, int, int) -> String call is redirected to
+    // GLSM GLStateManager, which must expose the same descriptor)
+    modImplementation "maven.modrinth:hammer-lib:B9uVCQjP"
 }

--- a/src/test/java/com/gtnewhorizons/angelica/glsm/redirect/GLStateManagerRedirectContractTest.java
+++ b/src/test/java/com/gtnewhorizons/angelica/glsm/redirect/GLStateManagerRedirectContractTest.java
@@ -1,0 +1,69 @@
+package com.gtnewhorizons.angelica.glsm.redirect;
+
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that every {@code glGetActiveUniform} signature the GL redirector can
+ * produce (it rewrites matching {@code org.lwjgl.opengl.GL20} calls by method name,
+ * preserving the caller's descriptor) actually exists on the GLSM
+ * {@code GLStateManager}.
+ *
+ * <p>HammerLib calls {@code GL20.glGetActiveUniform(int, int, int)} returning
+ * {@code String} (issue #40); the redirector rewrites that to
+ * {@code GLStateManager.glGetActiveUniform(III)Ljava/lang/String;}, which was
+ * missing and failed on mod init with {@code NoSuchMethodError}. A unit test
+ * cannot load {@code GLStateManager} because its static initializer requires a
+ * live GL context, so the contract is asserted against the compiled class bytes
+ * instead (same pattern as {@code MixinConfigurationTest}).</p>
+ */
+class GLStateManagerRedirectContractTest {
+    private static final String GL_STATE_MANAGER = "com/gtnewhorizons.angelica.glsm.GLStateManager";
+    private static final String GL_STATE_MANAGER_FILE = GL_STATE_MANAGER.replace('.', '/') + ".class";
+
+    private static final String LEGACY_STRING_FORM = "(III)Ljava/lang/String;";
+    private static final String BUFFER_FORM =
+        "(IILjava/nio/IntBuffer;Ljava/nio/IntBuffer;Ljava/nio/IntBuffer;Ljava/nio/ByteBuffer;)V";
+
+    @Test
+    void glGetActiveUniformLegacyStringFormExists() throws IOException {
+        assertTrue(
+            glGetActiveUniformDescriptors().contains(LEGACY_STRING_FORM),
+            "GLStateManager must expose glGetActiveUniform(int, int, int) returning String: "
+                + "the GL redirector rewrites HammerLib's GL20.glGetActiveUniform(III)Ljava/lang/String; "
+                + "call to it (issue #40)"
+        );
+    }
+
+    @Test
+    void glGetActiveUniformBufferFormStillExists() throws IOException {
+        assertTrue(
+            glGetActiveUniformDescriptors().contains(BUFFER_FORM),
+            "GLStateManager must keep the buffer-based glGetActiveUniform overload"
+        );
+    }
+
+    private static Set<String> glGetActiveUniformDescriptors() throws IOException {
+        ClassNode classNode = new ClassNode();
+        try (InputStream in = GLStateManagerRedirectContractTest.class.getClassLoader()
+            .getResourceAsStream(GL_STATE_MANAGER_FILE)) {
+            if (in == null) {
+                throw new IOException("Could not find " + GL_STATE_MANAGER_FILE + " on the test classpath");
+            }
+            new ClassReader(in).accept(classNode, 0);
+        }
+        return classNode.methods.stream()
+            .filter(method -> method.name.equals("glGetActiveUniform"))
+            .map(method -> method.desc)
+            .collect(Collectors.toSet());
+    }
+}


### PR DESCRIPTION
## 概述 / Summary

修复 HammerLib 在 Actinium 环境下无法初始化 shader 程序的问题（issue #40）。

Fixes HammerLib failing to initialize its shader programs when Actinium is installed (issue #40).

## 原因 / Root Cause

GLSM 的 GL 重定向器（`GLSMRedirector`）按**方法名**把 `org.lwjgl.opengl.GL20` 的调用改写为 `GLStateManager` 同名调用，并**保留调用方的描述符**。HammerLib 用 `GL20.glGetActiveUniform(int, int, int) -> String` 链接 shader 程序（`collectUniforms`），经重定向后变为 `GLStateManager.glGetActiveUniform(III)Ljava/lang/String;`——而 `GLStateManager` 只暴露了基于 buffer 的 6 参 void 形式，缺少该描述符，导致 mod 初始化时 `NoSuchMethodError`，shader 链接失败并输出 `GL error #501`。

The GLSM redirector rewrites `org.lwjgl.opengl.GL20` calls to the GLSM `GLStateManager` **by method name**, keeping the caller's descriptor. HammerLib links its shader programs via `GL20.glGetActiveUniform(int, int, int) -> String`, which becomes `GLStateManager.glGetActiveUniform(III)Ljava/lang/String;` after redirection — a descriptor `GLStateManager` did not expose (only the buffer-based 6-arg void form existed), so mod init died with `NoSuchMethodError` and the shader failed to link (`GL error #501`).

## 改动 / Changes

- `glsm/GLStateManager`：新增遗留形式的 `String glGetActiveUniform(int program, int index, int maxLength)`，委托 `RENDER_BACKEND.getActiveUniform(program, index, maxLength, sizeType)`（两个 backend 均已实现）。
- 新增 `GLStateManagerRedirectContractTest`：以字节码契约方式断言被重定向的描述符（`(III)Ljava/lang/String;` 与 6 参 buffer 形式）确实存在于 `GLStateManager`（该类静态初始化需要真实 GL context，无法在单测中加载）。
- `gradle/scripts/dependencies.gradle`：加入 HammerLib 12.2.66 dev 依赖（Modrinth）。

## 验证 / Verification

- `./gradlew build --no-daemon` 通过；391 个自动化测试 0 失败（含新增契约测试 2 例）。
- dev 环境（`runClient`，加载 HammerLib 12.2.66）：日志显示 `Shader program hammercore:ender has been linked.`，`NoSuchMethodError` 与 `GL error #501` 消失。
- 注：日志中另有一个 `NoSuchMethodException: sun.reflect.ReflectionFactory.newFieldAccessor`（HammerLib 的 BlockModelShapes 挂钩）是 HammerLib 在 **Java 25** 下使用已移除的 JDK 8 内部 API 导致的固有兼容问题，与 Actinium 无关（不装 Actinium 同样出现）。

Closes #40