### PR TITLE
fix(rso): handle Integer values in cycling option controls

### DIFF
--- a/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/frame/option/CyclingOptionRow.java
+++ b/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/frame/option/CyclingOptionRow.java
@@ -16,12 +16,12 @@ import net.minecraft.client.gui.GuiScreen;
 
 import java.util.List;
 
-final class EnumOptionRow<E extends Enum<E>> extends AbstractOptionRow {
+final class CyclingOptionRow extends AbstractOptionRow {
     private static final int MAX_CONTENT_WIDTH = 70;
 
     private final RsoOption option;
 
-    EnumOptionRow(LayoutBounds dim, GuiTheme theme, OptionStateStore optionStateStore, RsoOption option) {
+    CyclingOptionRow(LayoutBounds dim, GuiTheme theme, OptionStateStore optionStateStore, RsoOption option) {
         super(dim, theme, optionStateStore, option);
         this.option = option;
     }
@@ -132,7 +132,7 @@ final class EnumOptionRow<E extends Enum<E>> extends AbstractOptionRow {
     }
 
     private void cycleControl(boolean reverse) {
-        E nextValue = this.nextValue(reverse);
+        Object nextValue = this.nextValue(reverse);
         if (java.util.Objects.equals(nextValue, this.option.getPendingValue())) {
             return;
         }
@@ -141,10 +141,9 @@ final class EnumOptionRow<E extends Enum<E>> extends AbstractOptionRow {
         this.playClickSound();
     }
 
-    @SuppressWarnings("unchecked")
-    private E nextValue(boolean reverse) {
+    private Object nextValue(boolean reverse) {
         Object[] values = this.option.getAllowedValues();
-        E currentValue = (E) this.option.getPendingValue();
+        Object currentValue = this.option.getPendingValue();
         int valueIndex = 0;
 
         for (int i = 0; i < values.length; i++) {
@@ -158,7 +157,7 @@ final class EnumOptionRow<E extends Enum<E>> extends AbstractOptionRow {
             valueIndex = reverse
                     ? (valueIndex + values.length - 1) % values.length
                     : (valueIndex + 1) % values.length;
-            E nextValue = (E) values[valueIndex];
+            Object nextValue = values[valueIndex];
 
             if (this.option.isValueAllowed(nextValue)) {
                 return nextValue;

--- a/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/frame/option/OptionRowFactory.java
+++ b/src/main/java/me/flashyreese/mods/reeses_sodium_options/client/gui/frame/option/OptionRowFactory.java
@@ -64,7 +64,7 @@ final class OptionRowFactory {
             case Option<?> o when o.getControl() instanceof org.embeddedt.embeddium.api.options.control.SliderControl ->
                     new IntegerSliderOptionRow(dim, this.theme, this.optionStateStore, new RsoOption(o));
             case Option<?> o when o.getControl() instanceof org.embeddedt.embeddium.api.options.control.CyclingControl ->
-                    new EnumOptionRow<>(dim, this.theme, this.optionStateStore, new RsoOption(o));
+                    new CyclingOptionRow(dim, this.theme, this.optionStateStore, new RsoOption(o));
             case Option<?> o when o.getControl() instanceof org.embeddedt.embeddium.api.options.control.ExternalButtonControl ->
                     new ExternalButtonOptionRow(this.screen, dim, this.theme, this.optionStateStore, new RsoOption(o));
             default -> this.createUnsupportedRow(option, dim);


### PR DESCRIPTION
## Problem

Reese's Sodium Options GUI crashes with  when users click certain cycling controls (ATTACK_INDICATOR, CLOUDS, PARTICLES, SMOOTH_LIGHT).

**Error:**


## Root Cause

 assumes all  values are  types, but some options use  values (e.g., attack indicator, clouds quality, particles, smooth lighting).

## Fix

1. Rename  to 
2. Remove  type constraint, use  instead
3. Update  and  to handle non-Enum types

## Verification

- Compilation: Starting a Gradle Daemon, 1 incompatible and 3 stopped Daemons could not be reused, use --status for details passes
- No other references to  in codebase
