### PR TITLE
fix(shader): keep entity shadows bound to their casters

### DIFF
--- a/shader/src/main/java/net/coderbot/iris/celeritas/WorldRendererCompat.java
+++ b/shader/src/main/java/net/coderbot/iris/celeritas/WorldRendererCompat.java
@@ -19,6 +19,11 @@ public interface WorldRendererCompat {
 
     String getChunksDebugString();
 
+    /**
+     * Returns the viewport active before a temporary shadow-pass viewport is installed.
+     */
+    Viewport getCurrentViewport();
+
     void setCurrentViewport(Viewport viewport);
 
     void drawChunkLayer(BlockRenderLayer renderLayer, double x, double y, double z);

--- a/shader/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
+++ b/shader/src/main/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipeline.java
@@ -878,12 +878,12 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 	public void beginPass(Pass pass) {
         WorldRenderingPhase activePhase = getPhase();
         int previousProgram = getActivePassProgramId();
-		int nextProgram = pass != null && pass.getProgram() != null ? pass.getProgram().getProgramId() : -1;
+		int nextProgram = getPassProgramId(pass == null ? null : pass.getProgram());
 
 		if (current == pass) {
-			if (IrisGlDebug.shouldCaptureGlState()) {
+			if (shouldCheckCurrentProgram(activePhase, isRenderingShadow)) {
 				int currentProgram = GL11.glGetInteger(GL20.GL_CURRENT_PROGRAM);
-				if (currentProgram != nextProgram) {
+				if (shouldRebindPass(activePhase, isRenderingShadow, currentProgram, nextProgram)) {
 					if (pass != null) {
 						pass.use();
 					} else {
@@ -916,6 +916,52 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
         if (activePhase == WorldRenderingPhase.ENTITIES || activePhase == WorldRenderingPhase.BLOCK_ENTITIES || isRenderingShadow) {
             IrisGlDebug.logPassBind("begin-pass", activePhase.name(), previousProgram, nextProgram);
         }
+	}
+
+	/**
+	 * Limits GL program queries to phases where entity renderers can bypass pipeline ownership.
+	 */
+	static boolean shouldCheckCurrentProgram(WorldRenderingPhase activePhase, boolean renderingShadow) {
+		return renderingShadow
+			|| activePhase == WorldRenderingPhase.ENTITIES
+			|| activePhase == WorldRenderingPhase.BLOCK_ENTITIES;
+	}
+
+	/**
+	 * Determines whether the cached pass must be rebound after an external program change.
+	 */
+	static boolean shouldRebindPass(WorldRenderingPhase activePhase, boolean renderingShadow, int currentProgram, int nextProgram) {
+		return shouldCheckCurrentProgram(activePhase, renderingShadow) && currentProgram != nextProgram;
+	}
+
+	/**
+	 * Returns the GL program expected for a pass; a null program is the default pass and maps to program 0.
+	 */
+	static int getPassProgramId(@Nullable Program program) {
+		return program == null ? 0 : program.getProgramId();
+	}
+
+	/**
+	 * Runs a shadow pass and retains its failure if cleanup fails as well.
+	 */
+	static void runShadowPassWithCleanup(Runnable shadowPass, Runnable cleanup) {
+		Throwable shadowFailure = null;
+		try {
+			shadowPass.run();
+		} catch (RuntimeException | Error exception) {
+			shadowFailure = exception;
+			throw exception;
+		} finally {
+			try {
+				cleanup.run();
+			} catch (RuntimeException | Error cleanupFailure) {
+				if (shadowFailure != null) {
+					shadowFailure.addSuppressed(cleanupFailure);
+				} else {
+					throw cleanupFailure;
+				}
+			}
+		}
 	}
 
 	@Override
@@ -1238,6 +1284,8 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 
 			if (program != null) {
 				program.use();
+			} else {
+				Program.unbind();
 			}
 
 			DeferredWorldRenderingPipeline.this.customUniforms.push(this);
@@ -1657,16 +1705,24 @@ public class DeferredWorldRenderingPipeline implements WorldRenderingPipeline, R
 
 		if (shadowRenderer != null) {
 			isRenderingShadow = true;
-			matchPass();  // Ensure shadow shader is bound for entity rendering
-            IrisGlDebug.check("level:shadows:match-pass");
+			try {
+				runShadowPassWithCleanup(
+					() -> {
+						matchPass();  // Ensure shadow shader is bound for entity rendering
+                        IrisGlDebug.check("level:shadows:match-pass");
 
-			shadowRenderer.renderShadows(levelRenderer, playerCamera);
-            IrisGlDebug.check("level:shadows:render");
-
-			// needed to remove blend mode overrides and similar
-			beginPass(null);
-            IrisGlDebug.check("level:shadows:begin-pass-null");
-			isRenderingShadow = false;
+						shadowRenderer.renderShadows(levelRenderer, playerCamera);
+                        IrisGlDebug.check("level:shadows:render");
+					},
+					() -> {
+						// needed to remove blend mode overrides and similar
+						beginPass(null);
+                        IrisGlDebug.check("level:shadows:begin-pass-null");
+					}
+				);
+			} finally {
+				isRenderingShadow = false;
+			}
 		}
 
 		if (!shouldRenderPrepareBeforeShadow && !hasRenderedPreparePass) {

--- a/shader/src/main/java/net/coderbot/iris/pipeline/ShadowRenderer.java
+++ b/shader/src/main/java/net/coderbot/iris/pipeline/ShadowRenderer.java
@@ -52,6 +52,8 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.math.BlockPos;
 import org.embeddedt.embeddium.impl.gl.device.RenderDevice;
+import org.embeddedt.embeddium.impl.render.terrain.SimpleWorldRenderer;
+import org.embeddedt.embeddium.impl.render.viewport.Viewport;
 import org.embeddedt.embeddium.impl.render.viewport.ViewportProvider;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
@@ -194,7 +196,7 @@ public class ShadowRenderer {
 	}
 
 	public static MatrixStack createShadowModelView(float sunPathRotation, float intervalSize) {
-		final Vector3d entityPos = getShadowCameraAnchor(CapturedRenderingState.INSTANCE.getTickDelta());
+		final Vector3d entityPos = getShadowCameraAnchor();
 
 		// Set up our modelview matrix stack
 		final MatrixStack modelView = new MatrixStack();
@@ -203,16 +205,14 @@ public class ShadowRenderer {
 		return modelView;
 	}
 
-	private MatrixStack getShadowModelView() {
-		final Vector3d entityPos = getShadowCameraAnchor(CapturedRenderingState.INSTANCE.getTickDelta());
-
+	private MatrixStack getShadowModelView(Vector3d entityPos) {
 		shadowModelView.reset();
 		ShadowMatrices.createModelViewMatrix(shadowModelView, getShadowAngle(), this.intervalSize, this.sunPathRotation, entityPos.x, entityPos.y, entityPos.z);
 		return shadowModelView;
 	}
 
-	private static Vector3d getShadowCameraAnchor(float tickDelta) {
-		return Camera.INSTANCE.getEntityPos();
+	private static Vector3d getShadowCameraAnchor() {
+		return new Vector3d(Camera.INSTANCE.getEntityPos());
 	}
 
 	private static WorldClient getLevel() {
@@ -452,12 +452,21 @@ public class ShadowRenderer {
 		return cachedTileEntityCuller;
 	}
 
+	// State captured before setupGlState so a failed shadow pass cannot force the caller's defaults.
+	private boolean savedCullEnabled;
+	private boolean cullStateCaptured;
+	private boolean projectionMatrixPushed;
+
 	private void setupGlState(Matrix4f projMatrix) {
+		savedCullEnabled = GLStateManager.glIsEnabled(GL11.GL_CULL_FACE);
+		cullStateCaptured = true;
+
 		// Bind shadow framebuffer and set viewport to shadow resolution
 		targets.getDepthSourceFb().bind();
 		GLStateManager.glViewport(0, 0, resolution, resolution);
 
 		// Set up our projection matrix and load it into the legacy matrix stack
+		projectionMatrixPushed = true;
 		RenderSystem.setupProjectionMatrix(projMatrix);
 
 		// Disable backface culling
@@ -472,10 +481,18 @@ public class ShadowRenderer {
 
 	private void restoreGlState() {
 		// Restore backface culling
-        GLStateManager.enableCull();
+        if (cullStateCaptured && savedCullEnabled) {
+            GLStateManager.enableCull();
+        } else {
+            GLStateManager.disableCull();
+        }
+		cullStateCaptured = false;
 
 		// Make sure to unload the projection matrix
-		RenderSystem.restoreProjectionMatrix();
+		if (projectionMatrixPushed) {
+			RenderSystem.restoreProjectionMatrix();
+			projectionMatrixPushed = false;
+		}
 
 		// Restore main framebuffer and viewport
 		Minecraft mc = Minecraft.getMinecraft();
@@ -528,10 +545,13 @@ public class ShadowRenderer {
 	}
 
 	// Saved RenderManager position for shadow pass
-    private double savedRenderPosX, savedRenderPosY, savedRenderPosZ;
+	private double savedRenderPosX, savedRenderPosY, savedRenderPosZ;
     private double savedViewerPosX, savedViewerPosY, savedViewerPosZ;
     private boolean savedRenderShadow;
     private int savedMatrixMode;
+    private boolean savedPolygonOffsetFill;
+    private float savedPolygonOffsetFactor;
+    private float savedPolygonOffsetUnits;
     private final Matrix4f savedRenderingStateModelView = new Matrix4f();
     private final Matrix4f savedRenderingStateProjection = new Matrix4f();
 
@@ -544,6 +564,9 @@ public class ShadowRenderer {
         savedViewerPosY = renderManager.viewerPosY;
         savedViewerPosZ = renderManager.viewerPosZ;
         savedRenderShadow = renderManager.isRenderShadow();
+        savedPolygonOffsetFill = GLStateManager.glIsEnabled(GL11.GL_POLYGON_OFFSET_FILL);
+        savedPolygonOffsetFactor = GLStateManager.getPolygonState().getOffsetFactor();
+        savedPolygonOffsetUnits = GLStateManager.getPolygonState().getOffsetUnits();
 
         renderManager.setRenderPosition(cameraX, cameraY, cameraZ);
         renderManager.viewerPosX = cameraX;
@@ -583,8 +606,12 @@ public class ShadowRenderer {
         GLStateManager.glMatrixMode(savedMatrixMode);
         popShadowRenderingState();
 
-        GLStateManager.glDisable(GL11.GL_POLYGON_OFFSET_FILL);
-        GLStateManager.glPolygonOffset(0.0f, 0.0f);
+        if (savedPolygonOffsetFill) {
+            GLStateManager.glEnable(GL11.GL_POLYGON_OFFSET_FILL);
+        } else {
+            GLStateManager.glDisable(GL11.GL_POLYGON_OFFSET_FILL);
+        }
+        GLStateManager.glPolygonOffset(savedPolygonOffsetFactor, savedPolygonOffsetUnits);
 
         RenderManager renderManager = Minecraft.getMinecraft().getRenderManager();
         renderManager.setRenderPosition(savedRenderPosX, savedRenderPosY, savedRenderPosZ);
@@ -753,8 +780,9 @@ public class ShadowRenderer {
 		visibleTileEntities.clear();
 		globalTileEntities.clear();
 
-		// Create our camera
-		final MatrixStack modelView = getShadowModelView();
+		// Snapshot the camera anchor once so every shadow-pass consumer uses the same coordinate origin.
+		final Vector3d entityPos = new Vector3d(playerCamera.getEntityPos());
+		final MatrixStack modelView = getShadowModelView(entityPos);
 		MODELVIEW.set(modelView.peek().getModel());
 
 		final Matrix4f shadowProjection;
@@ -779,11 +807,20 @@ public class ShadowRenderer {
 			0
 		);
 
+		boolean cullingStateSaved = false;
+		boolean celeritasManaged = false;
+		boolean glStateSetup = false;
+		boolean glStateRestored = false;
+		boolean celeritasViewportCaptured = false;
+		WorldRendererCompat celeritasRenderer = null;
+		Viewport savedCeleritasViewport = null;
+
 		try {
 		profiler.startSection("terrain_setup");
 
 		if (levelRenderer instanceof CullingDataCache) {
 			((CullingDataCache) levelRenderer).saveState();
+			cullingStateSaved = true;
 		}
 
 		profiler.startSection("initialize frustum");
@@ -791,9 +828,8 @@ public class ShadowRenderer {
 		terrainFrustumHolder = createShadowFrustum(renderDistanceMultiplier, terrainFrustumHolder);
 		FRUSTUM = terrainFrustumHolder.getFrustum();
 
-		// Use the player/entity position for shadow rendering
+		// Use the frame-stable player/entity position for all shadow rendering origins.
 		final float tickDelta = CapturedRenderingState.INSTANCE.getTickDelta();
-		final Vector3d entityPos = playerCamera.getEntityPos();
 		final double entityX = entityPos.x;
 		final double entityY = entityPos.y;
 		final double entityZ = entityPos.z;
@@ -819,16 +855,17 @@ public class ShadowRenderer {
 
 		// Mark the shadow graph as needing update before terrain setup
 		// Modern Celeritas does this to ensure the shadow render lists get populated
-		boolean celeritasManaged = false;
 		if (IrisDebugOptions.enableCeleritas()) {
+			celeritasRenderer = WorldRendererCompatBridge.instance();
+			savedCeleritasViewport = celeritasRenderer.getCurrentViewport();
+			celeritasViewportCaptured = true;
 			RenderDevice.enterManagedCode();
 			celeritasManaged = true;
-			WorldRendererCompat renderer = WorldRendererCompatBridge.instance();
 			var terrainViewport = ((ViewportProvider)terrainFrustumHolder.getFrustum()).sodium$createViewport();
-			renderer.markSectionGraphDirty();
-			renderer.setupTerrain(
+			celeritasRenderer.markSectionGraphDirty();
+			celeritasRenderer.setupTerrain(
 				terrainViewport,
-				new org.embeddedt.embeddium.impl.render.terrain.SimpleWorldRenderer.CameraState(
+				new SimpleWorldRenderer.CameraState(
 					entityX,
 					entityY,
 					entityZ,
@@ -840,7 +877,7 @@ public class ShadowRenderer {
 				false,
 				false
 			);
-			renderer.setCurrentViewport(terrainViewport);
+			celeritasRenderer.setCurrentViewport(terrainViewport);
 		}
 
 		// Execute the vanilla terrain setup / culling routines using our shadow frustum.
@@ -853,6 +890,7 @@ public class ShadowRenderer {
 
 		profiler.endStartSection("terrain");
 
+		glStateSetup = true;
 		setupGlState(PROJECTION);
 
 		// Render all opaque terrain unless pack requests not to
@@ -885,8 +923,8 @@ public class ShadowRenderer {
 		entityShadowFrustum.setPosition(entityX, entityY, entityZ);
 
 		// Set viewport for entity visibility checks during shadow pass (matches modern Celeritas)
-		if (IrisDebugOptions.enableCeleritas()) {
-			WorldRendererCompatBridge.instance().setCurrentViewport(((ViewportProvider)entityShadowFrustum).sodium$createViewport());
+		if (celeritasRenderer != null) {
+			celeritasRenderer.setCurrentViewport(((ViewportProvider)entityShadowFrustum).sodium$createViewport());
 		}
 
 		// Render nearby entities
@@ -921,8 +959,11 @@ public class ShadowRenderer {
 		}
 
 		if (celeritasManaged) {
-			RenderDevice.exitManagedCode();
-			celeritasManaged = false;
+			try {
+				RenderDevice.exitManagedCode();
+			} finally {
+				celeritasManaged = false;
+			}
 		}
 
 		// Note: Apparently tripwire isn't rendered in the shadow pass.
@@ -938,10 +979,18 @@ public class ShadowRenderer {
 
 		profiler.endStartSection("restore gl state");
 
-		restoreGlState();
+		try {
+			restoreGlState();
+		} finally {
+			glStateRestored = true;
+		}
 
 		if (levelRenderer instanceof CullingDataCache) {
-			((CullingDataCache) levelRenderer).restoreState();
+			try {
+				((CullingDataCache) levelRenderer).restoreState();
+			} finally {
+				cullingStateSaved = false;
+			}
 		}
 
 		IrisGlDebug.logShadowPassState(
@@ -951,7 +1000,7 @@ public class ShadowRenderer {
 			shouldRenderEntities,
 			shouldRenderPlayer,
 			shouldRenderBlockEntities,
-			IrisDebugOptions.enableCeleritas() ? WorldRendererCompatBridge.instance().getVisibleChunkCount() : -1,
+			celeritasRenderer != null ? celeritasRenderer.getVisibleChunkCount() : -1,
 			renderedShadowEntities,
 			renderedShadowTileEntities
 		);
@@ -960,17 +1009,51 @@ public class ShadowRenderer {
 
 		if (compositeRenderer != null) compositeRenderer.renderAll();
 
-		if (celeritasManaged) {
-			RenderDevice.exitManagedCode();
-		}
 		ACTIVE = false;
 		CURRENT_TARGETS = null;
 		profiler.endSection();
 		profiler.endStartSection("updatechunks");
 		} finally {
-			InternalShadowRenderingState.end();
-			ACTIVE = false;
-			CURRENT_TARGETS = null;
+			try {
+				if (glStateSetup && !glStateRestored) {
+					try {
+						restoreGlState();
+					} finally {
+						glStateRestored = true;
+					}
+				}
+			} finally {
+				try {
+					if (celeritasManaged) {
+						try {
+							RenderDevice.exitManagedCode();
+						} finally {
+							celeritasManaged = false;
+						}
+					}
+				} finally {
+					try {
+						if (cullingStateSaved) {
+							try {
+								((CullingDataCache) levelRenderer).restoreState();
+							} finally {
+								cullingStateSaved = false;
+							}
+						}
+					} finally {
+						try {
+							if (celeritasViewportCaptured) {
+								celeritasRenderer.setCurrentViewport(savedCeleritasViewport);
+								celeritasViewportCaptured = false;
+							}
+						} finally {
+							InternalShadowRenderingState.end();
+							ACTIVE = false;
+							CURRENT_TARGETS = null;
+						}
+					}
+				}
+			}
 		}
 	}
 

--- a/src/main/java/com/dhj/actinium/render/terrain/ActiniumWorldRenderer.java
+++ b/src/main/java/com/dhj/actinium/render/terrain/ActiniumWorldRenderer.java
@@ -144,6 +144,11 @@ public class ActiniumWorldRenderer extends SimpleWorldRenderer<WorldClient, Vint
         this.currentViewport = viewport;
     }
 
+    @Override
+    public Viewport getCurrentViewport() {
+        return this.currentViewport;
+    }
+
     /**
      * Captures the iChun recursive terrain matrices while leaving ordinary and shadow rendering unchanged.
      */

--- a/src/test/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipelinePassBindingTest.java
+++ b/src/test/java/net/coderbot/iris/pipeline/DeferredWorldRenderingPipelinePassBindingTest.java
@@ -1,0 +1,91 @@
+package net.coderbot.iris.pipeline;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the pass-binding policy without requiring an OpenGL context.
+ */
+class DeferredWorldRenderingPipelinePassBindingTest {
+    @Test
+    void checksTheCurrentProgramForShadowRendering() {
+        assertTrue(DeferredWorldRenderingPipeline.shouldCheckCurrentProgram(WorldRenderingPhase.TERRAIN_SOLID, true));
+        assertTrue(DeferredWorldRenderingPipeline.shouldCheckCurrentProgram(WorldRenderingPhase.NONE, true));
+    }
+
+    @Test
+    void checksTheCurrentProgramForEntityPhases() {
+        assertTrue(DeferredWorldRenderingPipeline.shouldCheckCurrentProgram(WorldRenderingPhase.ENTITIES, false));
+        assertTrue(DeferredWorldRenderingPipeline.shouldCheckCurrentProgram(WorldRenderingPhase.BLOCK_ENTITIES, false));
+    }
+
+    @Test
+    void skipsTheCurrentProgramCheckForOrdinaryPhases() {
+        assertFalse(DeferredWorldRenderingPipeline.shouldCheckCurrentProgram(WorldRenderingPhase.TERRAIN_SOLID, false));
+        assertFalse(DeferredWorldRenderingPipeline.shouldCheckCurrentProgram(WorldRenderingPhase.SKY, false));
+    }
+
+    @Test
+    void rebindsOnlyWhenTheActualProgramDiffers() {
+        assertTrue(DeferredWorldRenderingPipeline.shouldRebindPass(
+            WorldRenderingPhase.TERRAIN_SOLID, true, 17, 23));
+        assertTrue(DeferredWorldRenderingPipeline.shouldRebindPass(
+            WorldRenderingPhase.ENTITIES, false, 17, 23));
+        assertTrue(DeferredWorldRenderingPipeline.shouldRebindPass(
+            WorldRenderingPhase.ENTITIES, false, 17, 0));
+        assertTrue(DeferredWorldRenderingPipeline.shouldRebindPass(
+            WorldRenderingPhase.TERRAIN_SOLID, true, 17, 0));
+        assertFalse(DeferredWorldRenderingPipeline.shouldRebindPass(
+            WorldRenderingPhase.BLOCK_ENTITIES, false, 23, 23));
+        assertFalse(DeferredWorldRenderingPipeline.shouldRebindPass(
+            WorldRenderingPhase.ENTITIES, false, 0, 0));
+        assertFalse(DeferredWorldRenderingPipeline.shouldRebindPass(
+            WorldRenderingPhase.TERRAIN_SOLID, true, 0, 0));
+        assertFalse(DeferredWorldRenderingPipeline.shouldRebindPass(
+            WorldRenderingPhase.TERRAIN_SOLID, false, 17, 23));
+    }
+
+    @Test
+    void treatsAProgramlessDefaultPassAsProgramZero() {
+        assertEquals(0, DeferredWorldRenderingPipeline.getPassProgramId(null));
+    }
+
+    @Test
+    void preservesTheShadowFailureWhenCleanupAlsoFails() {
+        RuntimeException shadowFailure = new RuntimeException("shadow failure");
+        RuntimeException cleanupFailure = new RuntimeException("cleanup failure");
+
+        RuntimeException thrown = assertThrows(RuntimeException.class, () ->
+            DeferredWorldRenderingPipeline.runShadowPassWithCleanup(
+                () -> {
+                    throw shadowFailure;
+                },
+                () -> {
+                    throw cleanupFailure;
+                }));
+
+        assertSame(shadowFailure, thrown);
+        assertEquals(1, thrown.getSuppressed().length);
+        assertSame(cleanupFailure, thrown.getSuppressed()[0]);
+    }
+
+    @Test
+    void propagatesCleanupFailureWhenShadowRenderingSucceeds() {
+        RuntimeException cleanupFailure = new RuntimeException("cleanup failure");
+
+        RuntimeException thrown = assertThrows(RuntimeException.class, () ->
+            DeferredWorldRenderingPipeline.runShadowPassWithCleanup(
+                () -> {
+                },
+                () -> {
+                    throw cleanupFailure;
+                }));
+
+        assertSame(cleanupFailure, thrown);
+    }
+}


### PR DESCRIPTION
## What

Fixes entity shadows detaching from their casters in shader packs (the shadow appearing as a small dark blob on nearby blocks):

- **Single camera anchor per shadow pass**: `ShadowRenderer#renderShadows` snapshots the player-camera position once; terrain setup, entity rendering and the shadow model-view matrix now share the same origin instead of reading drifting positions.
- **Reliable pass rebinding**: when a cached `Pass` object is unchanged but a third-party renderer overwrote `GL_CURRENT_PROGRAM`, `beginPass` now detects the mismatch during ENTITIES / BLOCK_ENTITIES / shadow phases and rebinds. The default (program-less) pass explicitly unbinds to program `0`.
- **Full GL state save/restore around the shadow pass**: backface-cull state, polygon offset factor/units and the Celeritas viewport are captured and restored, including on exception paths via nested `finally`.
- **Exception hygiene**: if shadow-pass cleanup fails, the original shadow failure is preserved via `addSuppressed` instead of being swallowed.

## Why

In packs like Bliss, entity shadows could detach from entities and render as a black spot on adjacent blocks. Root causes were inconsistent coordinate origins inside the shadow pass, stale program bindings after external GL program changes, and GL state leaking out of a failed/interrupted shadow pass. Reference implementations consulted: Iris, Sodium/Embeddium, Angelica.

## How verified

- New `DeferredWorldRenderingPipelinePassBindingTest` (7 direct-call tests, no source-contain checks): `.\gradlew.bat :test --tests "net.coderbot.iris.pipeline.DeferredWorldRenderingPipelinePassBindingTest" --rerun` ��?7/7 passed.
- `.\gradlew.bat check --no-daemon` BUILD SUCCESSFUL.
- Dev in-game regression with affected shader packs (Bliss etc.) is still pending and should be confirmed before merge.

Stacked on #80 (`chore/normalize-line-endings`); GitHub will retarget this PR to `main` once that branch merges.
