### PR TITLE
fix(ci): fetch full history so builds derive version from git tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        # Full history + tags: the build derives the version prefix from the nearest git tag
+        # (git describe), which fails on the default shallow checkout and silently falls back
+        # to gradle.properties mod_version.
+        fetch-depth: 0
     - name: Set up JDK
       uses: actions/setup-java@v5
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history + tags: the build derives the version from git tags (git describe),
+          # which fails on the default shallow checkout even when triggered by a tag push.
+          fetch-depth: 0
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ show_testing_output = false
 enable_lwjglx = true
 
 # Mod Information
-mod_version = alpha-0.0.2
+mod_version = alpha-0.0.3
 root_package = org.taumc
 mod_id = actinium
 mod_name = Actinium


### PR DESCRIPTION
## 问题 / Problem

main 上最新的 CI 构建产出的版本号是 **alpha-0.0.2**，而最新 tag 是 **alpha-0.0.3**。

版本推导（build.gradle）优先使用 `git describe --tags` 取最近 tag 作为前缀，但 `build.yml` / `release.yml` 的 `actions/checkout@v6` 用的是默认浅克隆（`fetch-depth: 1`，不含任何 tag）。CI 里 `git describe` 直接失败（`fatal: No names found, cannot describe anything`），版本回退到 `gradle.properties` 的 `mod_version`，而它停留在 `alpha-0.0.2`。

已复现确认：浅克隆环境下 `git describe` 退出码 128，最终版本为 `alpha-0.0.2-<sha>`。

## 修复 / Fix

1. **`build.yml` / `release.yml`**：checkout 增加 `fetch-depth: 0`（拉取全历史与 tag），使 `git describe` 在 CI 中可用。
2. **`gradle.properties`**：`mod_version` 从 `alpha-0.0.2` 同步到 `alpha-0.0.3`，保证兜底路径在任何无 tag 环境下也不会倒退版本号。

## 验证 / Verification

- 本地完整克隆：`./gradlew -q properties` → `version: alpha-0.0.3-7ae5e3b`（修复后 CI 的预期输出）。
- 浅克隆模拟（修复前 CI 行为）：`git describe` 失败 → 回退 `alpha-0.0.2-<sha>`，与用户报告一致。
- `release-to-cf-mr.yml` 已配置 `fetch-depth: 0`，无需改动。
