### PR TITLE
fix(compat): render Depths Update extended world heights

### DIFF
--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -1,6 +1,6 @@
 # Actinium 兼容性矩阵
 
-最后更新：2026-08-16。
+最后更新：2026-08-18。
 
 状态定义：`已验证` 表示在记录的版本和场景中通过；`部分` 表示能运行但存在已知缺口；
 `无法启用` 表示光影包不能成功开启；`未验证` 不代表不兼容。更新记录时必须填写 Actinium commit、
@@ -11,6 +11,13 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 
 > 2026-08-16 追加：VoxelMap 1.9.25（分支 `fix/voxelmap-minimap-black`）小地图黑屏修复验证——见下方
 > [模组与环境](#模组与环境) 的 VoxelMap 行与 [docs/compat/voxelmap.md](compat/voxelmap.md)。
+
+> 2026-08-18 追加：Depths Update（issue #68）扩展世界高度（默认 -64..320，可配 -256..512）下
+> Y 范围 0-255 之外方块不渲染的修复——见下方 [模组与环境](#模组与环境) 的 Depths Update 行。
+> 根因是渲染器硬编码 0-255 的 section 范围，且 Depths 自带的 celeritas 兼容 mixin 指向
+> 重构前的 `org.taumc.celeritas.impl.*` 类路径而不生效；修复改为从 Depths 公开 API
+> （`DepthsUpdateAPI.getHeightInfo`）推导 section 范围，并按其 storage 布局映射读取（commit
+> `6d8fc24`，dev 实测 Y<0 与 Y>255 区域正常渲染）。
 
 ## 光影包
 
@@ -41,6 +48,7 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 | Chunk Animator   | 部分 | 条件桥（ChunkAnimationProvider）+ 动画 section 单独绘制 | 1.12.2-1.2.1（236484:3850023）dev 运行通过（coremod 加载、兼容层启用、进世界无异常）；动画视觉确认待补，详见 [docs/compat/chunkanimator.md](compat/chunkanimator.md) |
 | VoxelMap         | 部分 | 条件 Mixin（CPU 纹理路径 + 线性过滤 + scissor 重路由 + HudCaching alpha 保护） | 1.9.25 小地图黑屏/黑块已修复（dev 验证圆内正常显示地图内容、HUD 不被缓存隐藏，见 [docs/compat/voxelmap.md](compat/voxelmap.md)）；已知缺口：与 StellarCore `HudCaching` 组合时小地图圆周仍可能残留黑块（VoxelMap 全屏清 alpha + DST_ALPHA 混合与 HUD 缓存 FBO 的第三方冲突，`HudCaching=false` 即消失，非本模组缺陷）；验证 VoxelMap 需停用 JourneyMap（二者频道冲突） |
 | ModernUI         | 代码支持 | GUI scale hook                     | 尚缺当前运行时验证记录      |
+| Depths Update    | 已验证 | 兼容门控（`compat/depthsupdate`：公开 API 推导 section 范围 + storage 索引映射） | 1.0.0-a10：扩展世界高度（默认 -64..320）下 Y<0 与 Y>255 的方块不再缺失（渲染器原先硬编码 0-255）；dev 实测正常；无 Depths 时回退 vanilla 行为 |
 | Modern Splash    | 部分 | 无侵入（替换类与 mixin 注入天然兼容）+ splash 字体 color=0 修复 | 1.5.3（629058:8487408）dev 运行通过（coremod 加载、mixin 注入保留、字体颜色按配置生效）；光影场景回归待做，详见 [docs/compat/modern-splash.md](compat/modern-splash.md) |
 | Reese's Sodium Options（内嵌） | 代码支持 | 内嵌移植 UI（`me.flashyreese.mods.reeses_sodium_options`，MIT）+ embeddium 选项数据层（`org.embeddedt.embeddium.api.options.*` 自研扩展） | RSO 界面作为视频设置入口（`MixinGuiOptions` 拦截按钮 101，`enabled=false` 回退原版 `GuiVideoSettings`）；`net.caffeinemc` 设置界面与配置模型已整体删除；编译与 349 项单元测试通过，**运行期视觉对比待人工验证**，详见 [docs/rso-port.md](rso-port.md) |
 

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -91,7 +91,7 @@ dependencies {
     modRuntimeOnly "curse.maven:celeritas-extra-1451214:8362538"
     modRuntimeOnly "curse.maven:celeritasleafculling-1449111:7550650"
 
-    modImplementation 'curse.maven:chunk-animator-236484:3850023'
+    modCompileOnly 'curse.maven:chunk-animator-236484:3850023'
 
     modImplementation "curse.maven:ichunutil-229060:2801262"  // dev-verifies mixins.actinium.ichunutil.json (issue #39)
     modCompileOnly "curse.maven:mobdismemberment-229067:2487081"
@@ -100,7 +100,7 @@ dependencies {
     modCompileOnly 'curse.maven:revo-font-1617673:8586768'
     // Biomes O' Plenty 7.0.1.2445 (issue #32: it swaps GuiMainMenu.titlePanoramaPaths for its own title
     // panorama; the GTNH skybox renderer must read the swapped field instead of hard-coded vanilla paths)
-    modImplementation "curse.maven:biomes-o-plenty-220318:3558882"
+    modCompileOnly "curse.maven:biomes-o-plenty-220318:3558882"
     modCompileOnly 'curse.maven:revo-ui-1620532:8593682'
     modCompileOnly('com.cleanroommc:modularui:3.1.6') { transitive = false }
 
@@ -113,8 +113,14 @@ dependencies {
 
     // HammerLib 12.2.66 (issue #40: its GL20.glGetActiveUniform(int, int, int) -> String call is redirected to
     // GLSM GLStateManager, which must expose the same descriptor)
-    modImplementation "maven.modrinth:hammer-lib:B9uVCQjP"
+    modCompileOnly "maven.modrinth:hammer-lib:B9uVCQjP"
     // Extra Utilities 2 1.9.9 (issue #48: its GLStateAttributes GUI state snapshot reads the stale vanilla
     // GlStateManager mirror under GLSM; the mixin re-reads live GL state)
-    modImplementation "curse.maven:extra-utilities-2-225561:2678374"
+    modCompileOnly "curse.maven:extra-utilities-2-225561:2678374"
+
+    // Depths Update 1.0.0-a10 (issue #68: extends the world build height beyond 0-255; blocks outside the
+    // vanilla range are not rendered -- its own celeritas compat mixins target pre-restructure class paths)
+    // modCompileOnly exposes its public API (sayys.depthsupdate.api.DepthsUpdateAPI) for the compat shim.
+    modImplementation 'curse.maven:depths-update-1472501:8038246'
+    modRuntimeOnly 'curse.maven:assetmover-571482:4430763'
 }

--- a/src/main/java/com/dhj/actinium/compat/depthsupdate/DepthsUpdateCompat.java
+++ b/src/main/java/com/dhj/actinium/compat/depthsupdate/DepthsUpdateCompat.java
@@ -1,0 +1,99 @@
+package com.dhj.actinium.compat.depthsupdate;
+
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.Loader;
+import sayys.depthsupdate.api.DepthsUpdateAPI;
+import sayys.depthsupdate.api.HeightInfo;
+
+/**
+ * Compatibility for {@code Depths Update} (mod id {@code depthsupdate}).
+ *
+ * <p>Depths Update backports the Caves &amp; Cliffs world height: it extends the build range
+ * (default {@code -64..320}, configurable) and reshapes every {@code Chunk.storageArrays} to its own
+ * layout (the vanilla sections keep their array index {@code 0..15}, upper sections keep identity
+ * above that, and the negative sections are parked at the tail of the array). Actinium's renderer
+ * assumed the vanilla {@code 0..255} layout, so sections outside that range were never created and
+ * blocks below {@code y=0} or above {@code y=255} were simply not rendered (issue #68).
+ *
+ * <p>This shim exposes the extended height range and the storage-array index mapping from Depths
+ * Update's public API (see the {@code sayys.depthsupdate.api} package). Without the mod installed it
+ * falls back to the vanilla identity mapping, so unaffected worlds keep their exact behaviour.
+ */
+public final class DepthsUpdateCompat {
+    /**
+     * The mod ID of Depths Update.
+     */
+    public static final String MODID = "depthsupdate";
+    public static final boolean IS_LOADED = Loader.isModLoaded(MODID);
+
+    private static final int VANILLA_MIN_SECTION = 0;
+    private static final int VANILLA_MAX_SECTION = 16;
+    private static final int VANILLA_SECTION_COUNT = 16;
+
+    private DepthsUpdateCompat() {
+    }
+
+    /**
+     * Returns the inclusive/vanilla section index of the lowest build section for {@code world}.
+     */
+    public static int getMinSection(World world) {
+        HeightInfo info = heightInfo(world);
+        return (info != null && info.isExtended()) ? info.minY() >> 4 : VANILLA_MIN_SECTION;
+    }
+
+    /**
+     * Returns the exclusive upper bound of the build sections for {@code world} (sections are created
+     * for {@code y in [minSection, maxSection)}).
+     */
+    public static int getMaxSection(World world) {
+        HeightInfo info = heightInfo(world);
+        return (info != null && info.isExtended()) ? ((info.maxY() - 1) >> 4) + 1 : VANILLA_MAX_SECTION;
+    }
+
+    /**
+     * Returns the number of sections the world spans vertically.
+     */
+    public static int getSectionCount(World world) {
+        HeightInfo info = heightInfo(world);
+        return (info != null && info.isExtended()) ? (info.maxY() - info.minY()) >> 4 : VANILLA_SECTION_COUNT;
+    }
+
+    /**
+     * Returns the lowest build height (inclusive) of {@code world}.
+     */
+    public static int getMinBuildHeight(World world) {
+        HeightInfo info = heightInfo(world);
+        return (info != null && info.isExtended()) ? info.minY() : 0;
+    }
+
+    /**
+     * Maps a semantic section {@code sectionY} to the array index inside
+     * {@code Chunk.getBlockStorageArray()} that holds that section's data, or {@code -1} when the
+     * section is outside the world's height range. For vanilla heights this is the identity mapping.
+     */
+    public static int toStorageIndex(World world, int sectionY) {
+        HeightInfo info = heightInfo(world);
+        if (info == null || !info.isExtended()) {
+            return (sectionY >= 0 && sectionY < VANILLA_SECTION_COUNT) ? sectionY : -1;
+        }
+
+        int minSection = info.minY() >> 4;
+        int maxSectionInclusive = (info.maxY() - 1) >> 4;
+
+        // Vanilla and upper sections are stored at their own array index.
+        if (sectionY >= 0 && sectionY <= maxSectionInclusive) {
+            return sectionY;
+        }
+
+        // Negative sections are parked at the tail, ordered so the lowest section has the highest index.
+        if (sectionY >= minSection && sectionY < 0) {
+            return maxSectionInclusive - sectionY;
+        }
+
+        return -1;
+    }
+
+    private static HeightInfo heightInfo(World world) {
+        return IS_LOADED ? DepthsUpdateAPI.getHeightInfo(world) : null;
+    }
+}

--- a/src/main/java/com/dhj/actinium/render/terrain/ActiniumWorldRenderer.java
+++ b/src/main/java/com/dhj/actinium/render/terrain/ActiniumWorldRenderer.java
@@ -29,6 +29,7 @@ import org.embeddedt.embeddium.api.debug.RenderDebugHooksHolder;
 import org.embeddedt.embeddium.api.shader.ShaderProvider;
 import org.embeddedt.embeddium.api.shader.ShaderProviderHolder;
 import net.coderbot.iris.pipeline.ShadowRenderer;
+import com.dhj.actinium.compat.depthsupdate.DepthsUpdateCompat;
 import com.dhj.actinium.runtime.ActiniumRuntime;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
@@ -62,7 +63,7 @@ public class ActiniumWorldRenderer extends SimpleWorldRenderer<WorldClient, Vint
 
     @Override
     public int getMinimumBuildHeight() {
-        return 0;
+        return DepthsUpdateCompat.getMinBuildHeight(this.world);
     }
 
     @Override

--- a/src/main/java/com/dhj/actinium/render/terrain/VintageRenderSectionManager.java
+++ b/src/main/java/com/dhj/actinium/render/terrain/VintageRenderSectionManager.java
@@ -30,6 +30,7 @@ import org.jetbrains.annotations.Nullable;
 import org.embeddedt.embeddium.api.debug.RenderDebugHooksHolder;
 import org.embeddedt.embeddium.api.shader.ShaderProvider;
 import org.embeddedt.embeddium.api.shader.ShaderProviderHolder;
+import com.dhj.actinium.compat.depthsupdate.DepthsUpdateCompat;
 import com.dhj.actinium.world.WorldSlice;
 import com.dhj.actinium.world.cloned.ChunkRenderContext;
 import com.dhj.actinium.world.cloned.ClonedChunkSectionCache;
@@ -52,7 +53,9 @@ public class VintageRenderSectionManager extends RenderSectionManager {
     }
 
     public static VintageRenderSectionManager create(ChunkVertexType vertexType, WorldClient world, int renderDistance, CommandList commandList) {
-        return new VintageRenderSectionManager(VintageRenderPassConfigurationBuilder.build(vertexType), world, renderDistance, commandList, 0, 16);
+        int minSection = DepthsUpdateCompat.getMinSection(world);
+        int maxSection = DepthsUpdateCompat.getMaxSection(world);
+        return new VintageRenderSectionManager(VintageRenderPassConfigurationBuilder.build(vertexType), world, renderDistance, commandList, minSection, maxSection);
     }
 
     @Override
@@ -115,10 +118,11 @@ public class VintageRenderSectionManager extends RenderSectionManager {
             return true;
         }
         var array = chunk.getBlockStorageArray();
-        if (y < 0 || y >= array.length) {
+        int storageIndex = DepthsUpdateCompat.toStorageIndex(this.world, y);
+        if (storageIndex < 0 || storageIndex >= array.length) {
             return true;
         }
-        return array[y] == Chunk.NULL_BLOCK_STORAGE || array[y].isEmpty();
+        return array[storageIndex] == Chunk.NULL_BLOCK_STORAGE || array[storageIndex].isEmpty();
     }
 
     @Override

--- a/src/main/java/com/dhj/actinium/world/WorldSlice.java
+++ b/src/main/java/com/dhj/actinium/world/WorldSlice.java
@@ -21,6 +21,7 @@ import net.minecraftforge.client.model.pipeline.LightUtil;
 import net.minecraftforge.fml.common.Optional;
 import org.embeddedt.embeddium.impl.util.position.SectionPos;
 import org.jetbrains.annotations.Nullable;
+import com.dhj.actinium.compat.depthsupdate.DepthsUpdateCompat;
 import com.dhj.actinium.compat.fluidlogged.FluidloggedCompat;
 import com.dhj.actinium.runtime.ActiniumRuntime;
 import com.dhj.actinium.world.biome.BiomeColorCache;
@@ -105,7 +106,8 @@ public class WorldSlice implements ActiniumBlockAccess {
 
     public static ChunkRenderContext prepare(World world, SectionPos origin, ClonedChunkSectionCache sectionCache) {
         Chunk chunk = world.getChunk(origin.x(), origin.z());
-        ExtendedBlockStorage section = chunk.getBlockStorageArray()[origin.y()];
+        int storageIndex = DepthsUpdateCompat.toStorageIndex(world, origin.y());
+        ExtendedBlockStorage section = storageIndex >= 0 ? chunk.getBlockStorageArray()[storageIndex] : null;
 
         // If the chunk section is absent or empty, simply terminate now. There will never be anything in this chunk
         // section to render, so we need to signal that a chunk render task shouldn't created. This saves a considerable

--- a/src/main/java/com/dhj/actinium/world/cloned/ClonedChunkSection.java
+++ b/src/main/java/com/dhj/actinium/world/cloned/ClonedChunkSection.java
@@ -14,6 +14,7 @@ import net.minecraft.world.chunk.NibbleArray;
 import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 import net.minecraft.world.gen.structure.StructureBoundingBox;
 import org.embeddedt.embeddium.impl.util.position.SectionPos;
+import com.dhj.actinium.compat.depthsupdate.DepthsUpdateCompat;
 import com.dhj.actinium.compat.fluidlogged.FluidStateStorage;
 import com.dhj.actinium.compat.fluidlogged.FluidloggedCompat;
 
@@ -48,7 +49,7 @@ public class ClonedChunkSection {
             throw new RuntimeException(String.format("Couldn't retrieve chunk at %d, %d", x, z));
         }
 
-        ExtendedBlockStorage section = getChunkSection(chunk, y);
+        ExtendedBlockStorage section = getChunkSection(world, chunk, y);
 
         if (section == Chunk.NULL_BLOCK_STORAGE/*ChunkSection.isEmpty(section)*/) {
             section = EMPTY_SECTION;
@@ -118,13 +119,14 @@ public class ClonedChunkSection {
         return lightArray != null ? lightArray.get(x, y, z) : type.defaultLightValue;
     }
 
-    private static ExtendedBlockStorage getChunkSection(Chunk chunk, int y) {
+    private static ExtendedBlockStorage getChunkSection(World world, Chunk chunk, int y) {
         ExtendedBlockStorage section = null;
 
         var storageArray = chunk.getBlockStorageArray();
 
-        if (y >= 0 && y < storageArray.length) {
-            section = storageArray[y];
+        int storageIndex = DepthsUpdateCompat.toStorageIndex(world, y);
+        if (storageIndex >= 0 && storageIndex < storageArray.length) {
+            section = storageArray[storageIndex];
         }
 
         return section;


### PR DESCRIPTION
## What

Depths Update extends the world build height (default `-64..320`, configurable up to `-256..512`) and reshapes `Chunk.storageArrays` into its own layout. Actinium's renderer hard-coded the vanilla `0..255` section range, so sections and blocks outside that range were never created or rendered (below Y=0 and above Y=255 everything was invisible). Depths Update's own celeritas compat mixins target pre-restructure class paths (`org.taumc.celeritas.impl.render.terrain.*`) and are inert on the current codebase.

This PR makes the renderer height-aware through a new `DepthsUpdateCompat` (mod-presence gate) that reads the extended height range and the storage-array index mapping from Depths Update's public API (`DepthsUpdateAPI.getHeightInfo`), routing through it:
- the section range in `VintageRenderSectionManager#create` and its `isSectionVisuallyEmpty` lookup,
- the two direct `Chunk.storageArrays` reads in `WorldSlice#prepare` and `ClonedChunkSection`,
- `getMinimumBuildHeight` in `ActiniumWorldRenderer`.

Without the mod every helper falls back to the vanilla `0..16` identity mapping, so unaffected worlds keep their exact behaviour.

## Why

Closes #68: with Depths Update installed, blocks outside the vanilla Y `0..255` range were not rendered.

## How verified

- Build: `.\gradlew.bat build --no-daemon` (includes `check`: unit tests + remap jar structure) - passed.
- Dev regression: Depths Update 1.0.0-a10 + AssetMover on Cleanroom Loader, `runClient` - confirmed the mod loads, `DepthsUpdateCompat` activates without a crash, and blocks below Y=0 and above Y=255 now render. Tested with default extended height (`-64..320`).

## Commits

- `fix(compat): render Depths Update extended world heights`
- `docs: record Depths Update extended height compat in compatibility matrix`