### PR TITLE
fix(compat): restore CoFH tab GUI blending

### DIFF
--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -111,6 +111,13 @@ dependencies {
     modCompileOnly "curse.maven:forgelin-continuous-456403:8248535"
     modCompileOnly "curse.maven:rlfoliage-970462:7645701"
 
+    modImplementation "curse.maven:cofh-core-69162:2920433"
+    modImplementation "curse.maven:cofh-world-271384:2920434"
+    modImplementation "curse.maven:thermal-expansion-69163:2926431"
+    modImplementation "curse.maven:thermal-foundation-222880:2926428"
+    modImplementation "curse.maven:redstone-flux-270789:2920436"
+    modImplementation "curse.maven:codechicken-lib-cre-1328922:6898525"
+
     // HammerLib 12.2.66 (issue #40: its GL20.glGetActiveUniform(int, int, int) -> String call is redirected to
     // GLSM GLStateManager, which must expose the same descriptor)
     modImplementation "maven.modrinth:hammer-lib:B9uVCQjP"

--- a/src/main/java/com/dhj/actinium/mixin/mod/cofhcore/MixinTabConfigurationTransfer.java
+++ b/src/main/java/com/dhj/actinium/mixin/mod/cofhcore/MixinTabConfigurationTransfer.java
@@ -1,0 +1,22 @@
+package com.dhj.actinium.mixin.mod.cofhcore;
+
+import com.dhj.actinium.render.GuiGlStateBoundary;
+import cofh.core.gui.element.tab.TabConfigurationTransfer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Restores the translucent GUI state after CoFH's configuration tab draws.
+ *
+ * <p>The tab disables blending after drawing its own panel icons, while the
+ * parent continues drawing the remaining tabs in the same foreground pass.</p>
+ */
+@Mixin(value = TabConfigurationTransfer.class, remap = false)
+public abstract class MixinTabConfigurationTransfer {
+    @Inject(method = "drawForeground", at = @At("RETURN"), remap = false)
+    private void actinium$restoreGuiTabState(CallbackInfo ci) {
+        GuiGlStateBoundary.beginTranslucentLayer();
+    }
+}

--- a/src/main/resources/mixins.actinium.cofhcore.json
+++ b/src/main/resources/mixins.actinium.cofhcore.json
@@ -1,0 +1,16 @@
+{
+  "package": "com.dhj.actinium.mixin.mod.cofhcore",
+  "required": true,
+  "refmap": "mixins.actinium-refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8.5",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [],
+  "server": [],
+  "client": [
+    "MixinTabConfigurationTransfer"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/main/resources/mixins.actinium.conditions.properties
+++ b/src/main/resources/mixins.actinium.conditions.properties
@@ -11,3 +11,4 @@ mixins.actinium.betterfoliage.json=betterfoliage
 mixins.actinium.ccl.json=codechickenlib
 mixins.actinium.voxelmap.json=voxelmap
 mixins.actinium.extrautils2.json=extrautils2
+mixins.actinium.cofhcore.json=cofhcore

--- a/src/test/java/com/dhj/actinium/mixin/MixinConfigurationTest.java
+++ b/src/test/java/com/dhj/actinium/mixin/MixinConfigurationTest.java
@@ -51,7 +51,8 @@ class MixinConfigurationTest {
         "mixins.actinium.betterfoliage.json",
         "mixins.actinium.ccl.json",
         "mixins.actinium.voxelmap.json",
-        "mixins.actinium.extrautils2.json"
+        "mixins.actinium.extrautils2.json",
+        "mixins.actinium.cofhcore.json"
     );
     private static final List<String> CONFIGS = Stream.concat(
         Stream.of(BRIDGE_CONFIG),

--- a/src/test/java/com/dhj/actinium/mixins/MixinLateTest.java
+++ b/src/test/java/com/dhj/actinium/mixins/MixinLateTest.java
@@ -27,6 +27,11 @@ class MixinLateTest {
         );
 
         assertEquals(
+            Set.of("mixins.actinium.cofhcore.json"),
+            Set.copyOf(MixinLate.configsFor("cofhcore"::equals))
+        );
+
+        assertEquals(
             Set.of(
                 "mixins.actinium.dh.json",
                 "mixins.actinium.gibbed.json",
@@ -36,7 +41,8 @@ class MixinLateTest {
                 "mixins.actinium.betterfoliage.json",
                 "mixins.actinium.ccl.json",
                 "mixins.actinium.voxelmap.json",
-                "mixins.actinium.extrautils2.json"
+                "mixins.actinium.extrautils2.json",
+                "mixins.actinium.cofhcore.json"
             ),
             Set.copyOf(MixinLate.configsFor(modId -> true))
         );


### PR DESCRIPTION
## What

CoFH Core's TabConfigurationTransfer.drawForeground disables blending after drawing the configuration tab content, while the parent GUI continues drawing the remaining tabs in the same foreground pass. This causes the two left-side machine tab icons to render incorrectly when the configuration tab is open.

This PR adds a CoFH Core conditional Mixin that restores Actinium's translucent GUI state when TabConfigurationTransfer.drawForeground returns. It also adds the required dev dependencies and Mixin configuration tests, and removes the temporary TE GUI diagnostics and ineffective global workaround.

## Why

Closes #59: Thermal Expansion machine GUIs render the left-side tab icons incorrectly after opening the right-side configuration tab.

## How verified

- Build: .\gradlew.bat build --no-daemon (includes check: unit tests, module-boundary checks, and remap Jar validation) - passed.
- Dev regression: Thermal Expansion 5.5.7.1 with CoFH Core 4.6.6.1 in the Cleanroom dev environment. Confirmed that the machine GUI tab icons render correctly while the configuration tab is open.
- Root cause: run/client/logs/debug.log records TabConfigurationTransfer.drawForeground disabling blending before the remaining tab icons are drawn.

## Commits

- fix(compat): restore CoFH tab GUI blending