### PR TITLE
fix(compat): remap iChunUtil loadRenderers injection target

### DIFF
--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -92,7 +92,7 @@ dependencies {
 
     modImplementation 'curse.maven:chunk-animator-236484:3850023'
 
-    modCompileOnly "curse.maven:ichunutil-229060:2801262"
+    modImplementation "curse.maven:ichunutil-229060:2801262"  // dev-verifies mixins.actinium.ichunutil.json (issue #39)
     modCompileOnly "curse.maven:mobdismemberment-229067:2487081"
 
 

--- a/src/main/java/com/dhj/actinium/mixin/mod/ichunutil/MixinRenderGlobalProxy.java
+++ b/src/main/java/com/dhj/actinium/mixin/mod/ichunutil/MixinRenderGlobalProxy.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = RenderGlobalProxy.class, remap = false)
 public class MixinRenderGlobalProxy {
-    @Inject(method = "loadRenderers", at = @At("TAIL"))
+    @Inject(method = "loadRenderers", remap = true, at = @At("TAIL"))
     private void actinium$reloadWorldRenderer(CallbackInfo ci) {
         ActiniumWorldRenderer renderer = SimpleWorldRenderer.Provider.getWorldRenderer(this);
         if (!renderer.isRenderingWorld(Minecraft.getMinecraft().world)) {


### PR DESCRIPTION
## 概述 / Summary

修复装 iChunUtil（Hats / Gravity Gun 依赖）时加入世界随机崩溃的问题（issue #39）。

Fixes the random crash when joining a world with iChunUtil installed (issue #39).

## 原因 / Root Cause

`MixinRenderGlobalProxy` 用 `@Mixin(remap = false)` 注入 iChunUtil 的 `RenderGlobalProxy#loadRenderers`。`remap=false` 使方法名按字面匹配运行时字节码，而发布的 iChunUtil jar 对 **vanilla 覆盖方法使用 SRG 名**（`loadRenderers` → `func_72712_a`），注入找不到目标 → mixin 应用失败（Critical injection failure）→ `RenderGlobalProxy` 类加载被污染 → 首次实体渲染时 `NoClassDefFoundError` 崩溃。

`MixinRenderGlobalProxy` injected `RenderGlobalProxy#loadRenderers` with `@Mixin(remap = false)`, which matches the method name verbatim against runtime bytes. The published iChunUtil jar names vanilla overrides with SRG names (`loadRenderers` → `func_72712_a`), so the injection found no target; the mixin apply failure poisoned `RenderGlobalProxy` class loading and the first entity render crashed with `NoClassDefFoundError`.

## 改动 / Changes

- `MixinRenderGlobalProxy`：仅给 `@Inject(method = "loadRenderers")` 开启 `remap = true`。类级 remap 保持关闭（同一 config 的其它两个 mixin 注入的是 iChunUtil 自定义方法/描述符，依赖 unmapped 行为）。生成的 refmap 条目在**生产环境**把 `loadRenderers` 翻译为 `func_72712_a`；**dev 环境**（MCP 命名、refmap 不生效）直接匹配原名——两种环境都正确。
- `gradle/scripts/dependencies.gradle`：iChunUtil 从 `modCompileOnly` 提升为 `modImplementation`，让 `mixins.actinium.ichunutil.json` 在 dev 运行时可实际加载验证。

## 验证 / Verification

- `./gradlew build --no-daemon` 通过；389 个自动化测试 0 失败。
- 构建产物 refmap 已确认包含新条目：`"loadRenderers": "Lme/ichun/.../RenderGlobalProxy;func_72712_a()V"`。
- dev 环境（加载 iChunUtil 7.2.2）：启动正常，`mixins.actinium.ichunutil.json` 已加载，无 mixin 应用错误（`RenderGlobalProxy` 在进入世界渲染实体时才被加载，进入世界验证请在 dev 或发布包中进行）。

Closes #39