### PR TITLE
fix(compat): render snow-covered blocks with Snow! Real Magic!

### DIFF
--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -1,6 +1,6 @@
 # Actinium 兼容性矩阵
 
-最后更新：2026-08-16。
+最后更新：2026-08-18。
 
 状态定义：`已验证` 表示在记录的版本和场景中通过；`部分` 表示能运行但存在已知缺口；
 `无法启用` 表示光影包不能成功开启；`未验证` 不代表不兼容。更新记录时必须填写 Actinium commit、
@@ -11,6 +11,12 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 
 > 2026-08-16 追加：VoxelMap 1.9.25（分支 `fix/voxelmap-minimap-black`）小地图黑屏修复验证——见下方
 > [模组与环境](#模组与环境) 的 VoxelMap 行与 [docs/compat/voxelmap.md](compat/voxelmap.md)。
+
+> 2026-08-18 追加：Snow! Real Magic! 0.7.4（issue #35）带雪栅栏不渲染的修复——见下方
+> [模组与环境](#模组与环境) 的 Snow! Real Magic! 行。根因是 SRM 把被雪覆盖的方块替换为携带
+> `SnowTile` 的 `snow_layer`，并只在 `BlockRendererDispatcher.renderBlock` 内重绘被覆盖方块，
+> 而 Actinium 的快速区块渲染路径直接走 baked model、从不调用该入口；修复让 SRM 的
+> `snow_layer` 块退回 vanilla dispatcher 路径（`6aee395`，dev 运行验证通过）。
 
 ## 光影包
 
@@ -41,6 +47,7 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 | Chunk Animator   | 部分 | 条件桥（ChunkAnimationProvider）+ 动画 section 单独绘制 | 1.12.2-1.2.1（236484:3850023）dev 运行通过（coremod 加载、兼容层启用、进世界无异常）；动画视觉确认待补，详见 [docs/compat/chunkanimator.md](compat/chunkanimator.md) |
 | VoxelMap         | 部分 | 条件 Mixin（CPU 纹理路径 + 线性过滤 + scissor 重路由 + HudCaching alpha 保护） | 1.9.25 小地图黑屏/黑块已修复（dev 验证圆内正常显示地图内容、HUD 不被缓存隐藏，见 [docs/compat/voxelmap.md](compat/voxelmap.md)）；已知缺口：与 StellarCore `HudCaching` 组合时小地图圆周仍可能残留黑块（VoxelMap 全屏清 alpha + DST_ALPHA 混合与 HUD 缓存 FBO 的第三方冲突，`HudCaching=false` 即消失，非本模组缺陷）；验证 VoxelMap 需停用 JourneyMap（二者频道冲突） |
 | ModernUI         | 代码支持 | GUI scale hook                     | 尚缺当前运行时验证记录      |
+| Snow! Real Magic! | 已验证 | 兼容门控（SRM 的 snow_layer 块退回 vanilla dispatcher 路径） | 0.7.4：带雪栅栏不渲染已修复（SRM 把被覆盖方块替换为带 SnowTile 的雪层、仅在 `BlockRendererDispatcher.renderBlock` 内重绘，快速区块路径已绕过）；`6aee395`，dev 运行验证通过（MakeUp Ultra Fast 下无光影 + 光影各验一次） |
 | Modern Splash    | 部分 | 无侵入（替换类与 mixin 注入天然兼容）+ splash 字体 color=0 修复 | 1.5.3（629058:8487408）dev 运行通过（coremod 加载、mixin 注入保留、字体颜色按配置生效）；光影场景回归待做，详见 [docs/compat/modern-splash.md](compat/modern-splash.md) |
 | Reese's Sodium Options（内嵌） | 代码支持 | 内嵌移植 UI（`me.flashyreese.mods.reeses_sodium_options`，MIT）+ embeddium 选项数据层（`org.embeddedt.embeddium.api.options.*` 自研扩展） | RSO 界面作为视频设置入口（`MixinGuiOptions` 拦截按钮 101，`enabled=false` 回退原版 `GuiVideoSettings`）；`net.caffeinemc` 设置界面与配置模型已整体删除；编译与 349 项单元测试通过，**运行期视觉对比待人工验证**，详见 [docs/rso-port.md](rso-port.md) |
 

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -117,4 +117,9 @@ dependencies {
     // Extra Utilities 2 1.9.9 (issue #48: its GLStateAttributes GUI state snapshot reads the stale vanilla
     // GlStateManager mirror under GLSM; the mixin re-reads live GL state)
     modImplementation "curse.maven:extra-utilities-2-225561:2678374"
+
+    // Snow! Real Magic! 0.7.4 (issue #35: SRM replaces snow-covered blocks with a snow layer carrying a
+    // SnowTile and only re-emits the covered block inside BlockRendererDispatcher.renderBlock; the fast
+    // chunk path must fall back to the vanilla dispatcher for its snow_layer block)
+    modRuntimeOnly 'curse.maven:snow-real-magic-308663:6275195'
 }

--- a/src/main/java/com/dhj/actinium/compat/snowrealmagic/SnowRealMagicCompat.java
+++ b/src/main/java/com/dhj/actinium/compat/snowrealmagic/SnowRealMagicCompat.java
@@ -1,0 +1,45 @@
+package com.dhj.actinium.compat.snowrealmagic;
+
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.Loader;
+
+/**
+ * Compatibility for {@code Snow! Real Magic!} (mod id {@code snowrealmagic}).
+ *
+ * <p>SRM replaces a block that can be covered in snow (e.g. a fence) with a snow layer that
+ * carries a {@code SnowTile}; the covered block's model is only re-emitted inside
+ * {@code BlockRendererDispatcher.renderBlock} (SRM redirects this entry point and re-renders the
+ * contained block at {@code RETURN}). Actinium's fast chunk path meshes model blocks straight from
+ * their baked model and never calls that entry point, so the covered block disappears from the
+ * chunk. Blocks that SRM owns must therefore fall back to the vanilla dispatcher path.
+ */
+public final class SnowRealMagicCompat {
+    /**
+     * The mod ID of Snow! Real Magic!.
+     */
+    public static final String MODID = "snowrealmagic";
+    public static final boolean IS_LOADED = Loader.isModLoaded(MODID);
+
+    private SnowRealMagicCompat() {
+    }
+
+    /**
+     * Returns whether {@code block} is the snow layer as replaced by SRM and therefore must be
+     * rendered through the vanilla {@code BlockRendererDispatcher} instead of the fast chunk path.
+     *
+     * <p>Identified by the {@code minecraft:snow_layer} registry name (SRM registers its
+     * {@code ModSnowBlock} under that name), which covers both the vanilla {@link Blocks#SNOW}
+     * instance and SRM's replacement without referencing any SRM class.
+     */
+    public static boolean shouldForceVanillaRender(Block block) {
+        if (!IS_LOADED) {
+            return false;
+        }
+        ResourceLocation name = block.getRegistryName();
+        return name != null
+            && "minecraft".equals(name.getNamespace())
+            && "snow_layer".equals(name.getPath());
+    }
+}

--- a/src/main/java/com/dhj/actinium/render/terrain/compile/task/ChunkBuilderMeshingTask.java
+++ b/src/main/java/com/dhj/actinium/render/terrain/compile/task/ChunkBuilderMeshingTask.java
@@ -34,6 +34,7 @@ import org.embeddedt.embeddium.api.shader.BlockRenderLayer;
 import org.embeddedt.embeddium.api.shader.ShaderProvider;
 import org.embeddedt.embeddium.api.shader.ShaderProviderHolder;
 import com.dhj.actinium.compat.fluidlogged.FluidloggedCompat;
+import com.dhj.actinium.compat.snowrealmagic.SnowRealMagicCompat;
 import com.dhj.actinium.runtime.ActiniumRuntime;
 import com.dhj.actinium.world.WorldSlice;
 import com.dhj.actinium.world.cloned.ActiniumBlockAccess;
@@ -123,7 +124,7 @@ public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> 
                             net.minecraft.util.BlockRenderLayer layer = shaderLayerOverride.toVanillaLayer();
                             ForgeHooksClient.setRenderLayer(layer);
                             block.canRenderInLayer(blockState, layer);
-                            if (blockState.getRenderType() == EnumBlockRenderType.MODEL && ActiniumRuntime.options().performance.useFastBlockRenderer) {
+                            if (blockState.getRenderType() == EnumBlockRenderType.MODEL && ActiniumRuntime.options().performance.useFastBlockRenderer && !SnowRealMagicCompat.shouldForceVanillaRender(block)) {
                                 buildContext.getBlockRenderer().renderBlock(blockState, blockPos, slice, layer, false);
                             } else {
                                 var buffer = buildContext.getBufferForLayer(layer);
@@ -138,7 +139,7 @@ public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> 
                             for (net.minecraft.util.BlockRenderLayer layer : VintageChunkBuildContext.LAYERS) {
                                 if (block.canRenderInLayer(blockState, layer)) {
                                     ForgeHooksClient.setRenderLayer(layer);
-                                    if (blockState.getRenderType() == EnumBlockRenderType.MODEL && ActiniumRuntime.options().performance.useFastBlockRenderer) {
+                                    if (blockState.getRenderType() == EnumBlockRenderType.MODEL && ActiniumRuntime.options().performance.useFastBlockRenderer && !SnowRealMagicCompat.shouldForceVanillaRender(block)) {
                                         buildContext.getBlockRenderer().renderBlock(blockState, blockPos, slice, layer);
                                     } else {
                                         var buffer = buildContext.getBufferForLayer(layer);


### PR DESCRIPTION
## What

Snow! Real Magic! replaces a block covered in snow (fences, walls, panes) with a `snow_layer` carrying a `SnowTile`, and only re-emits the covered block's model inside `BlockRendererDispatcher.renderBlock` (at `RETURN`). Actinium's fast chunk path meshes model blocks straight from their baked model and never calls that entry point, so the covered block vanished from the chunk when SRM was installed.

This PR gates the fast path for SRM's `snow_layer` block (`minecraft:snow_layer`, detected by registry name without referencing an SRM class) so it falls back to the vanilla dispatcher path where SRM's rendering hook applies.

## Why

Closes #35: with Snow! Real Magic! installed, snow-covered fences were not rendered (fast chunk renderer bypassed SRM's hook). The same applies to other `canContainState` blocks (walls, glass panes).

## How verified

- Build: `.\gradlew.bat build --no-daemon` (includes `check`: unit tests + remap jar structure) - passed.
- Dev regression: `.\gradlew.bat runClient --no-daemon` with SRM 0.7.4 (added to dev runtime as `curse.maven:snow-real-magic-308663:6275195`). Confirmed SRM's own MixinTweaker and mixins load, the `minecraft:snow_layer` replacement registers, and snow-covered fences render; no SRM-related crash. Tested both without shaders and with MakeUp Ultra Fast.

## Commits

- `fix(compat): render snow-covered blocks with Snow! Real Magic!`
- `docs: record Snow! Real Magic! snow layer fix in compatibility matrix`