### PR TITLE
fix(shader): keep translucent terrain from writing depth

### DIFF
--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -1,6 +1,6 @@
 # Actinium 兼容性矩阵
 
-最后更新：2026-08-16。
+最后更新：2026-08-18。
 
 状态定义：`已验证` 表示在记录的版本和场景中通过；`部分` 表示能运行但存在已知缺口；
 `无法启用` 表示光影包不能成功开启；`未验证` 不代表不兼容。更新记录时必须填写 Actinium commit、
@@ -11,6 +11,12 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 
 > 2026-08-16 追加：VoxelMap 1.9.25（分支 `fix/voxelmap-minimap-black`）小地图黑屏修复验证——见下方
 > [模组与环境](#模组与环境) 的 VoxelMap 行与 [docs/compat/voxelmap.md](compat/voxelmap.md)。
+
+> 2026-08-18 追加：EnderIO CEu 5.4.2 流体罐在光影开启时罐内液体不渲染的修复（#58）——见下方
+> [模组与环境](#模组与环境) 的 EnderIO 行。根因是 Iris celeritas 地形接口对所有 terrain pass
+> 无条件强制 `glDepthMask(true)`，translucent 层里的罐体玻璃窗因此写出深度，遮挡了其后绘制的
+> TESR 液体；修复后 translucent terrain pass 在主 pass 不再写深度（与 vanilla 语义一致），
+> 阴影图 pass 与不透明 pass 保持写深度。
 
 ## 光影包
 
@@ -41,6 +47,7 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 | Chunk Animator   | 部分 | 条件桥（ChunkAnimationProvider）+ 动画 section 单独绘制 | 1.12.2-1.2.1（236484:3850023）dev 运行通过（coremod 加载、兼容层启用、进世界无异常）；动画视觉确认待补，详见 [docs/compat/chunkanimator.md](compat/chunkanimator.md) |
 | VoxelMap         | 部分 | 条件 Mixin（CPU 纹理路径 + 线性过滤 + scissor 重路由 + HudCaching alpha 保护） | 1.9.25 小地图黑屏/黑块已修复（dev 验证圆内正常显示地图内容、HUD 不被缓存隐藏，见 [docs/compat/voxelmap.md](compat/voxelmap.md)）；已知缺口：与 StellarCore `HudCaching` 组合时小地图圆周仍可能残留黑块（VoxelMap 全屏清 alpha + DST_ALPHA 混合与 HUD 缓存 FBO 的第三方冲突，`HudCaching=false` 即消失，非本模组缺陷）；验证 VoxelMap 需停用 JourneyMap（二者频道冲突） |
 | ModernUI         | 代码支持 | GUI scale hook                     | 尚缺当前运行时验证记录      |
+| EnderIO CEu / EnderCore CEu | 已验证 | 无（核心渲染语义修复，非模组接入） | 5.4.2 + EnderCore 0.5.81：光影开启时流体罐内液体被罐体玻璃窗深度遮挡的问题已修复（`cb4feaa5`，translucent terrain pass 不再写深度）；MakeUp Ultra Fast 9.4c + Cleanroom 0.5.17-alpha 实测通过 |
 | Modern Splash    | 部分 | 无侵入（替换类与 mixin 注入天然兼容）+ splash 字体 color=0 修复 | 1.5.3（629058:8487408）dev 运行通过（coremod 加载、mixin 注入保留、字体颜色按配置生效）；光影场景回归待做，详见 [docs/compat/modern-splash.md](compat/modern-splash.md) |
 | Reese's Sodium Options（内嵌） | 代码支持 | 内嵌移植 UI（`me.flashyreese.mods.reeses_sodium_options`，MIT）+ embeddium 选项数据层（`org.embeddedt.embeddium.api.options.*` 自研扩展） | RSO 界面作为视频设置入口（`MixinGuiOptions` 拦截按钮 101，`enabled=false` 回退原版 `GuiVideoSettings`）；`net.caffeinemc` 设置界面与配置模型已整体删除；编译与 349 项单元测试通过，**运行期视觉对比待人工验证**，详见 [docs/rso-port.md](rso-port.md) |
 

--- a/shader/src/main/java/net/coderbot/iris/celeritas/IrisCeleritasChunkShaderInterface.java
+++ b/shader/src/main/java/net/coderbot/iris/celeritas/IrisCeleritasChunkShaderInterface.java
@@ -114,7 +114,10 @@ public class IrisCeleritasChunkShaderInterface implements ChunkShaderInterface {
         // Hand and fullscreen passes can leave depth disabled or mask writes off before terrain draws.
         GLStateManager.enableDepthTest();
         GLStateManager.glDepthFunc(GL11.GL_LEQUAL);
-        GLStateManager.glDepthMask(true);
+        // Opaque terrain passes and the shadow-map pass write depth; the main translucent pass does not.
+        // Forcing depth writes on the translucent pass makes glass windows (EnderIO fluid tanks, issue #58)
+        // occlude TESR geometry drawn behind them, unlike vanilla which leaves the depth mask off for that layer.
+        GLStateManager.glDepthMask(ShadowRenderingState.areShadowsCurrentlyBeingRendered() || !pass.isReverseOrder());
 
         if (ShadowRenderingState.areShadowsCurrentlyBeingRendered()) {
             GLStateManager.disableCull();


### PR DESCRIPTION
## What

`IrisCeleritasChunkShaderInterface.setupState` no longer forces `glDepthMask(true)` on the main translucent terrain pass. Depth is now written only for opaque terrain passes and the shadow-map pass; the main translucent pass leaves the depth mask off, matching vanilla/Iris semantics.

## Why

Closes #58: with shaders enabled, the fluid inside EnderIO fluid tanks did not render. The tank glass window is baked into the translucent terrain layer (EnderIO uses a layer-aware smart model), and the terrain interface previously forced depth writes on every pass. The glass therefore wrote depth in front of the TESR-drawn fluid and fully occluded it. Without shaders the translucent layer keeps the depth mask off, which is why the fluid rendered there.

## How verified

- Build: `.\gradlew.bat build --no-daemon` (includes `check`: unit tests + remap jar structure) - passed.
- Dev regression: EnderIO CEu 5.4.2 + EnderCore CEu 0.5.81 with MakeUp Ultra Fast 9.4c on Cleanroom Loader - tank fluid renders with shaders enabled; opaque terrain and shadow-map depth behavior unchanged. Diagnostic logging used during the investigation was removed; the final change is a single-line fix.

## Commits

- `fix(shader): keep translucent terrain from writing depth`
- `docs: record EnderIO tank fluid fix in compatibility matrix`