### PR TITLE
fix(shader): restore water depth writes

### DIFF
--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/RenderPassConfiguration.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/RenderPassConfiguration.java
@@ -15,7 +15,21 @@ public record RenderPassConfiguration<R>(Map<R, Material> chunkRenderTypeToMater
                                       Map<R, Collection<TerrainRenderPass>> vanillaRenderStages,
                                       Material defaultSolidMaterial,
                                       Material defaultCutoutMippedMaterial,
-                                      Material defaultTranslucentMaterial) {
+                                      Material defaultTranslucentMaterial,
+                                      Material defaultFluidMaterial) {
+    public RenderPassConfiguration(Map<R, Material> chunkRenderTypeToMaterialMap,
+                                   Map<R, Collection<TerrainRenderPass>> vanillaRenderStages,
+                                   Material defaultSolidMaterial,
+                                   Material defaultCutoutMippedMaterial,
+                                   Material defaultTranslucentMaterial) {
+        this(chunkRenderTypeToMaterialMap,
+                vanillaRenderStages,
+                defaultSolidMaterial,
+                defaultCutoutMippedMaterial,
+                defaultTranslucentMaterial,
+                defaultTranslucentMaterial);
+    }
+
     @Deprecated
     public ChunkVertexType getVertexTypeForPass(TerrainRenderPass pass) {
         return pass.vertexType();

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/RenderSectionManager.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/RenderSectionManager.java
@@ -213,14 +213,13 @@ public abstract class RenderSectionManager {
         var sortRebuildList = rebuildLists.get(ChunkUpdateType.SORT);
         var importantSortRebuildList = rebuildLists.get(ChunkUpdateType.IMPORTANT_SORT);
         var allowImportant = allowImportantRebuilds();
-        var translucentPass = this.renderPassConfiguration.defaultTranslucentMaterial().pass;
         if (!this.hasTranslucencySortedSections()) {
             return;
         }
         for (Iterator<ChunkRenderList> it = renderListManager.getRenderLists().iterator(); it.hasNext(); ) {
             ChunkRenderList entry = it.next();
             var region = entry.getRegion();
-            if (!region.hasSectionsInPass(translucentPass)) {
+            if (region.getPasses().stream().noneMatch(TerrainRenderPass::isSorted)) {
                 continue;
             }
             ByteIterator sectionIterator = entry.sectionsWithGeometryIterator();

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/terrain/TerrainRenderPass.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/terrain/TerrainRenderPass.java
@@ -1,5 +1,6 @@
 package org.embeddedt.embeddium.impl.render.chunk.terrain;
 
+import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Accessors;
 import org.embeddedt.embeddium.impl.render.chunk.compile.sorting.ChunkPrimitiveType;
@@ -23,6 +24,23 @@ import java.util.Objects;
 @EqualsAndHashCode
 public class TerrainRenderPass {
     /**
+     * Identifies the fixed-function terrain behavior represented by a render pass.
+     */
+    public enum Semantic {
+        SOLID,
+        CUTOUT,
+        TRANSLUCENT,
+        WATER;
+
+        private static Semantic fromLegacyFlags(boolean useReverseOrder, boolean fragmentDiscard) {
+            if (useReverseOrder) {
+                return TRANSLUCENT;
+            }
+            return fragmentDiscard ? CUTOUT : SOLID;
+        }
+    }
+
+    /**
      * The friendly name of this render pass.
      */
     @EqualsAndHashCode.Exclude
@@ -37,6 +55,14 @@ public class TerrainRenderPass {
      * Whether sections on this render pass should be rendered farthest-to-nearest, rather than nearest-to-farthest.
      */
     private final boolean useReverseOrder;
+    /**
+     * The stable semantic used by shader and pipeline integrations to classify this pass.
+     */
+    private final Semantic semantic;
+    /**
+     * Whether drawing this render pass updates the depth buffer.
+     */
+    private final boolean writesDepth;
     /**
      * Whether fragment alpha testing should be enabled for this render pass.
      */
@@ -55,6 +81,12 @@ public class TerrainRenderPass {
 
     private final Map<String, String> extraDefines;
 
+    /**
+     * The depth-mask state active before this pass starts drawing.
+     */
+    @EqualsAndHashCode.Exclude
+    private boolean previousDepthMaskEnabled;
+
     public TerrainRenderPass(String name,
                              PipelineState pipelineState,
                              boolean useReverseOrder,
@@ -64,15 +96,94 @@ public class TerrainRenderPass {
                              @NotNull ChunkVertexType vertexType,
                              @NotNull ChunkPrimitiveType primitiveType,
                              Map<String, String> extraDefines) {
+        this(name,
+                pipelineState,
+                useReverseOrder,
+                fragmentDiscard,
+                useTranslucencySorting,
+                hasNoLightmap,
+                vertexType,
+                primitiveType,
+                extraDefines,
+                Semantic.fromLegacyFlags(useReverseOrder, fragmentDiscard),
+                !useReverseOrder);
+    }
+
+    /**
+     * Constructs a terrain render pass with an explicit depth-write policy.
+     *
+     * @param name the friendly name of this render pass
+     * @param pipelineState the callback used to configure the GPU pipeline
+     * @param useReverseOrder whether sections are rendered farthest-to-nearest
+     * @param fragmentDiscard whether fragment alpha testing is enabled
+     * @param useTranslucencySorting whether translucency sorting is enabled
+     * @param hasNoLightmap whether this pass has no lightmap texture
+     * @param vertexType the vertex type used by this pass
+     * @param primitiveType the primitive type used by this pass
+     * @param extraDefines additional shader defines for this pass
+     * @param writesDepth whether drawing this pass updates the depth buffer
+     */
+    public TerrainRenderPass(String name,
+                             PipelineState pipelineState,
+                             boolean useReverseOrder,
+                             boolean fragmentDiscard,
+                             boolean useTranslucencySorting,
+                             boolean hasNoLightmap,
+                             @NotNull ChunkVertexType vertexType,
+                             @NotNull ChunkPrimitiveType primitiveType,
+                             Map<String, String> extraDefines,
+                             boolean writesDepth) {
+        this(name,
+                pipelineState,
+                useReverseOrder,
+                fragmentDiscard,
+                useTranslucencySorting,
+                hasNoLightmap,
+                vertexType,
+                primitiveType,
+                extraDefines,
+                Semantic.fromLegacyFlags(useReverseOrder, fragmentDiscard),
+                writesDepth);
+    }
+
+    /**
+     * Constructs a terrain render pass with explicit semantic and depth-write policies.
+     *
+     * @param name the friendly name of this render pass
+     * @param pipelineState the callback used to configure the GPU pipeline
+     * @param useReverseOrder whether sections are rendered farthest-to-nearest
+     * @param fragmentDiscard whether fragment alpha testing is enabled
+     * @param useTranslucencySorting whether translucency sorting is enabled
+     * @param hasNoLightmap whether this pass has no lightmap texture
+     * @param vertexType the vertex type used by this pass
+     * @param primitiveType the primitive type used by this pass
+     * @param extraDefines additional shader defines for this pass
+     * @param semantic the fixed-function behavior represented by this pass
+     * @param writesDepth whether drawing this pass updates the depth buffer
+     */
+    public TerrainRenderPass(String name,
+                             PipelineState pipelineState,
+                             boolean useReverseOrder,
+                             boolean fragmentDiscard,
+                             boolean useTranslucencySorting,
+                             boolean hasNoLightmap,
+                             @NotNull ChunkVertexType vertexType,
+                             @NotNull ChunkPrimitiveType primitiveType,
+                             Map<String, String> extraDefines,
+                             @NotNull Semantic semantic,
+                             boolean writesDepth) {
         if(name == null || name.length() == 0) {
             throw new IllegalArgumentException("Name not specified for terrain pass");
         }
         Objects.requireNonNull(vertexType);
         Objects.requireNonNull(primitiveType);
+        Objects.requireNonNull(semantic);
 
         this.name = name;
         this.pipelineState = pipelineState != null ? pipelineState : PipelineState.DEFAULT;
         this.useReverseOrder = useReverseOrder;
+        this.semantic = semantic;
+        this.writesDepth = writesDepth;
         this.fragmentDiscard = fragmentDiscard;
         this.useTranslucencySorting = useTranslucencySorting;
         this.hasNoLightmap = hasNoLightmap;
@@ -93,6 +204,20 @@ public class TerrainRenderPass {
         return this.useReverseOrder;
     }
 
+    /**
+     * Returns the stable semantic used to classify this render pass.
+     */
+    public Semantic semantic() {
+        return this.semantic;
+    }
+
+    /**
+     * Returns whether drawing this render pass updates the depth buffer.
+     */
+    public boolean writesDepth() {
+        return this.writesDepth;
+    }
+
     public boolean isSorted() {
         return this.useTranslucencySorting;
     }
@@ -102,11 +227,17 @@ public class TerrainRenderPass {
     }
 
     public void startDrawing() {
+        this.previousDepthMaskEnabled = GLStateManager.getDepthState().isMaskEnabled();
         this.pipelineState.setup();
+        GLStateManager.glDepthMask(this.writesDepth);
     }
 
     public void endDrawing() {
-        this.pipelineState.clear();
+        try {
+            this.pipelineState.clear();
+        } finally {
+            GLStateManager.glDepthMask(this.previousDepthMaskEnabled);
+        }
     }
 
     public boolean supportsFragmentDiscard() {
@@ -151,6 +282,8 @@ public class TerrainRenderPass {
         private String name;
         private PipelineState pipelineState;
         private boolean useReverseOrder;
+        private Semantic semantic;
+        private Boolean writesDepth;
         private boolean fragmentDiscard;
         private boolean useTranslucencySorting;
         private boolean hasNoLightmap;
@@ -170,6 +303,22 @@ public class TerrainRenderPass {
 
         public TerrainRenderPassBuilder useReverseOrder(boolean useReverseOrder) {
             this.useReverseOrder = useReverseOrder;
+            return this;
+        }
+
+        /**
+         * Sets the fixed-function semantic represented by this render pass.
+         */
+        public TerrainRenderPassBuilder semantic(Semantic semantic) {
+            this.semantic = semantic;
+            return this;
+        }
+
+        /**
+         * Sets whether drawing this render pass updates the depth buffer.
+         */
+        public TerrainRenderPassBuilder writesDepth(boolean writesDepth) {
+            this.writesDepth = writesDepth;
             return this;
         }
 
@@ -216,7 +365,11 @@ public class TerrainRenderPass {
                     this.hasNoLightmap,
                     this.vertexType,
                     this.primitiveType,
-                    this.extraDefines
+                    this.extraDefines,
+                    this.semantic != null
+                            ? this.semantic
+                            : Semantic.fromLegacyFlags(this.useReverseOrder, this.fragmentDiscard),
+                    this.writesDepth != null ? this.writesDepth : !this.useReverseOrder
             );
         }
     }

--- a/shader/src/main/java/net/coderbot/iris/celeritas/IrisCeleritasChunkProgramOverrides.java
+++ b/shader/src/main/java/net/coderbot/iris/celeritas/IrisCeleritasChunkProgramOverrides.java
@@ -136,23 +136,14 @@ public class IrisCeleritasChunkProgramOverrides {
             createShaders(celeritasPipeline, configuration);
         }
 
-        if (ShadowRenderingState.areShadowsCurrentlyBeingRendered()) {
+        final boolean isShadow = ShadowRenderingState.areShadowsCurrentlyBeingRendered();
+        if (isShadow) {
             if (celeritasPipeline != null && !celeritasPipeline.hasShadowPass()) {
                 throw new IllegalStateException("Shadow program requested, but shader pack has no shadow pass");
             }
-            if (pass.isReverseOrder()) {
-                return programs.get(IrisTerrainPass.SHADOW_TRANSLUCENT);
-            }
-            return programs.get(pass.supportsFragmentDiscard() ? IrisTerrainPass.SHADOW_CUTOUT : IrisTerrainPass.SHADOW);
-        } else {
-            if (pass.supportsFragmentDiscard()) {
-                return programs.get(IrisTerrainPass.GBUFFER_CUTOUT);
-            } else if (pass.isReverseOrder()) {
-                return programs.get(IrisTerrainPass.GBUFFER_TRANSLUCENT);
-            } else {
-                return programs.get(IrisTerrainPass.GBUFFER_SOLID);
-            }
         }
+
+        return programs.get(IrisTerrainPass.fromTerrainPass(pass, isShadow));
     }
 
     public void deleteShaders() {

--- a/shader/src/main/java/net/coderbot/iris/celeritas/IrisCeleritasChunkShaderInterface.java
+++ b/shader/src/main/java/net/coderbot/iris/celeritas/IrisCeleritasChunkShaderInterface.java
@@ -106,7 +106,7 @@ public class IrisCeleritasChunkShaderInterface implements ChunkShaderInterface {
 
         if (!depthStateOverridden) {
             previousDepthTestEnabled = GLStateManager.glIsEnabled(GL11.GL_DEPTH_TEST);
-            previousDepthMaskEnabled = GLStateManager.getDepthState().isEnabled();
+            previousDepthMaskEnabled = GLStateManager.getDepthState().isMaskEnabled();
             previousDepthFunc = GLStateManager.getDepthState().getFunc();
             depthStateOverridden = true;
         }
@@ -114,10 +114,7 @@ public class IrisCeleritasChunkShaderInterface implements ChunkShaderInterface {
         // Hand and fullscreen passes can leave depth disabled or mask writes off before terrain draws.
         GLStateManager.enableDepthTest();
         GLStateManager.glDepthFunc(GL11.GL_LEQUAL);
-        // Opaque terrain passes and the shadow-map pass write depth; the main translucent pass does not.
-        // Forcing depth writes on the translucent pass makes glass windows (EnderIO fluid tanks, issue #58)
-        // occlude TESR geometry drawn behind them, unlike vanilla which leaves the depth mask off for that layer.
-        GLStateManager.glDepthMask(ShadowRenderingState.areShadowsCurrentlyBeingRendered() || !pass.isReverseOrder());
+        GLStateManager.glDepthMask(shouldWriteDepth(pass, ShadowRenderingState.areShadowsCurrentlyBeingRendered()));
 
         if (ShadowRenderingState.areShadowsCurrentlyBeingRendered()) {
             GLStateManager.disableCull();
@@ -159,6 +156,10 @@ public class IrisCeleritasChunkShaderInterface implements ChunkShaderInterface {
 
         customUniforms.push(this);
         IrisGlDebug.logCeleritasTerrainState(pass.name(), this.handle, alphaTestOverride != null, alphaReference);
+    }
+
+    public static boolean shouldWriteDepth(TerrainRenderPass pass, boolean shadowPass) {
+        return shadowPass || pass.writesDepth();
     }
 
     @Override
@@ -256,20 +257,7 @@ public class IrisCeleritasChunkShaderInterface implements ChunkShaderInterface {
         }
 
         final boolean isShadow = ShadowRenderingState.areShadowsCurrentlyBeingRendered();
-        final IrisTerrainPass irisPass;
-        if (isShadow) {
-            if (pass.isReverseOrder()) {
-                irisPass = IrisTerrainPass.SHADOW_TRANSLUCENT;
-            } else {
-                irisPass = pass.supportsFragmentDiscard() ? IrisTerrainPass.SHADOW_CUTOUT : IrisTerrainPass.SHADOW;
-            }
-        } else if (pass.isReverseOrder()) {
-            irisPass = IrisTerrainPass.GBUFFER_TRANSLUCENT;
-        } else if (pass.supportsFragmentDiscard()) {
-            irisPass = IrisTerrainPass.GBUFFER_CUTOUT;
-        } else {
-            irisPass = IrisTerrainPass.GBUFFER_SOLID;
-        }
+        final IrisTerrainPass irisPass = IrisTerrainPass.fromTerrainPass(pass, isShadow);
 
         final GlFramebuffer framebuffer = pipeline.getPassInfo(irisPass).framebuffer();
         if (framebuffer != null) {

--- a/shader/src/main/java/net/coderbot/iris/celeritas/IrisTerrainPass.java
+++ b/shader/src/main/java/net/coderbot/iris/celeritas/IrisTerrainPass.java
@@ -36,17 +36,10 @@ public enum IrisTerrainPass {
     }
 
     public static IrisTerrainPass fromTerrainPass(TerrainRenderPass pass, boolean isShadow) {
-        if (isShadow) {
-            if (pass.isReverseOrder()) {
-                return SHADOW_TRANSLUCENT;
-            }
-            return pass.supportsFragmentDiscard() ? SHADOW_CUTOUT : SHADOW;
-        } else if (pass.supportsFragmentDiscard()) {
-            return GBUFFER_CUTOUT;
-        } else if (pass.isReverseOrder()) {
-            return GBUFFER_TRANSLUCENT;
-        } else {
-            return GBUFFER_SOLID;
-        }
+        return switch (pass.semantic()) {
+            case WATER, TRANSLUCENT -> isShadow ? SHADOW_TRANSLUCENT : GBUFFER_TRANSLUCENT;
+            case CUTOUT -> isShadow ? SHADOW_CUTOUT : GBUFFER_CUTOUT;
+            case SOLID -> isShadow ? SHADOW : GBUFFER_SOLID;
+        };
     }
 }

--- a/shader/src/main/java/net/coderbot/iris/gl/blending/DepthColorStorage.java
+++ b/shader/src/main/java/net/coderbot/iris/gl/blending/DepthColorStorage.java
@@ -1,14 +1,13 @@
 package net.coderbot.iris.gl.blending;
 
 import com.gtnewhorizons.angelica.glsm.states.DepthState;
-import com.gtnewhorizons.angelica.glsm.states.ColorMask;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import lombok.Getter;
 
 public class DepthColorStorage {
 	private static boolean originalDepthEnable;
-	private static net.coderbot.iris.gl.blending.ColorMask originalColor;
+	private static ColorMask originalColor;
 	@Getter
     private static boolean depthColorLocked;
 
@@ -29,11 +28,11 @@ public class DepthColorStorage {
     public static void disableDepthColor() {
 		if (!depthColorLocked) {
 			// Only save the previous state if the depth and color mask wasn't already locked
-			final ColorMask colorMask = GLStateManager.getColorMask();
+			final var colorMask = GLStateManager.getColorMask();
 			final DepthState depthState = GLStateManager.getDepthState();
 
-			originalDepthEnable = depthState.isEnabled();
-			originalColor = new net.coderbot.iris.gl.blending.ColorMask(colorMask.red, colorMask.green, colorMask.blue, colorMask.alpha);
+            originalDepthEnable = depthState.isMaskEnabled();
+			originalColor = new ColorMask(colorMask.red, colorMask.green, colorMask.blue, colorMask.alpha);
 		}
 
 		depthColorLocked = false;
@@ -49,7 +48,7 @@ public class DepthColorStorage {
 	}
 
 	public static void deferColorMask(boolean red, boolean green, boolean blue, boolean alpha) {
-		originalColor = new net.coderbot.iris.gl.blending.ColorMask(red, green, blue, alpha);
+		originalColor = new ColorMask(red, green, blue, alpha);
 	}
 
 	public static void unlockDepthColor() {

--- a/src/main/java/com/dhj/actinium/render/terrain/VintageRenderPassConfigurationBuilder.java
+++ b/src/main/java/com/dhj/actinium/render/terrain/VintageRenderPassConfigurationBuilder.java
@@ -52,34 +52,50 @@ public class VintageRenderPassConfigurationBuilder {
 
     public static RenderPassConfiguration<BlockRenderLayer> build(ChunkVertexType vertexType) {
         // First, build the main passes
-        TerrainRenderPass solidPass, cutoutMippedPass, translucentPass;
+        TerrainRenderPass solidPass, cutoutMippedPass, translucentPass, fluidPass;
 
         solidPass = builderForRenderType(BlockRenderLayer.SOLID, vertexType, true)
                 .name("solid")
                 .fragmentDiscard(false)
                 .useReverseOrder(false)
+                .semantic(TerrainRenderPass.Semantic.SOLID)
+                .writesDepth(true)
                 .build();
         cutoutMippedPass = builderForRenderType(BlockRenderLayer.CUTOUT_MIPPED, vertexType, true)
                 .name("cutout_mipped")
                 .fragmentDiscard(true)
                 .useReverseOrder(false)
+                .semantic(TerrainRenderPass.Semantic.CUTOUT)
+                .writesDepth(true)
+                .build();
+        fluidPass = builderForRenderType(BlockRenderLayer.TRANSLUCENT, vertexType, true)
+                .name("water")
+                .fragmentDiscard(false)
+                .useReverseOrder(true)
+                .semantic(TerrainRenderPass.Semantic.WATER)
+                .writesDepth(true)
+                .useTranslucencySorting(ActiniumRuntime.options().performance.useTranslucentFaceSorting)
                 .build();
         translucentPass = builderForRenderType(BlockRenderLayer.TRANSLUCENT, vertexType, true)
                 .name("translucent")
                 .fragmentDiscard(false)
                 .useReverseOrder(true)
+                .semantic(TerrainRenderPass.Semantic.TRANSLUCENT)
+                .writesDepth(false)
                 .useTranslucencySorting(ActiniumRuntime.options().performance.useTranslucentFaceSorting)
                 .build();
 
         ImmutableListMultimap.Builder<BlockRenderLayer, TerrainRenderPass> vanillaRenderStages = ImmutableListMultimap.builder();
 
         // Build the materials for the vanilla render passes
-        Material solidMaterial, cutoutMaterial, cutoutMippedMaterial, translucentMaterial;
+        Material solidMaterial, cutoutMaterial, cutoutMippedMaterial, translucentMaterial, fluidMaterial;
         solidMaterial = new Material(solidPass, AlphaCutoffParameter.ZERO, true);
         translucentMaterial = new Material(translucentPass, AlphaCutoffParameter.ZERO, true);
+        fluidMaterial = new Material(fluidPass, AlphaCutoffParameter.ZERO, true);
         cutoutMippedMaterial = new Material(cutoutMippedPass, AlphaCutoffParameter.ONE_TENTH, true);
 
         vanillaRenderStages.put(BlockRenderLayer.SOLID, solidPass);
+        vanillaRenderStages.put(BlockRenderLayer.TRANSLUCENT, fluidPass);
         vanillaRenderStages.put(BlockRenderLayer.TRANSLUCENT, translucentPass);
 
         if (ActiniumRuntime.options().performance.useRenderPassConsolidation) {
@@ -93,6 +109,8 @@ public class VintageRenderPassConfigurationBuilder {
                     .name("cutout")
                     .fragmentDiscard(true)
                     .useReverseOrder(false)
+                    .semantic(TerrainRenderPass.Semantic.CUTOUT)
+                    .writesDepth(true)
                     .build();
 
             cutoutMaterial = new Material(cutoutPass, AlphaCutoffParameter.ONE_TENTH, false);
@@ -112,7 +130,7 @@ public class VintageRenderPassConfigurationBuilder {
         for (BlockRenderLayer layer : BlockRenderLayer.values()) {
             if (!renderTypeToMaterialMap.containsKey(layer)) {
                 ActiniumRuntime.logger().warn("Falling back to cutout-like behavior for custom block render layer '{}'", layer);
-                TerrainRenderPass pass = builderForRenderType(layer, vertexType, true).name(layer.name().toLowerCase(Locale.ROOT)).fragmentDiscard(true).useReverseOrder(false).build();
+                TerrainRenderPass pass = builderForRenderType(layer, vertexType, true).name(layer.name().toLowerCase(Locale.ROOT)).fragmentDiscard(true).useReverseOrder(false).semantic(TerrainRenderPass.Semantic.CUTOUT).writesDepth(true).build();
                 Material material = new Material(pass, AlphaCutoffParameter.ONE_TENTH, true);
                 vanillaRenderStages.put(layer, pass);
                 renderTypeToMaterialMap.put(layer, material);
@@ -125,7 +143,8 @@ public class VintageRenderPassConfigurationBuilder {
                 vanillaRenderStageMap.asMap(),
                 solidMaterial,
                 cutoutMippedMaterial,
-                translucentMaterial);
+                translucentMaterial,
+                fluidMaterial);
     }
 }
 

--- a/src/main/java/com/dhj/actinium/render/terrain/compile/VintageChunkBuildContext.java
+++ b/src/main/java/com/dhj/actinium/render/terrain/compile/VintageChunkBuildContext.java
@@ -9,6 +9,7 @@ import org.embeddedt.embeddium.api.shader.vertex.BlockRenderContext;
 import org.embeddedt.embeddium.api.shader.vertex.ContextAwareChunkVertexEncoder;
 import org.embeddedt.embeddium.api.shader.vertex.ExtendedDataHelper;
 import lombok.Getter;
+import net.coderbot.iris.block_rendering.BlockMaterialMapping;
 import net.coderbot.iris.block_rendering.BlockRenderingSettings;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
@@ -42,6 +43,9 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+
+import static net.minecraft.block.material.Material.LAVA;
+import static net.minecraft.block.material.Material.WATER;
 
 import static com.mitchej123.lwjgl.LWJGLServiceProvider.LWJGL;
 
@@ -107,8 +111,9 @@ public class VintageChunkBuildContext extends ChunkBuildContext {
             List<VanillaQuadContext> quadContexts = bufferBuilder instanceof BufferBuilderExtension extension
                     ? extension.actinium$consumeQuadContexts()
                     : Collections.emptyList();
-            var material = buffers.getRenderPassConfiguration().getMaterialForRenderType(LAYERS[i]);
-            copyBlockData(rawBuffer, buffers, material, quadContexts);
+            BlockRenderLayer layer = LAYERS[i];
+            var material = buffers.getRenderPassConfiguration().getMaterialForRenderType(layer);
+            copyBlockData(rawBuffer, buffers, material, layer, quadContexts);
         }
     }
 
@@ -124,7 +129,7 @@ public class VintageChunkBuildContext extends ChunkBuildContext {
         if (nbtBlockId != -1) {
             shaderBlockId = nbtBlockId;
         }
-        short renderType = state.getMaterial() == net.minecraft.block.material.Material.WATER
+        short renderType = state.getMaterial() == WATER || state.getMaterial() == LAVA
                 ? ExtendedDataHelper.FLUID_RENDER_TYPE
                 : ExtendedDataHelper.BLOCK_RENDER_TYPE;
 
@@ -200,7 +205,7 @@ public class VintageChunkBuildContext extends ChunkBuildContext {
         BLOCK_VERTEX_FORMAT_SIZE = size;
     }
 
-    private void copyBlockData(ByteBuffer source, ChunkBuildBuffers buffers, Material material, List<VanillaQuadContext> quadContexts) {
+    private void copyBlockData(ByteBuffer source, ChunkBuildBuffers buffers, Material material, BlockRenderLayer layer, List<VanillaQuadContext> quadContexts) {
         int vsize = BLOCK_VERTEX_FORMAT_SIZE;
         int numQuads = source.limit() / (vsize * 4);
         long ptr = LWJGL.memAddress(source);
@@ -236,7 +241,14 @@ public class VintageChunkBuildContext extends ChunkBuildContext {
             VanillaQuadContext quadContext = q < quadContexts.size() ? quadContexts.get(q) : null;
             boolean isFluidQuad = quadContext != null && quadContext.renderType() == ExtendedDataHelper.FLUID_RENDER_TYPE;
             Material optimizedMaterial = selectMaterial(material, sprite);
-            Material correctMaterial = isFluidQuad ? material : optimizedMaterial;
+            Material correctMaterial;
+            if (isFluidQuad) {
+                correctMaterial = layer == BlockRenderLayer.TRANSLUCENT
+                        ? buffers.getRenderPassConfiguration().defaultFluidMaterial()
+                        : material;
+            } else {
+                correctMaterial = optimizedMaterial;
+            }
 
             ChunkModelBuilder builder = buffers.get(correctMaterial);
             ContextAwareChunkVertexEncoder encoder = this.prepareVanillaEncoder(builder, quadContext);
@@ -284,7 +296,7 @@ public class VintageChunkBuildContext extends ChunkBuildContext {
         if (BlockRenderingSettings.INSTANCE.hasSnowyEntries()
                 && BlockRenderingSettings.INSTANCE.getSnowyBlocks().contains(state.getBlock())
                 && isSnowCovered(pos)) {
-            return metadata | net.coderbot.iris.block_rendering.BlockMaterialMapping.SNOWY_META_BIT;
+            return metadata | BlockMaterialMapping.SNOWY_META_BIT;
         }
 
         return metadata;

--- a/src/main/java/com/dhj/actinium/render/terrain/compile/pipeline/VintageBlockRenderer.java
+++ b/src/main/java/com/dhj/actinium/render/terrain/compile/pipeline/VintageBlockRenderer.java
@@ -41,6 +41,7 @@ import org.embeddedt.embeddium.api.shader.vertex.ContextAwareChunkVertexEncoder;
 import org.embeddedt.embeddium.api.shader.vertex.ExtendedDataHelper;
 import org.embeddedt.embeddium.api.shader.ShaderProvider;
 import org.embeddedt.embeddium.api.shader.ShaderProviderHolder;
+import net.coderbot.iris.block_rendering.BlockMaterialMapping;
 import net.coderbot.iris.block_rendering.BlockRenderingSettings;
 import com.dhj.actinium.runtime.ActiniumRuntime;
 import com.dhj.actinium.world.cloned.ActiniumBlockAccess;
@@ -56,6 +57,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+
+import static net.minecraft.block.material.Material.LAVA;
+import static net.minecraft.block.material.Material.WATER;
 
 public class VintageBlockRenderer {
     private final BlockModelShapes shapes;
@@ -120,7 +124,10 @@ public class VintageBlockRenderer {
         this.currentRenderLayer = layer;
 
         var buffers = this.context.buffers;
-        var material = buffers.getRenderPassConfiguration().getMaterialForRenderType(layer);
+        boolean isFluid = state.getMaterial() == WATER || state.getMaterial() == LAVA;
+        var material = isFluid && layer == BlockRenderLayer.TRANSLUCENT
+                ? buffers.getRenderPassConfiguration().defaultFluidMaterial()
+                : buffers.getRenderPassConfiguration().getMaterialForRenderType(layer);
         var buffer = buffers.get(material);
 
         long rand = MathHelper.getPositionRandom(pos);
@@ -228,7 +235,9 @@ public class VintageBlockRenderer {
 
             ModelQuadOrientation orientation = ModelQuadOrientation.NORMAL;
 
-            var quadMaterial = BakedQuadGroupAnalyzer.chooseOptimalMaterial(this.currentQuadRenderingFlags, material, config, BakedQuadView.of(quad));
+            var quadMaterial = isCurrentFluid()
+                    ? material
+                    : BakedQuadGroupAnalyzer.chooseOptimalMaterial(this.currentQuadRenderingFlags, material, config, BakedQuadView.of(quad));
             ChunkModelBuilder buffer = (quadMaterial == material) ? defaultBuffer : buffers.get(quadMaterial);
             this.prepareEncoder(buffer, pos);
 
@@ -255,8 +264,7 @@ public class VintageBlockRenderer {
 
         Block block = this.currentState.getBlock();
         byte lightValue = (byte) this.currentState.getLightValue(this.currentBlockAccess, pos);
-        boolean isFluid = this.currentState.getMaterial() == net.minecraft.block.material.Material.WATER
-                || this.currentState.getMaterial() == net.minecraft.block.material.Material.LAVA;
+        boolean isFluid = isCurrentFluid();
         int blockId = Block.getIdFromBlock(block);
         short renderType = isFluid
                 ? ExtendedDataHelper.FLUID_RENDER_TYPE
@@ -286,11 +294,15 @@ public class VintageBlockRenderer {
         this.usedContextEncoders.add(encoder);
     }
 
+    private boolean isCurrentFluid() {
+        return this.currentState.getMaterial() == WATER || this.currentState.getMaterial() == LAVA;
+    }
+
     private int applyShaderStateBits(IBlockState state, BlockPos pos, ActiniumBlockAccess blockAccess, int metadata) {
         if (BlockRenderingSettings.INSTANCE.hasSnowyEntries()
                 && BlockRenderingSettings.INSTANCE.getSnowyBlocks().contains(state.getBlock())
                 && isSnowCovered(blockAccess, pos)) {
-            return metadata | net.coderbot.iris.block_rendering.BlockMaterialMapping.SNOWY_META_BIT;
+            return metadata | BlockMaterialMapping.SNOWY_META_BIT;
         }
 
         return metadata;

--- a/src/test/java/org/embeddedt/embeddium/impl/render/chunk/terrain/TerrainRenderPassTest.java
+++ b/src/test/java/org/embeddedt/embeddium/impl/render/chunk/terrain/TerrainRenderPassTest.java
@@ -1,0 +1,233 @@
+package org.embeddedt.embeddium.impl.render.chunk.terrain;
+
+import net.coderbot.iris.celeritas.IrisTerrainPass;
+import net.coderbot.iris.celeritas.IrisCeleritasChunkShaderInterface;
+import net.minecraft.util.BlockRenderLayer;
+import org.embeddedt.embeddium.impl.render.chunk.RenderPassConfiguration;
+import org.embeddedt.embeddium.impl.render.chunk.compile.sorting.QuadPrimitiveType;
+import org.embeddedt.embeddium.impl.render.chunk.terrain.material.Material;
+import org.embeddedt.embeddium.impl.render.chunk.terrain.material.parameters.AlphaCutoffParameter;
+import org.embeddedt.embeddium.impl.render.chunk.vertex.format.ChunkMeshFormats;
+import org.embeddedt.embeddium.impl.render.chunk.vertex.format.ChunkVertexType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Verifies the public configuration contract used to classify terrain render passes.
+ */
+class TerrainRenderPassTest {
+    /**
+     * Explicit depth writes must remain observable independently from the legacy pass shape.
+     */
+    @ParameterizedTest(name = "{0} keeps explicit writesDepth={1}")
+    @MethodSource("explicitDepthWriteCases")
+    void preservesExplicitDepthWrite(
+            String name,
+            boolean writesDepth,
+            boolean reverseOrder,
+            boolean fragmentDiscard
+    ) {
+        TerrainRenderPass pass = TerrainRenderPass.builder()
+                .name(name)
+                .writesDepth(writesDepth)
+                .useReverseOrder(reverseOrder)
+                .fragmentDiscard(fragmentDiscard)
+                .primitiveType(QuadPrimitiveType.TRIANGULATED)
+                .vertexType(ChunkMeshFormats.COMPACT)
+                .build();
+
+        assertEquals(writesDepth, pass.writesDepth());
+    }
+
+    /**
+     * Legacy pass definitions derive their depth policy from the draw order.
+     */
+    @ParameterizedTest(name = "legacy {0} derives writesDepth={1}")
+    @MethodSource("legacyDepthWriteCases")
+    void derivesLegacyDepthWrite(String name, boolean writesDepth, boolean reverseOrder) {
+        TerrainRenderPass pass = TerrainRenderPass.builder()
+                .name(name)
+                .useReverseOrder(reverseOrder)
+                .fragmentDiscard(false)
+                .primitiveType(QuadPrimitiveType.TRIANGULATED)
+                .vertexType(ChunkMeshFormats.COMPACT)
+                .build();
+
+        assertEquals(writesDepth, pass.writesDepth());
+    }
+
+    /**
+     * Main terrain pass classification must preserve opaque, cutout, translucent, and water semantics.
+     */
+    @ParameterizedTest(name = "main {0} maps to {1}")
+    @MethodSource("mainPassSemantics")
+    void classifiesMainPassSemantics(
+            String name,
+            boolean writesDepth,
+            boolean reverseOrder,
+            boolean fragmentDiscard,
+            TerrainRenderPass.Semantic semantic,
+            IrisTerrainPass expected,
+            String expectedShaderPass
+    ) {
+        TerrainRenderPass pass = pass(name, writesDepth, reverseOrder, fragmentDiscard, semantic);
+
+        assertEquals(semantic, pass.semantic());
+        assertEquals(expected, IrisTerrainPass.fromTerrainPass(pass, false));
+        assertEquals(expectedShaderPass, expected.getName());
+    }
+
+    /**
+     * Shadow pass classification must use explicit depth writes, including shadow water.
+     */
+    @ParameterizedTest(name = "shadow {0} maps to {1}")
+    @MethodSource("shadowPassSemantics")
+    void classifiesShadowPassSemantics(
+            String name,
+            boolean writesDepth,
+            boolean reverseOrder,
+            boolean fragmentDiscard,
+            TerrainRenderPass.Semantic semantic,
+            IrisTerrainPass expected,
+            String expectedShaderPass
+    ) {
+        TerrainRenderPass pass = pass(name, writesDepth, reverseOrder, fragmentDiscard, semantic);
+
+        assertEquals(semantic, pass.semantic());
+        assertEquals(expected, IrisTerrainPass.fromTerrainPass(pass, true));
+        assertEquals(expectedShaderPass, expected.getName());
+    }
+
+    private static Stream<Arguments> mainPassSemantics() {
+        return Stream.of(
+                Arguments.of("opaque", true, false, false, TerrainRenderPass.Semantic.SOLID, IrisTerrainPass.GBUFFER_SOLID, "gbuffers_terrain"),
+                Arguments.of("cutout", true, false, true, TerrainRenderPass.Semantic.CUTOUT, IrisTerrainPass.GBUFFER_CUTOUT, "gbuffers_terrain_cutout"),
+                Arguments.of("translucent", false, true, false, TerrainRenderPass.Semantic.TRANSLUCENT, IrisTerrainPass.GBUFFER_TRANSLUCENT, "gbuffers_water"),
+                Arguments.of("water", true, true, false, TerrainRenderPass.Semantic.WATER, IrisTerrainPass.GBUFFER_TRANSLUCENT, "gbuffers_water")
+        );
+    }
+
+    private static Stream<Arguments> explicitDepthWriteCases() {
+        return Stream.of(
+                Arguments.of("opaque", false, false, false),
+                Arguments.of("cutout", false, false, true),
+                Arguments.of("translucent", true, true, false),
+                Arguments.of("water", true, true, false),
+                Arguments.of("shadow", false, false, true)
+        );
+    }
+
+    private static Stream<Arguments> legacyDepthWriteCases() {
+        return Stream.of(
+                Arguments.of("solid", true, false),
+                Arguments.of("translucent", false, true)
+        );
+    }
+
+    private static Stream<Arguments> shadowPassSemantics() {
+        return Stream.of(
+                Arguments.of("shadow", true, false, false, TerrainRenderPass.Semantic.SOLID, IrisTerrainPass.SHADOW, "shadow"),
+                Arguments.of("shadow_cutout", true, false, true, TerrainRenderPass.Semantic.CUTOUT, IrisTerrainPass.SHADOW_CUTOUT, "shadow"),
+                Arguments.of("shadow_water", true, true, false, TerrainRenderPass.Semantic.WATER, IrisTerrainPass.SHADOW_TRANSLUCENT, "shadow_water")
+        );
+    }
+
+    @ParameterizedTest(name = "{0} shadow={1} writes depth={2}")
+    @MethodSource("depthWritePolicies")
+    void appliesDepthWritePolicy(String name, boolean shadowPass, boolean expected) {
+        TerrainRenderPass pass = pass(name, expected, shadowPass, false);
+
+        assertEquals(expected, IrisCeleritasChunkShaderInterface.shouldWriteDepth(pass, shadowPass));
+    }
+
+    private static Stream<Arguments> depthWritePolicies() {
+        return Stream.of(
+                Arguments.of("translucent", false, false),
+                Arguments.of("water", false, true),
+                Arguments.of("shadow translucent", true, true)
+        );
+    }
+
+    @Test
+    void sharedTranslucentShaderUsesDefaultTranslucentVertexContract() {
+        TerrainRenderPass translucentPass = pass(
+                "translucent",
+                false,
+                true,
+                false,
+                TerrainRenderPass.Semantic.TRANSLUCENT,
+                ChunkMeshFormats.COMPACT
+        );
+        TerrainRenderPass fluidPass = pass(
+                "water",
+                true,
+                true,
+                false,
+                TerrainRenderPass.Semantic.WATER,
+                ChunkMeshFormats.VANILLA_LIKE
+        );
+        Material translucent = new Material(translucentPass, AlphaCutoffParameter.ZERO, true);
+        Material fluid = new Material(fluidPass, AlphaCutoffParameter.ZERO, true);
+        RenderPassConfiguration<BlockRenderLayer> configuration = new RenderPassConfiguration<>(
+                Map.of(BlockRenderLayer.TRANSLUCENT, translucent),
+                Map.of(BlockRenderLayer.TRANSLUCENT, List.of(translucentPass, fluidPass)),
+                translucent,
+                translucent,
+                translucent,
+                fluid
+        );
+
+        assertSame(translucentPass, IrisTerrainPass.GBUFFER_TRANSLUCENT.toTerrainPass(configuration));
+        assertSame(translucentPass, IrisTerrainPass.SHADOW_TRANSLUCENT.toTerrainPass(configuration));
+    }
+
+    private static TerrainRenderPass pass(
+            String name,
+            boolean writesDepth,
+            boolean reverseOrder,
+            boolean fragmentDiscard
+    ) {
+        return pass(name, writesDepth, reverseOrder, fragmentDiscard, null, ChunkMeshFormats.COMPACT);
+    }
+
+    private static TerrainRenderPass pass(
+            String name,
+            boolean writesDepth,
+            boolean reverseOrder,
+            boolean fragmentDiscard,
+            TerrainRenderPass.Semantic semantic
+    ) {
+        return pass(name, writesDepth, reverseOrder, fragmentDiscard, semantic, ChunkMeshFormats.COMPACT);
+    }
+
+    private static TerrainRenderPass pass(
+            String name,
+            boolean writesDepth,
+            boolean reverseOrder,
+            boolean fragmentDiscard,
+            TerrainRenderPass.Semantic semantic,
+            ChunkVertexType vertexType
+    ) {
+        TerrainRenderPass.TerrainRenderPassBuilder builder = TerrainRenderPass.builder()
+                .name(name)
+                .writesDepth(writesDepth)
+                .useReverseOrder(reverseOrder)
+                .fragmentDiscard(fragmentDiscard)
+                .primitiveType(QuadPrimitiveType.TRIANGULATED)
+                .vertexType(vertexType);
+        if (semantic != null) {
+            builder.semantic(semantic);
+        }
+        return builder.build();
+    }
+}


### PR DESCRIPTION
## What

- Add explicit terrain pass semantics and depth-write policies.
- Split water/fluid terrain from ordinary translucent terrain: water writes depth, while ordinary translucent terrain keeps depth writes disabled.
- Keep both passes on Iris `gbuffers_water` / `shadow_water` shader programs and preserve shader-pack layer overrides.
- Add regression coverage for pass classification, depth policies, and the shared translucent vertex contract.

## Why

The earlier Bliss/Eclipse water fix forced depth writes for translucent terrain. A later EnderIO fluid-tank fix disabled depth writes for the whole translucent pass, which restored TESR fluid rendering but regressed water transparency. This PR isolates the two behaviors so both fixes remain effective.

## How verified

- `./gradlew :test --tests 'org.embeddedt.embeddium.impl.render.chunk.terrain.TerrainRenderPassTest' --rerun-tasks --no-daemon` - passed.
- `./gradlew check --no-daemon` - passed.
- `./gradlew build --no-daemon` - passed.
- Java 25 with `GRADLE_USER_HOME=D:/gradle`.
- Manual acceptance completed by the requester for Bliss/Eclipse water transparency and EnderIO fluid-tank rendering behavior.

## Commits

- `fix(shader): restore water depth writes`