### PR TITLE
fix(shader): tolerate jcpp lexer warnings when defining property macros

### DIFF
--- a/shader/src/main/java/net/coderbot/iris/shaderpack/preprocessor/PropertiesPreprocessor.java
+++ b/shader/src/main/java/net/coderbot/iris/shaderpack/preprocessor/PropertiesPreprocessor.java
@@ -30,6 +30,13 @@ public class PropertiesPreprocessor {
 		final Map<String, String> stringValues = getStringValues(shaderPackOptions);
 
 		try (Preprocessor pp = new Preprocessor()) {
+			// Install a listener before adding macros: jcpp throws LexerException for lexer warnings
+			// (e.g. "Decimal constant starts with 0, but not octal") only when no listener is set.
+			// Shader packs such as Complementary Unbound r5.8.1 trigger such warnings in macro values,
+			// and Iris treats a LexerException here as a fatal pack load failure, breaking shader
+			// toggling. With a listener installed the warning is logged and processing continues.
+			pp.setListener(new PropertiesCommentListener());
+
 			for (String value : booleanValues) {
 				pp.addMacro(value);
 			}
@@ -60,6 +67,9 @@ public class PropertiesPreprocessor {
 		}
 
 		final Preprocessor preprocessor = new Preprocessor();
+		// See the comment in the other preprocessSource overload: without a listener, jcpp turns lexer
+		// warnings into LexerExceptions, which must not be fatal for shader pack properties.
+		preprocessor.setListener(new PropertiesCommentListener());
 
 		try {
 			for (StringPair envDefine : environmentDefines) {

--- a/src/test/java/net/coderbot/iris/shaderpack/preprocessor/PropertiesPreprocessorTest.java
+++ b/src/test/java/net/coderbot/iris/shaderpack/preprocessor/PropertiesPreprocessorTest.java
@@ -1,0 +1,42 @@
+package net.coderbot.iris.shaderpack.preprocessor;
+
+import net.coderbot.iris.shaderpack.StringPair;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that lexer warnings during property macro preprocessing are not fatal.
+ *
+ * <p>jcpp throws a {@code LexerException} for warnings (e.g. "Decimal constant starts with 0, but
+ * not octal") only while no listener is installed. Iris installs its listeners inside
+ * {@code process()}, so macro values added before that point could fail the whole pack load.
+ * Complementary Unbound r5.8.1 triggers exactly this warning, which broke shader toggling
+ * (issue #31).</p>
+ */
+class PropertiesPreprocessorTest {
+    @Test
+    void zeroPrefixedDecimalInEnvironmentDefineValueIsNotFatal() {
+        // The macro value is lexed while the preprocessor has no listener installed (issue #31).
+        assertDoesNotThrow(() -> PropertiesPreprocessor.preprocessSource(
+            "someKey = someValue\n",
+            List.of(new StringPair("COMPLEMENTARY", "00002178"))
+        ));
+    }
+
+    @Test
+    void zeroPrefixedDecimalInSourceContentIsNotFatal() {
+        // Lexing the source itself goes through the collecting listener; warnings are logged, not thrown.
+        String result = PropertiesPreprocessor.preprocessSource(
+            "profile.TEST = SHADOW_QUALITY=00002178\nnextKey = nextValue\n",
+            List.of()
+        );
+
+        // The line survives preprocessing (the token stream is not interrupted by the warning).
+        assertEquals(true, result.contains("SHADOW_QUALITY=00002178"));
+        assertEquals(true, result.contains("nextKey = nextValue"));
+    }
+}


### PR DESCRIPTION
## Problem

Fixes #31 (shader toggling crashes with Complementary Unbound r5.8.1).

jcpp throws a `LexerException` for lexer *warnings* (e.g. `Decimal constant starts with 0, but not octal`) whenever no listener is installed on the preprocessor. `PropertiesPreprocessor` installs its real listener only inside `process()`, so macro values added *before* that point — boolean option macros, environment defines, string option macros — could throw, and the outer catch turned it into `Unexpected LexerException processing macros`, failing the whole shaderpack load.

Complementary Unbound r5.8.1 defines a macro whose value is `00002178`, which triggers exactly this warning:

```
Caused by: org.anarres.cpp.LexerException: Warning at 1:7: Decimal constant starts with 0, but not octal: 00002178
```

## Fix

Install a `PropertiesCommentListener` on the preprocessor **before** `addMacro` in both `preprocessSource` overloads. With a listener present, jcpp routes warnings to it (logged, not thrown) and macro definition proceeds, so the pack loads and shaders can be toggled. No behavioral change for packs that never hit the warning.

## Verification

- New `PropertiesPreprocessorTest`: zero-prefixed decimal values in environment defines and in source content both preprocess without throwing.
- Full suite: **393 tests, 0 failures** (baseline 391 + 2 new).

Closes #31
