### PR TITLE
fix(ci): repair merge-broken mixin config test lists

### DIFF
--- a/src/test/java/com/dhj/actinium/mixin/MixinConfigurationTest.java
+++ b/src/test/java/com/dhj/actinium/mixin/MixinConfigurationTest.java
@@ -50,7 +50,7 @@ class MixinConfigurationTest {
         "mixins.actinium.revoui.json",
         "mixins.actinium.betterfoliage.json",
         "mixins.actinium.ccl.json",
-        "mixins.actinium.voxelmap.json"
+        "mixins.actinium.voxelmap.json",
         "mixins.actinium.extrautils2.json"
     );
     private static final List<String> CONFIGS = Stream.concat(

--- a/src/test/java/com/dhj/actinium/mixins/MixinLateTest.java
+++ b/src/test/java/com/dhj/actinium/mixins/MixinLateTest.java
@@ -35,7 +35,7 @@ class MixinLateTest {
                 "mixins.actinium.revoui.json",
                 "mixins.actinium.betterfoliage.json",
                 "mixins.actinium.ccl.json",
-                "mixins.actinium.voxelmap.json"
+                "mixins.actinium.voxelmap.json",
                 "mixins.actinium.extrautils2.json"
             ),
             Set.copyOf(MixinLate.configsFor(modId -> true))


### PR DESCRIPTION
## 概述 / Summary

修复网页合并（#49，VoxelMap 兼容）时损坏的两个测试文件：`MixinLateTest` 与 `MixinConfigurationTest` 的 mixin 配置列表**丢失了尾逗号**，导致 `compileTestJava` 失败（CI 阻断）。

Fixes the two test files broken by the web merge (#49, VoxelMap compatibility): the expected mixin config lists in `MixinLateTest` and `MixinConfigurationTest` lost their trailing commas, breaking `compileTestJava` on CI.

## 改动 / Changes

- `MixinLateTest.java` / `MixinConfigurationTest.java`：在 `"mixins.actinium.voxelmap.json"` 与 `"mixins.actinium.extrautils2.json"` 之间补回逗号。

## 验证 / Verification

- `./gradlew build --no-daemon` 通过；391 个自动化测试 0 失败（含 #34 VoxelMap 的 config 断言）。

（基于当前 `main`（`165def8`），仅包含本次修复；未包含任何功能改动。）