### PR TITLE
fix(compat): re-read live GL state for Extra Utilities 2 GUI snapshots

### DIFF
--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -106,4 +106,8 @@ dependencies {
     modCompileOnly "curse.maven:rebooter-1625784:8518809"
     modCompileOnly "curse.maven:forgelin-continuous-456403:8248535"
     modCompileOnly "curse.maven:rlfoliage-970462:7645701"
+
+    // Extra Utilities 2 1.9.9 (issue #48: its GLStateAttributes GUI state snapshot reads the stale vanilla
+    // GlStateManager mirror under GLSM; the mixin re-reads live GL state)
+    modImplementation "curse.maven:extra-utilities-2-225561:2678374"
 }

--- a/src/main/java/com/dhj/actinium/compat/extrautils2/ExtraUtils2GLStateCompat.java
+++ b/src/main/java/com/dhj/actinium/compat/extrautils2/ExtraUtils2GLStateCompat.java
@@ -1,0 +1,44 @@
+package com.dhj.actinium.compat.extrautils2;
+
+import com.gtnewhorizons.angelica.glsm.GLStateManager;
+
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+
+/**
+ * Live GL state queries for the Extra Utilities 2 GUI compatibility (issue #48).
+ *
+ * <p>Extra Utilities 2's {@code GLStateAttributes} snapshots vanilla
+ * {@code GlStateManager} fields so its {@code restore()} can bring the GL state
+ * back after each GUI widget renders. Under Actinium those fields are never
+ * updated (the GLSM redirector takes over the method calls), so the snapshot is
+ * stale. Re-reading the state through the GLSM {@code GLStateManager} returns the
+ * cached logical state where a cache exists (texture binding/enable, blend
+ * factors, alpha test, fog, depth ...) and falls back to the live GL state
+ * otherwise, which is correct on the core-profile context Actinium creates
+ * (plain GPU queries for e.g. {@code GL_TEXTURE_2D} are invalid there).</p>
+ */
+public final class ExtraUtils2GLStateCompat {
+    private ExtraUtils2GLStateCompat() {
+    }
+
+    public static int getInteger(int pname) {
+        return GLStateManager.glGetInteger(pname);
+    }
+
+    public static void getInteger(int pname, IntBuffer params) {
+        GLStateManager.glGetInteger(pname, params);
+    }
+
+    public static float getFloat(int pname) {
+        return GLStateManager.glGetFloat(pname);
+    }
+
+    public static void getFloat(int pname, FloatBuffer params) {
+        GLStateManager.glGetFloat(pname, params);
+    }
+
+    public static boolean isEnabled(int cap) {
+        return GLStateManager.glIsEnabled(cap);
+    }
+}

--- a/src/main/java/com/dhj/actinium/mixin/mod/extrautils2/BooleanStateCapAccessor.java
+++ b/src/main/java/com/dhj/actinium/mixin/mod/extrautils2/BooleanStateCapAccessor.java
@@ -1,0 +1,20 @@
+package com.dhj.actinium.mixin.mod.extrautils2;
+
+import net.minecraft.client.renderer.GlStateManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+/**
+ * Exposes the GL capability constant of a vanilla {@code GlStateManager.BooleanState}
+ * so the Extra Utilities 2 state snapshot can re-read live GL state (issue #48).
+ *
+ * <p>Under Actinium the vanilla {@code GlStateManager} method calls are redirected
+ * to the GLSM cache, so the vanilla field mirror that Extra Utilities 2 snapshots
+ * is stale; re-querying each boolean state by its capability keeps the snapshot in
+ * sync with the real GL state.</p>
+ */
+@Mixin(GlStateManager.BooleanState.class)
+public interface BooleanStateCapAccessor {
+    @Accessor("capability")
+    int getCap();
+}

--- a/src/main/java/com/dhj/actinium/mixin/mod/extrautils2/MixinGLStateAttributes.java
+++ b/src/main/java/com/dhj/actinium/mixin/mod/extrautils2/MixinGLStateAttributes.java
@@ -1,0 +1,164 @@
+package com.dhj.actinium.mixin.mod.extrautils2;
+
+import com.dhj.actinium.compat.extrautils2.ExtraUtils2GLStateCompat;
+import com.rwtema.extrautils2.utils.client.GLStateAttributes;
+import net.minecraft.client.renderer.GlStateManager;
+import org.lwjgl.BufferUtils;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL13;
+import org.lwjgl.opengl.GL14;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.util.ArrayList;
+
+/**
+ * Fixes Extra Utilities 2 GUI rendering under Actinium (issue #48: opening a
+ * Slightly-Larger Chest renders the GUI fully transparent with white items).
+ *
+ * <p>{@code GLStateAttributes.loadStates()} snapshots vanilla
+ * {@code GlStateManager} state fields so {@code restore()} can bring the GL state
+ * back after each widget renders. Under Actinium every vanilla
+ * {@code GlStateManager} method call is redirected to the GLSM cache, so those
+ * fields are never updated and the snapshot reads stale values (e.g. texture
+ * binding 0); {@code restore()} then unbinds the GUI texture, which renders the
+ * whole GUI transparent and the items white.</p>
+ *
+ * <p>The constructor injection re-reads every snapshotted state through
+ * {@link ExtraUtils2GLStateCompat} (the GLSM state cache where available, the
+ * live GL state otherwise), so the snapshot and the restore behave exactly like
+ * vanilla. Texture-generation states are left at their constructed values: they
+ * are never enabled during GUI rendering.</p>
+ */
+@Mixin(value = GLStateAttributes.class, remap = false)
+public abstract class MixinGLStateAttributes {
+    @Shadow
+    private int alphaState_alphaFunc;
+    @Shadow
+    private float alphaState_alphaRef;
+    @Shadow
+    private boolean textureState_enabled;
+    @Shadow
+    private int textureState_name;
+    @Shadow
+    private int colorMaterialState_face;
+    @Shadow
+    private int colorMaterialState_mode;
+    @Shadow
+    private int blendState_srcFactor;
+    @Shadow
+    private int blendState_dstFactor;
+    @Shadow
+    private int blendState_srcFactorAlpha;
+    @Shadow
+    private int blendState_dstFactorAlpha;
+    @Shadow
+    private boolean depthState_maskEnabled;
+    @Shadow
+    private int depthState_depthFunc;
+    @Shadow
+    private int fogState_mode;
+    @Shadow
+    private float fogState_density;
+    @Shadow
+    private float fogState_start;
+    @Shadow
+    private float fogState_end;
+    @Shadow
+    private int cullState_field_179053_b;
+    @Shadow
+    private float polygonOffsetState_factor;
+    @Shadow
+    private float polygonOffsetState_units;
+    @Shadow
+    private int colorLogicState_field_179196_b;
+    @Shadow
+    private double clearState_field_179205_a;
+    @Shadow
+    private float clearState_field_179203_b_r;
+    @Shadow
+    private float clearState_field_179203_b_g;
+    @Shadow
+    private float clearState_field_179203_b_b;
+    @Shadow
+    private float clearState_field_179203_b_a;
+    @Shadow
+    private int activeTextureUnit;
+    @Shadow
+    private int activeShadeModel;
+    @Shadow
+    private boolean colorMaskState_r;
+    @Shadow
+    private boolean colorMaskState_g;
+    @Shadow
+    private boolean colorMaskState_b;
+    @Shadow
+    private boolean colorMaskState_a;
+    @Shadow
+    private float r;
+    @Shadow
+    private float g;
+    @Shadow
+    private float b;
+    @Shadow
+    private float a;
+    @Shadow
+    private boolean[] boolStates;
+
+    @Shadow
+    private static ArrayList<GlStateManager.BooleanState> booleanStates;
+
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void celeritas$readLiveGlState(CallbackInfo ci) {
+        this.alphaState_alphaFunc = ExtraUtils2GLStateCompat.getInteger(GL11.GL_ALPHA_TEST_FUNC);
+        this.alphaState_alphaRef = ExtraUtils2GLStateCompat.getFloat(GL11.GL_ALPHA_TEST_REF);
+        this.textureState_enabled = ExtraUtils2GLStateCompat.isEnabled(GL11.GL_TEXTURE_2D);
+        this.textureState_name = ExtraUtils2GLStateCompat.getInteger(GL11.GL_TEXTURE_BINDING_2D);
+        this.colorMaterialState_face = ExtraUtils2GLStateCompat.getInteger(GL11.GL_COLOR_MATERIAL_FACE);
+        this.colorMaterialState_mode = ExtraUtils2GLStateCompat.getInteger(GL11.GL_COLOR_MATERIAL_PARAMETER);
+        this.blendState_srcFactor = ExtraUtils2GLStateCompat.getInteger(GL14.GL_BLEND_SRC_RGB);
+        this.blendState_dstFactor = ExtraUtils2GLStateCompat.getInteger(GL14.GL_BLEND_DST_RGB);
+        this.blendState_srcFactorAlpha = ExtraUtils2GLStateCompat.getInteger(GL14.GL_BLEND_SRC_ALPHA);
+        this.blendState_dstFactorAlpha = ExtraUtils2GLStateCompat.getInteger(GL14.GL_BLEND_DST_ALPHA);
+        this.depthState_maskEnabled = ExtraUtils2GLStateCompat.getInteger(GL11.GL_DEPTH_WRITEMASK) != 0;
+        this.depthState_depthFunc = ExtraUtils2GLStateCompat.getInteger(GL11.GL_DEPTH_FUNC);
+        this.fogState_mode = ExtraUtils2GLStateCompat.getInteger(GL11.GL_FOG_MODE);
+        this.fogState_density = ExtraUtils2GLStateCompat.getFloat(GL11.GL_FOG_DENSITY);
+        this.fogState_start = ExtraUtils2GLStateCompat.getFloat(GL11.GL_FOG_START);
+        this.fogState_end = ExtraUtils2GLStateCompat.getFloat(GL11.GL_FOG_END);
+        this.cullState_field_179053_b = ExtraUtils2GLStateCompat.getInteger(GL11.GL_CULL_FACE_MODE);
+        this.polygonOffsetState_factor = ExtraUtils2GLStateCompat.getFloat(GL11.GL_POLYGON_OFFSET_FACTOR);
+        this.polygonOffsetState_units = ExtraUtils2GLStateCompat.getFloat(GL11.GL_POLYGON_OFFSET_UNITS);
+        this.colorLogicState_field_179196_b = ExtraUtils2GLStateCompat.getInteger(GL11.GL_LOGIC_OP_MODE);
+        this.clearState_field_179205_a = ExtraUtils2GLStateCompat.getFloat(GL11.GL_DEPTH_CLEAR_VALUE);
+        FloatBuffer clearColor = BufferUtils.createFloatBuffer(4);
+        ExtraUtils2GLStateCompat.getFloat(GL11.GL_COLOR_CLEAR_VALUE, clearColor);
+        this.clearState_field_179203_b_r = clearColor.get(0);
+        this.clearState_field_179203_b_g = clearColor.get(1);
+        this.clearState_field_179203_b_b = clearColor.get(2);
+        this.clearState_field_179203_b_a = clearColor.get(3);
+        this.activeTextureUnit = ExtraUtils2GLStateCompat.getInteger(GL13.GL_ACTIVE_TEXTURE) - GL13.GL_TEXTURE0;
+        this.activeShadeModel = ExtraUtils2GLStateCompat.getInteger(GL11.GL_SHADE_MODEL);
+        IntBuffer colorMask = BufferUtils.createIntBuffer(4);
+        ExtraUtils2GLStateCompat.getInteger(GL11.GL_COLOR_WRITEMASK, colorMask);
+        this.colorMaskState_r = colorMask.get(0) != 0;
+        this.colorMaskState_g = colorMask.get(1) != 0;
+        this.colorMaskState_b = colorMask.get(2) != 0;
+        this.colorMaskState_a = colorMask.get(3) != 0;
+        FloatBuffer currentColor = BufferUtils.createFloatBuffer(4);
+        ExtraUtils2GLStateCompat.getFloat(GL11.GL_CURRENT_COLOR, currentColor);
+        this.r = currentColor.get(0);
+        this.g = currentColor.get(1);
+        this.b = currentColor.get(2);
+        this.a = currentColor.get(3);
+        for (int i = 0; i < this.boolStates.length; i++) {
+            int cap = ((BooleanStateCapAccessor) (Object) booleanStates.get(i)).getCap();
+            this.boolStates[i] = ExtraUtils2GLStateCompat.isEnabled(cap);
+        }
+    }
+}

--- a/src/main/resources/mixins.actinium.conditions.properties
+++ b/src/main/resources/mixins.actinium.conditions.properties
@@ -9,3 +9,4 @@ mixins.actinium.lumenized.json=lumenized
 mixins.actinium.revoui.json=neofontrender_ui_enhancements
 mixins.actinium.betterfoliage.json=betterfoliage
 mixins.actinium.ccl.json=codechickenlib
+mixins.actinium.extrautils2.json=extrautils2

--- a/src/main/resources/mixins.actinium.extrautils2.json
+++ b/src/main/resources/mixins.actinium.extrautils2.json
@@ -1,0 +1,17 @@
+{
+  "package": "com.dhj.actinium.mixin.mod.extrautils2",
+  "required": true,
+  "refmap": "mixins.actinium-refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8.5",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [],
+  "server": [],
+  "client": [
+    "BooleanStateCapAccessor",
+    "MixinGLStateAttributes"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/test/java/com/dhj/actinium/mixin/MixinConfigurationTest.java
+++ b/src/test/java/com/dhj/actinium/mixin/MixinConfigurationTest.java
@@ -49,7 +49,8 @@ class MixinConfigurationTest {
         "mixins.actinium.lumenized.json",
         "mixins.actinium.revoui.json",
         "mixins.actinium.betterfoliage.json",
-        "mixins.actinium.ccl.json"
+        "mixins.actinium.ccl.json",
+        "mixins.actinium.extrautils2.json"
     );
     private static final List<String> CONFIGS = Stream.concat(
         Stream.of(BRIDGE_CONFIG),

--- a/src/test/java/com/dhj/actinium/mixins/MixinLateTest.java
+++ b/src/test/java/com/dhj/actinium/mixins/MixinLateTest.java
@@ -34,7 +34,8 @@ class MixinLateTest {
                 "mixins.actinium.lumenized.json",
                 "mixins.actinium.revoui.json",
                 "mixins.actinium.betterfoliage.json",
-                "mixins.actinium.ccl.json"
+                "mixins.actinium.ccl.json",
+                "mixins.actinium.extrautils2.json"
             ),
             Set.copyOf(MixinLate.configsFor(modId -> true))
         );


### PR DESCRIPTION
## 概述 / Summary

修复 Extra Utilities 2 的 Slightly-Larger Chest GUI 渲染问题（issue #48：打开箱子后 GUI 全透明、物品全白，修复期间还发现并处理了 core profile 下的状态查询问题）。

Fixes the Extra Utilities 2 Slightly-Larger Chest GUI rendering under Actinium (issue #48: fully transparent GUI with white items when opening the chest).

## 原因 / Root Cause

XU2 的 `GLStateAttributes` 在渲染每个 GUI widget 前**快照 vanilla `GlStateManager` 的状态字段**，之后 `restore()` 恢复。在 Actinium 下，GLSM 重定向接管了所有 vanilla `GlStateManager` 的**方法调用**，这些**字段镜像永不更新**（例如纹理绑定保持 0）→ `restore()` 把纹理绑回 0，**GUI 纹理被解绑** → 整个 GUI 透明、物品全白。

修复过程中的第二个问题：直接查询 GPU（`glGetBoolean(GL_TEXTURE_2D)` 等）在 Actinium 创建的 **core profile**（OpenGL 3.3+）上下文中是**非法枚举**，会把纹理启用状态错误地读成 false，导致部分元素渲染异常、交互后恶化——必须走 **GLSM 状态缓存**。

`GLStateAttributes` snapshots vanilla `GlStateManager` state fields before each GUI widget renders and `restore()`s them afterwards. Under Actinium the GLSM redirector takes over the method calls, so those field mirrors never update (e.g. texture binding stays 0); `restore()` then unbinds the GUI texture and the whole GUI renders transparent with white items. A second trap: querying the GPU directly (`glGetBoolean(GL_TEXTURE_2D)` etc.) is invalid on the core-profile context Actinium creates, so the snapshot must go through the GLSM state cache instead.

## 改动 / Changes

- 新增 `compat/extrautils2/ExtraUtils2GLStateCompat.java`：GLSM 状态查询封装（**缓存优先**，未缓存项回退真实 GL 查询——core profile 语义正确）。
- 新增 `mixin/mod/extrautils2/MixinGLStateAttributes.java`：`<init>` RETURN 注入，把快照的全部字段（纹理绑定/启用、blend 因子、alpha 测试、fog、深度、clear 颜色、颜色掩码、当前颜色、shade model、布尔状态）改为经 helper 实时读取；texGen 状态保持构造初值（GUI 渲染从不启用）。
- 新增 `mixin/mod/extrautils2/BooleanStateCapAccessor.java`：`@Accessor("capability")` 暴露 vanilla `BooleanState` 的 GL 能力常量，供布尔状态逐项查询。
- 新增 late/conditional 配置 `mixins.actinium.extrautils2.json`（按 `extrautils2` 门控）+ conditions 声明。
- `gradle/scripts/dependencies.gradle`：Extra Utilities 2 1.9.9 提为 `modImplementation` dev 依赖。

## 验证 / Verification

- `./gradlew build --no-daemon` 通过；389 个自动化测试 0 失败。
- dev 环境（XU2 1.9.9 加载）：放置并打开 Slightly-Larger Chest，GUI 渲染正常（人工确认）。

Closes #48