### PR TITLE
fix(gui): honor mods that swap the main menu panorama paths

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'maven-publish'
     id 'com.gradleup.shadow' version '9.5.1'
     id 'org.jetbrains.gradle.plugin.idea-ext' version '1.4.1'
-    id 'xyz.wagyourtail.unimined' version '1.4.26-kappa'
+    id 'xyz.wagyourtail.unimined' version '1.4.36-kappa'
     id 'net.kyori.blossom' version '2.2.0'
 }
 

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -97,6 +97,9 @@ dependencies {
 
 
     modCompileOnly 'curse.maven:revo-font-1617673:8586768'
+    // Biomes O' Plenty 7.0.1.2445 (issue #32: it swaps GuiMainMenu.titlePanoramaPaths for its own title
+    // panorama; the GTNH skybox renderer must read the swapped field instead of hard-coded vanilla paths)
+    modImplementation "curse.maven:biomes-o-plenty-220318:3558882"
     modCompileOnly 'curse.maven:revo-ui-1620532:8593682'
     modCompileOnly('com.cleanroommc:modularui:3.1.6') { transitive = false }
 

--- a/src/main/java/com/dhj/actinium/mixin/vintage/gui/MixinGuiMainMenu.java
+++ b/src/main/java/com/dhj/actinium/mixin/vintage/gui/MixinGuiMainMenu.java
@@ -4,23 +4,23 @@ import com.gtnewhorizons.angelica.render.PanoramaRenderer;
 import net.minecraft.client.gui.GuiMainMenu;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.util.ResourceLocation;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(GuiMainMenu.class)
 public abstract class MixinGuiMainMenu extends GuiScreen {
     @Shadow
     private float panoramaTimer;
 
-    private static final ResourceLocation[] celeritas$titlePanoramaPaths = new ResourceLocation[] {
-        new ResourceLocation("textures/gui/title/background/panorama_0.png"),
-        new ResourceLocation("textures/gui/title/background/panorama_1.png"),
-        new ResourceLocation("textures/gui/title/background/panorama_2.png"),
-        new ResourceLocation("textures/gui/title/background/panorama_3.png"),
-        new ResourceLocation("textures/gui/title/background/panorama_4.png"),
-        new ResourceLocation("textures/gui/title/background/panorama_5.png")
-    };
+    /**
+     * The panorama paths rendered on the title screen. Read at render time instead of
+     * hard-coding the vanilla paths so mods that replace this field (e.g. Biomes O'
+     * Plenty swaps it for its own panorama textures, issue #32) keep their title
+     * screen background under the GTNH/Angelica skybox renderer.
+     */
+    @Shadow
+    private static ResourceLocation[] TITLE_PANORAMA_PATHS;
 
     /**
      * @author Actinium
@@ -32,7 +32,7 @@ public abstract class MixinGuiMainMenu extends GuiScreen {
             .renderSkybox(
                 (int) this.panoramaTimer,
                 partialTicks,
-                celeritas$titlePanoramaPaths,
+                TITLE_PANORAMA_PATHS,
                 this.mc,
                 this.width,
                 this.height,


### PR DESCRIPTION
## 概述 / Summary

修复装 Biomes O' Plenty 时主菜单背景被覆盖为 vanilla 的问题（issue #32）。

Fixes the Biomes O' Plenty main menu background being overridden by the vanilla panorama when Actinium is installed (issue #32).

## 原因 / Root Cause

`MixinGuiMainMenu` 用 GTNH/Angelica 的 `PanoramaRenderer` **@Overwrite** 了 `GuiMainMenu.renderSkybox`，但把全景贴图路径**硬编码为 vanilla 路径**。BOP 通过替换静态字段 `GuiMainMenu.titlePanoramaPaths`（`field_73978_o`，其 AT 移除 final）为 BOP 自己的全景贴图来实现主菜单定制；硬编码路径使该替换完全失效，背景回落到 vanilla。

`MixinGuiMainMenu` @Overwrites `GuiMainMenu.renderSkybox` to use the GTNH/Angelica `PanoramaRenderer`, but hard-coded the vanilla panorama texture paths. Biomes O' Plenty customizes the title screen by swapping the static field `GuiMainMenu.titlePanoramaPaths` (`field_73978_o`, made non-final via its AT) for its own panorama textures; the hard-coded paths ignored that swap entirely.

## 改动 / Changes

- `MixinGuiMainMenu`：改为在渲染时读取被替换的字段，按 **MCP 名** `TITLE_PANORAMA_PATHS` shadow（IDE 友好），运行时名交由 refmap 翻译。
- `build.gradle`：**Unimined 升级到 `1.4.36-kappa`**（当前 CleanroomModTemplate 版本；`1.4.26-kappa` 的 dev 管线不重映射 mixin 注解，导致 dev 环境无法解析 MCP 名——此前只能以 SRG 名 `field_73978_o` shadow）。Cleanroom loader 保持 `0.6.7-alpha`（`0.6.10-alpha` 在子项目 classpath 与部分 mod remap 上存在兼容问题，另行处理）。
- `gradle/scripts/dependencies.gradle`：加入 Biomes O' Plenty 7.0.1.2445 dev 依赖，使主菜单替换路径在 dev 运行时可实际验证。

## 验证 / Verification

- `./gradlew build --no-daemon` 通过；389 个自动化测试 0 失败。
- dev 环境（Unimined 1.4.36-kappa + BOP 7.0.1.2445）：启动无 mixin 错误，主菜单正常；**请人工确认 BOP 全景背景已恢复**。

Closes #32