### PR TITLE
fix(compat): restore Old Research GUI performance

### DIFF
--- a/docs/compat/oldresearch.md
+++ b/docs/compat/oldresearch.md
@@ -56,6 +56,16 @@ while (newCapacity < requiredBytes) {
   `OldResearchTessellatorCompat`，再复用 Actinium streaming drawer；
 - `[DEBUG-OR74]` 临时探针已移除，Old Research Mixin 仅在 `oldresearch` 已加载时启用。
 
+## 性能优化
+
+- 常见的 `POSITION_COLOR` 和 `POSITION_TEXTURE_COLOR` legacy raw layout 直接批量打包到
+  native `IntBuffer`，避免每个属性分别调用通用 writer；`POSITION` 和
+  `POSITION_TEXTURE` 也使用同一条快路径。
+- 单个矩形 quad 在位置/UV 构成平行四边形且颜色、法线、亮度等平坦属性保持不变时，使用
+  `GL_TRIANGLE_FAN` 绘制，绕过共享 quad EBO；不满足条件的 quad 继续使用原有
+  `QuadConverter`，保留原始 provoking-vertex 语义。
+- 相关条件和 packed 输出由 `TessellatorStreamingDrawerTest` 直接调用实现验证。
+
 ## 验证状态
 
 已完成：
@@ -67,11 +77,13 @@ while (newCapacity < requiredBytes) {
 - `.\gradlew.bat build --no-daemon`；
 - Mixin 配置、late loader、remap Jar 和模块边界检查均通过；
 - 构建产物包含 Old Research 兼容类和 `mixins.actinium.oldresearch.json`。
+- 性能优化后的研究笔记 GUI FPS 尚待在同一客户端场景复测；当前已知基线为普通 GUI 约
+  800 FPS、放入研究笔记后约 400 FPS。
 
 待完成：
 
-- 使用修复后的客户端再次打开 Old Research GUI，确认不再卡死；
-- 记录修复后的 GUI FPS，并与复现基线约 850 FPS 对比；
+- 使用性能优化后的客户端再次打开 Old Research GUI，确认不再卡死；
+- 记录优化后的 GUI FPS，并与当前约 400 FPS 的基线对比；
 - 在实际运行环境确认 Old Research GUI 内的研究树、节点图标和 Thaumcraft 相关绘制无视觉回归。
 
 ## 来源

--- a/docs/compat/oldresearch.md
+++ b/docs/compat/oldresearch.md
@@ -77,13 +77,10 @@ while (newCapacity < requiredBytes) {
 - `.\gradlew.bat build --no-daemon`；
 - Mixin 配置、late loader、remap Jar 和模块边界检查均通过；
 - 构建产物包含 Old Research 兼容类和 `mixins.actinium.oldresearch.json`。
-- 性能优化后的研究笔记 GUI FPS 尚待在同一客户端场景复测；当前已知基线为普通 GUI 约
-  800 FPS、放入研究笔记后约 400 FPS。
+- dev 人工回归确认性能优化后的研究笔记 GUI 不再卡死，FPS 回到 500+，与背包界面同量级。
 
 待完成：
 
-- 使用性能优化后的客户端再次打开 Old Research GUI，确认不再卡死；
-- 记录优化后的 GUI FPS，并与当前约 400 FPS 的基线对比；
 - 在实际运行环境确认 Old Research GUI 内的研究树、节点图标和 Thaumcraft 相关绘制无视觉回归。
 
 ## 来源

--- a/docs/compat/oldresearch.md
+++ b/docs/compat/oldresearch.md
@@ -1,0 +1,87 @@
+# TC4 Research Port: Reborn 渲染兼容
+
+最后更新：2026-08-20。相关 issue：[Actinium #74](https://github.com/DHJComical/Actinium/issues/74)。
+验证分支：`research/issue74-tc4-research-port-fps`。
+
+## 模组与源码入口
+
+目标模组为 TC4 Research Port: Reborn，CurseForge 坐标为
+`curse.maven:oldresearchreborn-1632015:8642028`，运行时 mod id 为 `oldresearch`，版本为
+`1.0.1-release`。它依赖 Thaumcraft 和 Baubles，因此开发运行环境同时加入：
+
+- `curse.maven:thaumcraft-223628:2629023`
+- `curse.maven:baubles-227083:2518667`
+
+Old Research 自带的旧版 Tessellator 位于
+`com.wonginnovations.oldresearch.tc4legacy.client.Tessellator`。它保留了自己的
+client-array 绘制路径，不能直接使用 Actinium 注入到 vanilla Tessellator 的路径。
+
+## 问题与证据
+
+Issue #74 的复现结果是：正常 GUI 约 850 FPS，打开包含 Old Research 绘制内容的 GUI 后下降到
+约 16 FPS；随后客户端线程停止响应。
+
+DEBUG 计时器确认调用链已进入兼容层，并在容量准备阶段停止：
+
+```text
+[DEBUG-OR74] enter drawing=true vertices=4 rawInts=32 rawSize=65536 mode=7
+[DEBUG-OR74] ... after-vertex-size value=24
+[DEBUG-OR74] before-capacity requiredBytes=96
+```
+
+`requiredBytes=96` 对应 4 个顶点和 24-byte vertex format，说明问题发生在上传前的 repack buffer
+容量准备，而不是 Old Research 的顶点数据解析。
+
+## 根因
+
+`MixinSplashProgress.finish()` 会调用 `TessellatorStreamingDrawer.destroy()`。原实现释放
+repack buffer 后将 `repackCapacity` 设为 `0`。Old Research GUI 在 splash 结束后第一次绘制时
+调用 `ensureRepackCapacity(96)`，原扩容逻辑从当前容量开始翻倍：
+
+```java
+int newCapacity = repackCapacity;
+while (newCapacity < requiredBytes) {
+    newCapacity *= 2;
+}
+```
+
+当 `newCapacity` 为 `0` 时，循环永远保持为 `0`，Client thread 因此无限循环，表现为 GUI 卡死。
+
+## 修复
+
+- `TessellatorStreamingDrawer` 使用原有的 64 KiB 初始容量作为 destroy 后的懒重建下限；
+- `ensureRepackCapacity` 在 buffer 已被 destroy 后重新分配 buffer，并避免对 null buffer 重复释放；
+- 将容量计算提取为 `nextRepackCapacity`，覆盖 destroy 后从 0 开始和正常的 64 KiB 到 128 KiB 扩容；
+- Old Research 的 `Tessellator.draw()` 由条件 Mixin 转发到
+  `OldResearchTessellatorCompat`，再复用 Actinium streaming drawer；
+- `[DEBUG-OR74]` 临时探针已移除，Old Research Mixin 仅在 `oldresearch` 已加载时启用。
+
+## 验证状态
+
+已完成：
+
+- 定向测试：`TessellatorStreamingDrawerTest` 验证 destroy 后 `0 -> 64 KiB` 不会进入死循环，
+  以及正常容量扩容；
+- `.\gradlew.bat :test --tests com.gtnewhorizons.angelica.glsm.streaming.TessellatorStreamingDrawerTest --no-daemon`；
+- `.\gradlew.bat check --no-daemon`；
+- `.\gradlew.bat build --no-daemon`；
+- Mixin 配置、late loader、remap Jar 和模块边界检查均通过；
+- 构建产物包含 Old Research 兼容类和 `mixins.actinium.oldresearch.json`。
+
+待完成：
+
+- 使用修复后的客户端再次打开 Old Research GUI，确认不再卡死；
+- 记录修复后的 GUI FPS，并与复现基线约 850 FPS 对比；
+- 在实际运行环境确认 Old Research GUI 内的研究树、节点图标和 Thaumcraft 相关绘制无视觉回归。
+
+## 来源
+
+- [Actinium issue #74](https://github.com/DHJComical/Actinium/issues/74)：FPS 下降和客户端无响应的复现描述；
+- [dependencies.gradle](../../gradle/scripts/dependencies.gradle)：Old Research、Thaumcraft 和 Baubles 的
+  CurseForge Maven 坐标；
+- [MixinOldResearchTessellator.java](../../src/main/java/com/dhj/actinium/mixin/mod/oldresearch/MixinOldResearchTessellator.java)：
+  Old Research Tessellator 的目标类、字段映射和 draw 注入；
+- [TessellatorStreamingDrawer.java](../../glsm/src/main/java/com/gtnewhorizons/angelica/glsm/streaming/TessellatorStreamingDrawer.java)：
+  repack capacity 生命周期和修复后的懒重建逻辑；
+- 本地运行证据：`run/client/logs/debug.log` 中的 FML mod 元数据、Mixin 应用记录以及
+  `[DEBUG-OR74]` 计时器输出（当前运行目录属于本地验证产物，不纳入 Git）。

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -1,6 +1,6 @@
 # Actinium 兼容性矩阵
 
-最后更新：2026-08-18。
+最后更新：2026-08-20。
 
 状态定义：`已验证` 表示在记录的版本和场景中通过；`部分` 表示能运行但存在已知缺口；
 `无法启用` 表示光影包不能成功开启；`未验证` 不代表不兼容。更新记录时必须填写 Actinium commit、
@@ -30,6 +30,10 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 > `SnowTile` 的 `snow_layer`，并只在 `BlockRendererDispatcher.renderBlock` 内重绘被覆盖方块，
 > 而 Actinium 的快速区块渲染路径直接走 baked model、从不调用该入口；修复让 SRM 的
 > `snow_layer` 块退回 vanilla dispatcher 路径（`6aee395`，dev 运行验证通过）。
+
+> 2026-08-20 追加：TC4 Research Port: Reborn（issue #74）旧版 Tessellator 的 GUI 卡死修复——见下方
+> [模组与环境](#模组与环境) 的 TC4 Research Port: Reborn 行与
+> [docs/compat/oldresearch.md](compat/oldresearch.md)。修复后 GUI/FPS 的人工回归尚待完成。
 
 ## 光影包
 
@@ -63,8 +67,11 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 | Depths Update    | 已验证 | 兼容门控（`compat/depthsupdate`：公开 API 推导 section 范围 + storage 索引映射） | 1.0.0-a10：扩展世界高度（默认 -64..320）下 Y<0 与 Y>255 的方块不再缺失（渲染器原先硬编码 0-255）；dev 实测正常；无 Depths 时回退 vanilla 行为 |
 | EnderIO CEu / EnderCore CEu | 已验证 | 无（核心渲染语义修复，非模组接入） | 5.4.2 + EnderCore 0.5.81：光影开启时流体罐内液体被罐体玻璃窗深度遮挡的问题已修复（`cb4feaa5`，translucent terrain pass 不再写深度）；MakeUp Ultra Fast 9.4c + Cleanroom 0.5.17-alpha 实测通过 |
 | Snow! Real Magic! | 已验证 | 兼容门控（SRM 的 snow_layer 块退回 vanilla dispatcher 路径） | 0.7.4：带雪栅栏不渲染已修复（SRM 把被覆盖方块替换为带 SnowTile 的雪层、仅在 `BlockRendererDispatcher.renderBlock` 内重绘，快速区块路径已绕过）；`6aee395`，dev 运行验证通过（MakeUp Ultra Fast 下无光影 + 光影各验一次） |
+| TC4 Research Port: Reborn | 未验证 | 条件 Mixin（Old Research Tessellator 转发到 streaming drawer） | 1.0.1-release（1632015:8642028）：已修复 splash 结束后 repack capacity 为 0 导致的 GUI Client thread 无限循环；修复后 GUI/FPS 和研究树视觉回归待人工确认，详见 [docs/compat/oldresearch.md](compat/oldresearch.md) |
 | Modern Splash    | 部分 | 无侵入（替换类与 mixin 注入天然兼容）+ splash 字体 color=0 修复 | 1.5.3（629058:8487408）dev 运行通过（coremod 加载、mixin 注入保留、字体颜色按配置生效）；光影场景回归待做，详见 [docs/compat/modern-splash.md](compat/modern-splash.md) |
 | Reese's Sodium Options（内嵌） | 代码支持 | 内嵌移植 UI（`me.flashyreese.mods.reeses_sodium_options`，MIT）+ embeddium 选项数据层（`org.embeddedt.embeddium.api.options.*` 自研扩展） | RSO 界面作为视频设置入口（`MixinGuiOptions` 拦截按钮 101，`enabled=false` 回退原版 `GuiVideoSettings`）；`net.caffeinemc` 设置界面与配置模型已整体删除；编译与 349 项单元测试通过，**运行期视觉对比待人工验证**，详见 [docs/rso-port.md](rso-port.md) |
+| Extra Utilities 2 | 已验证 | `ModdedBlockRenderCompat` 在完整 block-render 生命周期内按 block 实例串行化 | `extrautils2@1.0`：Java 25 dev 客户端启动 10 个 chunk-builder worker，进入已有世界并触发区块重载后未复现 Issue #36 的 CME；代码提交 `44f4295`，详见 [docs/compat/extrautils2.md](compat/extrautils2.md) |
+| AgriCraft | 部分 | `ModdedBlockRenderCompat` 使用共享 renderer 锁保护 crop 缓存 | 与 XU2 相同的异步第三方缓存访问模式已加入兼容层；dev 运行验证待补，详见 [docs/compat/extrautils2.md](compat/extrautils2.md) |
 
 ## 验证记录模板
 

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -33,7 +33,8 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 
 > 2026-08-20 追加：TC4 Research Port: Reborn（issue #74）旧版 Tessellator 的 GUI 卡死修复——见下方
 > [模组与环境](#模组与环境) 的 TC4 Research Port: Reborn 行与
-> [docs/compat/oldresearch.md](compat/oldresearch.md)。修复后 GUI/FPS 的人工回归尚待完成。
+> [docs/compat/oldresearch.md](compat/oldresearch.md)。dev 人工回归确认研究笔记 GUI 不再卡死，
+> 优化后约 500+ FPS，与背包界面同量级；研究树视觉回归仍待补充。
 
 ## 光影包
 
@@ -67,7 +68,7 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 | Depths Update    | 已验证 | 兼容门控（`compat/depthsupdate`：公开 API 推导 section 范围 + storage 索引映射） | 1.0.0-a10：扩展世界高度（默认 -64..320）下 Y<0 与 Y>255 的方块不再缺失（渲染器原先硬编码 0-255）；dev 实测正常；无 Depths 时回退 vanilla 行为 |
 | EnderIO CEu / EnderCore CEu | 已验证 | 无（核心渲染语义修复，非模组接入） | 5.4.2 + EnderCore 0.5.81：光影开启时流体罐内液体被罐体玻璃窗深度遮挡的问题已修复（`cb4feaa5`，translucent terrain pass 不再写深度）；MakeUp Ultra Fast 9.4c + Cleanroom 0.5.17-alpha 实测通过 |
 | Snow! Real Magic! | 已验证 | 兼容门控（SRM 的 snow_layer 块退回 vanilla dispatcher 路径） | 0.7.4：带雪栅栏不渲染已修复（SRM 把被覆盖方块替换为带 SnowTile 的雪层、仅在 `BlockRendererDispatcher.renderBlock` 内重绘，快速区块路径已绕过）；`6aee395`，dev 运行验证通过（MakeUp Ultra Fast 下无光影 + 光影各验一次） |
-| TC4 Research Port: Reborn | 未验证 | 条件 Mixin（Old Research Tessellator 转发到 streaming drawer） | 1.0.1-release（1632015:8642028）：已修复 splash 结束后 repack capacity 为 0 导致的 GUI Client thread 无限循环；修复后 GUI/FPS 和研究树视觉回归待人工确认，详见 [docs/compat/oldresearch.md](compat/oldresearch.md) |
+| TC4 Research Port: Reborn | 部分 | 条件 Mixin（Old Research Tessellator 转发到 streaming drawer） | 1.0.1-release（1632015:8642028）：已修复 splash 结束后 repack capacity 为 0 导致的 GUI Client thread 无限循环；dev 人工回归确认研究笔记 GUI 不再卡死，优化后约 500+ FPS，与背包界面同量级；研究树视觉回归待补，详见 [docs/compat/oldresearch.md](compat/oldresearch.md) |
 | Modern Splash    | 部分 | 无侵入（替换类与 mixin 注入天然兼容）+ splash 字体 color=0 修复 | 1.5.3（629058:8487408）dev 运行通过（coremod 加载、mixin 注入保留、字体颜色按配置生效）；光影场景回归待做，详见 [docs/compat/modern-splash.md](compat/modern-splash.md) |
 | Reese's Sodium Options（内嵌） | 代码支持 | 内嵌移植 UI（`me.flashyreese.mods.reeses_sodium_options`，MIT）+ embeddium 选项数据层（`org.embeddedt.embeddium.api.options.*` 自研扩展） | RSO 界面作为视频设置入口（`MixinGuiOptions` 拦截按钮 101，`enabled=false` 回退原版 `GuiVideoSettings`）；`net.caffeinemc` 设置界面与配置模型已整体删除；编译与 349 项单元测试通过，**运行期视觉对比待人工验证**，详见 [docs/rso-port.md](rso-port.md) |
 | Extra Utilities 2 | 已验证 | `ModdedBlockRenderCompat` 在完整 block-render 生命周期内按 block 实例串行化 | `extrautils2@1.0`：Java 25 dev 客户端启动 10 个 chunk-builder worker，进入已有世界并触发区块重载后未复现 Issue #36 的 CME；代码提交 `44f4295`，详见 [docs/compat/extrautils2.md](compat/extrautils2.md) |

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/streaming/TessellatorStreamingDrawer.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/streaming/TessellatorStreamingDrawer.java
@@ -34,6 +34,7 @@ public class TessellatorStreamingDrawer {
 
     private static final Logger LOGGER = LogManager.getLogger("TessellatorStreamingDrawer");
     private static final int FORMAT_COUNT = VertexFlags.BITSET_SIZE; // 16
+    private static final int INITIAL_REPACK_CAPACITY = 0x10000;
     private static final boolean DEBUG_STREAMING_DRAWS = Boolean.getBoolean("actinium.glsm.verboseDrawLogs");
 
     private static PersistentStreamingBuffer persistentBuffer;
@@ -50,7 +51,7 @@ public class TessellatorStreamingDrawer {
 
     static {
         // Initial repack buffer: 64KB
-        repackCapacity = 0x10000;
+        repackCapacity = INITIAL_REPACK_CAPACITY;
         repackBuffer = memAlloc(repackCapacity);
         repackAddress = memAddress0(repackBuffer);
     }
@@ -305,17 +306,27 @@ public class TessellatorStreamingDrawer {
      * Public for use by external batch systems that need to pack data before calling {@link #drawPacked}.
      */
     public static void ensureRepackCapacity(int requiredBytes) {
-        if (requiredBytes <= repackCapacity) return;
+        if (repackBuffer != null && requiredBytes <= repackCapacity) return;
 
-        int newCapacity = repackCapacity;
-        while (newCapacity < requiredBytes) {
-            newCapacity *= 2;
+        int newCapacity = nextRepackCapacity(repackCapacity, requiredBytes);
+
+        if (repackBuffer != null) {
+            memFree(repackBuffer);
         }
-
-        memFree(repackBuffer);
         repackBuffer = memAlloc(newCapacity);
         repackAddress = memAddress0(repackBuffer);
         repackCapacity = newCapacity;
+    }
+
+    /** Calculates the next power-of-two repack capacity, including after a full drawer destroy. */
+    static int nextRepackCapacity(int currentCapacity, int requiredBytes) {
+        if (requiredBytes <= currentCapacity) return currentCapacity;
+
+        int newCapacity = Math.max(INITIAL_REPACK_CAPACITY, currentCapacity);
+        while (newCapacity < requiredBytes) {
+            newCapacity *= 2;
+        }
+        return newCapacity;
     }
 
     /** Get the repack buffer's native address. Valid until next {@link #ensureRepackCapacity} call. */

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/streaming/TessellatorStreamingDrawer.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/streaming/TessellatorStreamingDrawer.java
@@ -17,6 +17,8 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL15;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.IntBuffer;
 
 import static com.gtnewhorizon.gtnhlib.bytebuf.MemoryUtilities.memAddress0;
 import static com.gtnewhorizon.gtnhlib.bytebuf.MemoryUtilities.memAlloc;
@@ -35,6 +37,7 @@ public class TessellatorStreamingDrawer {
     private static final Logger LOGGER = LogManager.getLogger("TessellatorStreamingDrawer");
     private static final int FORMAT_COUNT = VertexFlags.BITSET_SIZE; // 16
     private static final int INITIAL_REPACK_CAPACITY = 0x10000;
+    private static final int RAW_VERTEX_STRIDE_INTS = 8;
     private static final boolean DEBUG_STREAMING_DRAWS = Boolean.getBoolean("actinium.glsm.verboseDrawLogs");
 
     private static PersistentStreamingBuffer persistentBuffer;
@@ -44,6 +47,7 @@ public class TessellatorStreamingDrawer {
     private static final int[] orphanVAOs = new int[FORMAT_COUNT];
 
     private static ByteBuffer repackBuffer;
+    private static IntBuffer repackIntBuffer;
     private static long repackAddress;
     private static int repackCapacity;
 
@@ -54,6 +58,7 @@ public class TessellatorStreamingDrawer {
         repackCapacity = INITIAL_REPACK_CAPACITY;
         repackBuffer = memAlloc(repackCapacity);
         repackAddress = memAddress0(repackBuffer);
+        repackIntBuffer = repackBuffer.order(ByteOrder.nativeOrder()).asIntBuffer();
     }
 
     private static void init() {
@@ -103,11 +108,28 @@ public class TessellatorStreamingDrawer {
         final int requiredBytes = vertexCount * vertexSize;
         ensureRepackCapacity(requiredBytes);
 
-        final long writePtr = format.writeToBuffer0(repackAddress, tess.getRawBuffer(), tess.getRawBufferIndex());
+        final int[] rawBuffer = tess.getRawBuffer();
+        final int rawBufferIndex = tess.getRawBufferIndex();
+        final int packedBytes = packRawVertices(repackIntBuffer, rawBuffer, rawBufferIndex, flags);
+        final long writePtr;
+        if (packedBytes >= 0) {
+            writePtr = repackAddress + packedBytes;
+        } else {
+            writePtr = format.writeToBuffer0(repackAddress, rawBuffer, rawBufferIndex);
+        }
         repackBuffer.position(0);
         repackBuffer.limit((int)(writePtr - repackAddress));
 
-        uploadAndDraw(repackBuffer, flags, format, vertexSize, tess.getDrawMode(), vertexCount);
+        final boolean singleQuadFastPath = isSingleQuadFastPath(
+            tess.getDrawMode(), vertexCount, flags, rawBuffer, rawBufferIndex);
+        uploadAndDraw(
+            repackBuffer,
+            flags,
+            format,
+            vertexSize,
+            tess.getDrawMode(),
+            vertexCount,
+            singleQuadFastPath);
         if (perfDebugEnabled) {
             GLSMPerfDebug.count(GLSMPerfDebug.Source.STREAM_TESSELLATOR);
         }
@@ -153,7 +175,7 @@ public class TessellatorStreamingDrawer {
         final ByteBuffer buffer = dt.getWriteBuffer();
         final int vertexSize = format.getVertexSize();
 
-        uploadAndDraw(buffer, flags, format, vertexSize, drawMode, vertexCount);
+        uploadAndDraw(buffer, flags, format, vertexSize, drawMode, vertexCount, false);
         if (perfDebugEnabled) {
             GLSMPerfDebug.count(GLSMPerfDebug.Source.DIRECT_EXTERNAL);
         }
@@ -172,7 +194,7 @@ public class TessellatorStreamingDrawer {
     public static void drawPacked(ByteBuffer packedData, int drawMode, int flags, int vertexCount) {
         final VertexFormat format = DefaultVertexFormat.ALL_FORMATS[flags];
         final int vertexSize = format.getVertexSize();
-        uploadAndDraw(packedData, flags, format, vertexSize, drawMode, vertexCount);
+        uploadAndDraw(packedData, flags, format, vertexSize, drawMode, vertexCount, false);
     }
 
     private static String cachedDebugInfo = "Stream: not initialized";
@@ -223,7 +245,15 @@ public class TessellatorStreamingDrawer {
      * Upload packed vertex data to a streaming buffer and issue the draw call.
      * Tries the persistent ring buffer first, falls back to orphan buffer on overflow.
      */
-    private static void uploadAndDraw(ByteBuffer packed, int flags, VertexFormat format, int vertexSize, int drawMode, int vertexCount) {
+    private static void uploadAndDraw(
+        ByteBuffer packed,
+        int flags,
+        VertexFormat format,
+        int vertexSize,
+        int drawMode,
+        int vertexCount,
+        boolean singleQuadFastPath
+    ) {
         final boolean perfDebugEnabled = GLSMPerfDebug.isEnabled();
         final long perfStart = perfDebugEnabled ? GLSMPerfDebug.begin(GLSMPerfDebug.Stage.STREAM_UPLOAD_AND_DRAW) : 0L;
         final boolean perfSampled = perfStart != 0L;
@@ -278,7 +308,7 @@ public class TessellatorStreamingDrawer {
             GLSMPerfDebug.record(GLSMPerfDebug.Stage.STREAM_SHADER_PREDRAW, preDrawStart, GLSMPerfDebug.now());
         }
         final long drawStart = perfSampled ? GLSMPerfDebug.now() : 0L;
-        drawWithQuadConversion(drawMode, firstVertex, vertexCount);
+        drawWithQuadConversion(drawMode, firstVertex, vertexCount, singleQuadFastPath);
         if (perfSampled) {
             GLSMPerfDebug.record(GLSMPerfDebug.Stage.STREAM_DRAW_CALL, drawStart, GLSMPerfDebug.now());
         }
@@ -289,9 +319,13 @@ public class TessellatorStreamingDrawer {
         }
     }
 
-    private static void drawWithQuadConversion(int drawMode, int firstVertex, int vertexCount) {
+    private static void drawWithQuadConversion(int drawMode, int firstVertex, int vertexCount, boolean singleQuadFastPath) {
         if (drawMode == GL11.GL_QUADS) {
-            QuadConverter.drawQuadsAsTriangles(firstVertex, vertexCount);
+            if (singleQuadFastPath) {
+                RENDER_BACKEND.drawArrays(GL11.GL_TRIANGLE_FAN, firstVertex, 4);
+            } else {
+                QuadConverter.drawQuadsAsTriangles(firstVertex, vertexCount);
+            }
         } else if (drawMode == GL11.GL_QUAD_STRIP) {
             RENDER_BACKEND.drawArrays(GL11.GL_TRIANGLE_STRIP, firstVertex, vertexCount & ~1);
         } else if (drawMode == GL11.GL_POLYGON) {
@@ -315,7 +349,83 @@ public class TessellatorStreamingDrawer {
         }
         repackBuffer = memAlloc(newCapacity);
         repackAddress = memAddress0(repackBuffer);
+        repackIntBuffer = repackBuffer.order(ByteOrder.nativeOrder()).asIntBuffer();
         repackCapacity = newCapacity;
+    }
+
+    /**
+     * Packs the common legacy raw layouts without invoking one writer for every attribute.
+     * Returns {@code -1} when the format contains an attribute that still needs the generic writer.
+     */
+    static int packRawVertices(IntBuffer destination, int[] rawBuffer, int rawBufferIndex, int flags) {
+        if (!supportsRawPacking(flags)) {
+            return -1;
+        }
+
+        destination.clear();
+        if (flags == VertexFlags.COLOR_BIT) {
+            for (int index = 0; index < rawBufferIndex; index += RAW_VERTEX_STRIDE_INTS) {
+                destination.put(rawBuffer, index, 3);
+                destination.put(rawBuffer[index + 5]);
+            }
+        } else {
+            final int copiedInts = flags == (VertexFlags.TEXTURE_BIT | VertexFlags.COLOR_BIT) ? 6
+                : flags == VertexFlags.TEXTURE_BIT ? 5 : 3;
+            for (int index = 0; index < rawBufferIndex; index += RAW_VERTEX_STRIDE_INTS) {
+                destination.put(rawBuffer, index, copiedInts);
+            }
+        }
+        return destination.position() * Integer.BYTES;
+    }
+
+    static boolean supportsRawPacking(int flags) {
+        return flags == 0
+            || flags == VertexFlags.TEXTURE_BIT
+            || flags == VertexFlags.COLOR_BIT
+            || flags == (VertexFlags.TEXTURE_BIT | VertexFlags.COLOR_BIT);
+    }
+
+    /**
+     * A single rectangular quad can use a non-indexed fan and avoid the shared quad EBO.
+     * Flat-sensitive attributes must be constant so the provoking vertex remains equivalent.
+     */
+    static boolean isSingleQuadFastPath(int drawMode, int vertexCount, int flags, int[] rawBuffer, int rawBufferIndex) {
+        if (drawMode != GL11.GL_QUADS || vertexCount != 4 || rawBufferIndex != RAW_VERTEX_STRIDE_INTS * 4) {
+            return false;
+        }
+        if (!isParallelogram(rawBuffer, 0)) {
+            return false;
+        }
+        if ((flags & VertexFlags.TEXTURE_BIT) != 0 && !isParallelogram(rawBuffer, 3)) {
+            return false;
+        }
+        if ((flags & VertexFlags.COLOR_BIT) != 0 && !hasConstantAttribute(rawBuffer, 5)) {
+            return false;
+        }
+        if ((flags & VertexFlags.NORMAL_BIT) != 0 && !hasConstantAttribute(rawBuffer, 6)) {
+            return false;
+        }
+        return (flags & VertexFlags.BRIGHTNESS_BIT) == 0 || hasConstantAttribute(rawBuffer, 7);
+    }
+
+    private static boolean hasConstantAttribute(int[] rawBuffer, int attributeOffset) {
+        final int first = rawBuffer[attributeOffset];
+        return rawBuffer[RAW_VERTEX_STRIDE_INTS + attributeOffset] == first
+            && rawBuffer[RAW_VERTEX_STRIDE_INTS * 2 + attributeOffset] == first
+            && rawBuffer[RAW_VERTEX_STRIDE_INTS * 3 + attributeOffset] == first;
+    }
+
+    private static boolean isParallelogram(int[] rawBuffer, int attributeOffset) {
+        for (int component = 0; component < (attributeOffset == 0 ? 3 : 2); component++) {
+            final float first = Float.intBitsToFloat(rawBuffer[attributeOffset + component]);
+            final float second = Float.intBitsToFloat(rawBuffer[RAW_VERTEX_STRIDE_INTS + attributeOffset + component]);
+            final float third = Float.intBitsToFloat(rawBuffer[RAW_VERTEX_STRIDE_INTS * 2 + attributeOffset + component]);
+            final float fourth = Float.intBitsToFloat(rawBuffer[RAW_VERTEX_STRIDE_INTS * 3 + attributeOffset + component]);
+            if (first + third != second + fourth) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /** Calculates the next power-of-two repack capacity, including after a full drawer destroy. */
@@ -381,6 +491,7 @@ public class TessellatorStreamingDrawer {
         if (repackBuffer != null) {
             memFree(repackBuffer);
             repackBuffer = null;
+            repackIntBuffer = null;
             repackAddress = 0;
             repackCapacity = 0;
         }

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -137,4 +137,8 @@ dependencies {
     // SnowTile and only re-emits the covered block inside BlockRendererDispatcher.renderBlock; the fast
     // chunk path must fall back to the vanilla dispatcher for its snow_layer block)
     modRuntimeOnly 'curse.maven:snow-real-magic-308663:6275195'
+
+    modImplementation 'curse.maven:oldresearchreborn-1632015:8642028'
+    modImplementation 'curse.maven:thaumcraft-223628:2629023'
+    modImplementation 'curse.maven:baubles-227083:2518667'
 }

--- a/src/main/java/com/dhj/actinium/compat/oldresearch/OldResearchTessellatorCompat.java
+++ b/src/main/java/com/dhj/actinium/compat/oldresearch/OldResearchTessellatorCompat.java
@@ -1,0 +1,22 @@
+package com.dhj.actinium.compat.oldresearch;
+
+import com.gtnewhorizons.angelica.glsm.ITessellatorData;
+import com.gtnewhorizons.angelica.glsm.streaming.TessellatorStreamingDrawer;
+
+/**
+ * Routes Old Research's legacy client-array tessellator through Actinium's streaming renderer.
+ *
+ * <p>Old Research keeps a private copy of the 1.12 tessellator. Its original draw method exposes
+ * client-side vertex pointers, which Actinium must upload to a temporary VBO before every draw.
+ * The streaming drawer repacks the same legacy vertex layout once and renders it through the
+ * persistent or orphan VBO path.</p>
+ */
+public final class OldResearchTessellatorCompat {
+    private OldResearchTessellatorCompat() {
+    }
+
+    /** Draws one Old Research tessellator batch with Actinium's streaming path. */
+    public static int draw(ITessellatorData tessellator) {
+        return TessellatorStreamingDrawer.draw(tessellator);
+    }
+}

--- a/src/main/java/com/dhj/actinium/mixin/mod/oldresearch/MixinOldResearchTessellator.java
+++ b/src/main/java/com/dhj/actinium/mixin/mod/oldresearch/MixinOldResearchTessellator.java
@@ -1,0 +1,119 @@
+package com.dhj.actinium.mixin.mod.oldresearch;
+
+import com.dhj.actinium.compat.oldresearch.OldResearchTessellatorCompat;
+import com.gtnewhorizons.angelica.glsm.ITessellatorData;
+import com.wonginnovations.oldresearch.tc4legacy.client.Tessellator;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Replaces Old Research's client-side vertex-array draw with Actinium's streaming VBO draw.
+ *
+ * <p>The target is conditionally loaded because the Old Research class is absent in installations
+ * that do not include TC4 Research Port: Reborn.</p>
+ */
+@Mixin(value = Tessellator.class, remap = false)
+public abstract class MixinOldResearchTessellator implements ITessellatorData {
+    @Shadow
+    private boolean isDrawing;
+    @Shadow
+    private int rawBufferSize;
+    @Shadow
+    private int[] rawBuffer;
+    @Shadow
+    private int vertexCount;
+    @Shadow
+    private boolean hasColor;
+    @Shadow
+    private boolean hasTexture;
+    @Shadow
+    private boolean hasBrightness;
+    @Shadow
+    private boolean hasNormals;
+    @Shadow
+    private int rawBufferIndex;
+    @Shadow
+    private int drawMode;
+    @Shadow
+    protected abstract void reset();
+
+    @Inject(method = "draw", at = @At("HEAD"), cancellable = true, remap = false)
+    private void actinium$drawWithStreaming(CallbackInfoReturnable<Integer> cir) {
+        cir.setReturnValue(OldResearchTessellatorCompat.draw(this));
+    }
+
+    @Override
+    public boolean isDrawing() {
+        return this.isDrawing;
+    }
+
+    @Override
+    public void setDrawing(boolean drawing) {
+        this.isDrawing = drawing;
+    }
+
+    @Override
+    public int getVertexCount() {
+        return this.vertexCount;
+    }
+
+    @Override
+    public int[] getRawBuffer() {
+        return this.rawBuffer;
+    }
+
+    @Override
+    public int getRawBufferIndex() {
+        return this.rawBufferIndex;
+    }
+
+    @Override
+    public int getRawBufferSize() {
+        return this.rawBufferSize;
+    }
+
+    @Override
+    public void setRawBufferSize(int size) {
+        this.rawBufferSize = size;
+    }
+
+    @Override
+    public void setRawBuffer(int[] buffer) {
+        this.rawBuffer = buffer;
+    }
+
+    @Override
+    public int getDrawMode() {
+        return this.drawMode;
+    }
+
+    @Override
+    public boolean hasTexture() {
+        return this.hasTexture;
+    }
+
+    @Override
+    public boolean hasColor() {
+        return this.hasColor;
+    }
+
+    @Override
+    public boolean hasNormals() {
+        return this.hasNormals;
+    }
+
+    @Override
+    public boolean hasBrightness() {
+        return this.hasBrightness;
+    }
+
+    @Override
+    @Unique
+    public void angelica$reset() {
+        this.reset();
+    }
+}

--- a/src/main/resources/mixins.actinium.conditions.properties
+++ b/src/main/resources/mixins.actinium.conditions.properties
@@ -12,3 +12,4 @@ mixins.actinium.ccl.json=codechickenlib
 mixins.actinium.voxelmap.json=voxelmap
 mixins.actinium.extrautils2.json=extrautils2
 mixins.actinium.cofhcore.json=cofhcore
+mixins.actinium.oldresearch.json=oldresearch

--- a/src/main/resources/mixins.actinium.oldresearch.json
+++ b/src/main/resources/mixins.actinium.oldresearch.json
@@ -1,0 +1,16 @@
+{
+  "package": "com.dhj.actinium.mixin.mod.oldresearch",
+  "required": true,
+  "refmap": "mixins.actinium-refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8.5",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [],
+  "server": [],
+  "client": [
+    "MixinOldResearchTessellator"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/test/java/com/dhj/actinium/mixin/MixinConfigurationTest.java
+++ b/src/test/java/com/dhj/actinium/mixin/MixinConfigurationTest.java
@@ -52,7 +52,8 @@ class MixinConfigurationTest {
         "mixins.actinium.ccl.json",
         "mixins.actinium.voxelmap.json",
         "mixins.actinium.extrautils2.json",
-        "mixins.actinium.cofhcore.json"
+        "mixins.actinium.cofhcore.json",
+        "mixins.actinium.oldresearch.json"
     );
     private static final List<String> CONFIGS = Stream.concat(
         Stream.of(BRIDGE_CONFIG),

--- a/src/test/java/com/dhj/actinium/mixins/MixinLateTest.java
+++ b/src/test/java/com/dhj/actinium/mixins/MixinLateTest.java
@@ -42,7 +42,8 @@ class MixinLateTest {
                 "mixins.actinium.ccl.json",
                 "mixins.actinium.voxelmap.json",
                 "mixins.actinium.extrautils2.json",
-                "mixins.actinium.cofhcore.json"
+                "mixins.actinium.cofhcore.json",
+                "mixins.actinium.oldresearch.json"
             ),
             Set.copyOf(MixinLate.configsFor(modId -> true))
         );

--- a/src/test/java/com/gtnewhorizons/angelica/glsm/streaming/TessellatorStreamingDrawerTest.java
+++ b/src/test/java/com/gtnewhorizons/angelica/glsm/streaming/TessellatorStreamingDrawerTest.java
@@ -1,8 +1,19 @@
 package com.gtnewhorizons.angelica.glsm.streaming;
 
+import org.lwjgl.opengl.GL11;
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.IntBuffer;
+
+import static com.gtnewhorizon.gtnhlib.client.renderer.vertex.VertexFlags.COLOR_BIT;
+import static com.gtnewhorizon.gtnhlib.client.renderer.vertex.VertexFlags.NORMAL_BIT;
+import static com.gtnewhorizon.gtnhlib.client.renderer.vertex.VertexFlags.TEXTURE_BIT;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TessellatorStreamingDrawerTest {
     @Test
@@ -13,5 +24,91 @@ class TessellatorStreamingDrawerTest {
     @Test
     void growsRepackCapacityFromTheExistingPowerOfTwo() {
         assertEquals(0x20000, TessellatorStreamingDrawer.nextRepackCapacity(0x10000, 0x10001));
+    }
+
+    @Test
+    void packsPositionColorRawVertices() {
+        final int[] raw = {
+            1, 2, 3, 4, 5, 6, 7, 8,
+            11, 12, 13, 14, 15, 16, 17, 18
+        };
+        final IntBuffer packed = ByteBuffer.allocateDirect(32).order(ByteOrder.nativeOrder()).asIntBuffer();
+
+        assertEquals(32, TessellatorStreamingDrawer.packRawVertices(packed, raw, raw.length, COLOR_BIT));
+        assertArrayEquals(new int[] { 1, 2, 3, 6, 11, 12, 13, 16 }, read(packed));
+    }
+
+    @Test
+    void packsPositionTextureColorRawVerticesAsOneContiguousCopy() {
+        final int[] raw = {
+            1, 2, 3, 4, 5, 6, 7, 8,
+            11, 12, 13, 14, 15, 16, 17, 18
+        };
+        final IntBuffer packed = ByteBuffer.allocateDirect(48).order(ByteOrder.nativeOrder()).asIntBuffer();
+
+        assertEquals(48, TessellatorStreamingDrawer.packRawVertices(
+            packed,
+            raw,
+            raw.length,
+            TEXTURE_BIT | COLOR_BIT));
+        assertArrayEquals(new int[] { 1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16 }, read(packed));
+    }
+
+    @Test
+    void fallsBackForFormatsWithNormalData() {
+        final IntBuffer packed = ByteBuffer.allocateDirect(32).order(ByteOrder.nativeOrder()).asIntBuffer();
+
+        assertEquals(-1, TessellatorStreamingDrawer.packRawVertices(packed, new int[8], 8, NORMAL_BIT));
+    }
+
+    @Test
+    void acceptsAConstantAttributeRectangularQuad() {
+        final int[] raw = rectangularQuad(0x11223344);
+
+        assertTrue(TessellatorStreamingDrawer.isSingleQuadFastPath(
+            GL11.GL_QUADS,
+            4,
+            TEXTURE_BIT | COLOR_BIT,
+            raw,
+            raw.length));
+    }
+
+    @Test
+    void rejectsAQuadWithDifferentFlatSensitiveAttributes() {
+        final int[] raw = rectangularQuad(0x11223344);
+        raw[5 + 8] = 0x01020304;
+
+        assertFalse(TessellatorStreamingDrawer.isSingleQuadFastPath(
+            GL11.GL_QUADS,
+            4,
+            TEXTURE_BIT | COLOR_BIT,
+            raw,
+            raw.length));
+    }
+
+    @Test
+    void rejectsNonQuadAndNonRectangularInput() {
+        final int[] raw = rectangularQuad(0x11223344);
+        raw[16] = Float.floatToRawIntBits(3.0f);
+
+        assertFalse(TessellatorStreamingDrawer.isSingleQuadFastPath(GL11.GL_LINES, 4, COLOR_BIT, raw, raw.length));
+        assertFalse(TessellatorStreamingDrawer.isSingleQuadFastPath(GL11.GL_QUADS, 4, COLOR_BIT, raw, raw.length));
+    }
+
+    private static int[] read(IntBuffer buffer) {
+        final int[] result = new int[buffer.position()];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = buffer.get(i);
+        }
+        return result;
+    }
+
+    private static int[] rectangularQuad(int color) {
+        return new int[] {
+            Float.floatToRawIntBits(0.0f), Float.floatToRawIntBits(0.0f), 0, Float.floatToRawIntBits(0.0f), Float.floatToRawIntBits(0.0f), color, 0, 220,
+            Float.floatToRawIntBits(2.0f), Float.floatToRawIntBits(0.0f), 0, Float.floatToRawIntBits(1.0f), Float.floatToRawIntBits(0.0f), color, 0, 220,
+            Float.floatToRawIntBits(2.0f), Float.floatToRawIntBits(2.0f), 0, Float.floatToRawIntBits(1.0f), Float.floatToRawIntBits(1.0f), color, 0, 220,
+            Float.floatToRawIntBits(0.0f), Float.floatToRawIntBits(2.0f), 0, Float.floatToRawIntBits(0.0f), Float.floatToRawIntBits(1.0f), color, 0, 220
+        };
     }
 }

--- a/src/test/java/com/gtnewhorizons/angelica/glsm/streaming/TessellatorStreamingDrawerTest.java
+++ b/src/test/java/com/gtnewhorizons/angelica/glsm/streaming/TessellatorStreamingDrawerTest.java
@@ -1,0 +1,17 @@
+package com.gtnewhorizons.angelica.glsm.streaming;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TessellatorStreamingDrawerTest {
+    @Test
+    void restartsRepackCapacityAfterDrawerDestroy() {
+        assertEquals(0x10000, TessellatorStreamingDrawer.nextRepackCapacity(0, 96));
+    }
+
+    @Test
+    void growsRepackCapacityFromTheExistingPowerOfTwo() {
+        assertEquals(0x20000, TessellatorStreamingDrawer.nextRepackCapacity(0x10000, 0x10001));
+    }
+}


### PR DESCRIPTION
## What

- Add a conditional Old Research Mixin that routes the mod's legacy Tessellator through Actinium's streaming drawer.
- Rebuild the streaming drawer lazily after splash teardown so a zero repack capacity cannot enter an infinite growth loop.
- Reduce the hot-path overhead with native IntBuffer packing for common legacy layouts and a valid single-rectangle quad fast path using GL_TRIANGLE_FAN.
- Add the Old Research, Thaumcraft, and Baubles Maven dependencies, Mixin configuration coverage, direct streaming-drawer tests, and compatibility documentation.

## Why

Closes #74: TC4 Research Port: Reborn could reduce a normal approximately 850 FPS GUI to approximately 16 FPS and leave the client thread unresponsive after opening a research GUI. The root cause was the legacy tessellator path reaching a repack buffer whose capacity had been reset to zero after splash teardown.

## How verified

- Build: `.gradlew.bat build --no-daemon` with Java 25 and `GRADLE_USER_HOME=D:/gradle` - passed. This includes unit tests, module-boundary checks, compatibility-bridge checks, and remap Jar validation.
- Automated coverage: `TessellatorStreamingDrawerTest` directly verifies destroy/reallocation behavior, common packed layouts, quad fast-path selection, and fallback conversion.
- Dev regression: TC4 Research Port: Reborn 1.0.1-release with Thaumcraft and Baubles. Confirmed that the research GUI no longer hangs; after the optimization pass it runs above 500 FPS, in the same range as the inventory GUI.
- Remaining coverage: the research tree, node icons, and Thaumcraft-specific drawing have not been separately recorded as a visual regression test.

## Commits

- fix(compat): route Old Research tessellator through streaming drawer
- perf(glsm): reduce legacy tessellator draw overhead
- docs(compat): record Old Research GUI regression