### PR TITLE
fix(shader): keep shader GUI sliders tracking the cursor

### DIFF
--- a/shader/src/main/java/net/coderbot/iris/gui/element/IrisGuiSlot.java
+++ b/shader/src/main/java/net/coderbot/iris/gui/element/IrisGuiSlot.java
@@ -10,6 +10,11 @@ import net.minecraft.client.renderer.Tessellator;
 public abstract class IrisGuiSlot extends GuiSlot {
     @Setter @Getter protected boolean renderBackground = true;
     boolean scrolling = false;
+    // Drag origin and scale: the handle tracks the cursor across the full track while
+    // the content crosses its whole scroll range (see ScrollBarGeometry).
+    private float scrollingFactor = 1.0F;
+    private float scrollingStartAmount;
+    private int scrollingStartMouseY;
 
     protected IrisGuiSlot(Minecraft mc, int width, int height, int top, int bottom, int slotHeight) {
         super(mc, width, height, top, bottom, slotHeight);
@@ -75,6 +80,9 @@ public abstract class IrisGuiSlot extends GuiSlot {
         if (mouseButton == 0 && mouseX >= scrollBarX && mouseX <= scrollBarX + 6) {
             scrolling = true;
             this.initialClickY = mouseY;
+            this.scrollingStartMouseY = mouseY;
+            this.scrollingStartAmount = this.amountScrolled;
+            this.scrollingFactor = ScrollBarGeometry.dragFactor(this.getContentHeight(), this.bottom - this.top, this.headerPadding);
             handled = true;
         } else if (mouseButton == 0 || mouseButton == 1) {
             final int index = relativeY / this.slotHeight;
@@ -112,8 +120,8 @@ public abstract class IrisGuiSlot extends GuiSlot {
     @Override
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
         if (this.scrolling) {
-            this.amountScrolled += (mouseY - this.initialClickY);
-            this.initialClickY = mouseY;
+            this.amountScrolled = this.scrollingStartAmount + (mouseY - this.scrollingStartMouseY) * this.scrollingFactor;
+            this.bindAmountScrolled();
         }
 
         super.drawScreen(mouseX, mouseY, partialTicks);

--- a/shader/src/main/java/net/coderbot/iris/gui/element/ScrollBarGeometry.java
+++ b/shader/src/main/java/net/coderbot/iris/gui/element/ScrollBarGeometry.java
@@ -1,0 +1,41 @@
+package net.coderbot.iris.gui.element;
+
+/**
+ * Pure math for the shader list scrollbar drag scaling.
+ *
+ * <p>Motivation: dragging the handle must map "handle travels the whole track" to
+ * "content scrolls from top to bottom", matching vanilla {@code GuiSlot}'s scroll
+ * multiplier. Without this factor both the handle and the content move 1:1 with the
+ * cursor, so on long lists the handle lags far behind the mouse and the bottom of the
+ * list cannot be reached within one screen height of dragging.</p>
+ */
+final class ScrollBarGeometry {
+	/** Minimum rendered handle height, matching vanilla GuiSlot's clamp. */
+	private static final int MIN_HANDLE_HEIGHT = 32;
+
+	private ScrollBarGeometry() {
+	}
+
+	/**
+	 * Content pixels scrolled per cursor pixel while dragging the handle, so the handle
+	 * crosses its full track exactly while the content crosses its full scroll range.
+	 *
+	 * @param contentHeight total list content height in GUI pixels
+	 * @param viewportHeight visible list height (bottom - top) in GUI pixels
+	 * @param headerPadding top padding that entries cannot scroll into
+	 * @return the drag scale factor
+	 */
+	static float dragFactor(int contentHeight, int viewportHeight, int headerPadding) {
+		int scrollable = contentHeight - (viewportHeight - headerPadding);
+		if (scrollable < 1) {
+			scrollable = 1;
+		}
+
+		// Handle height shrinks as the list grows, clamped like vanilla GuiSlot draws it
+		final int handleHeight = Math.min(
+			Math.max((int) ((float) viewportHeight * viewportHeight / contentHeight), MIN_HANDLE_HEIGHT),
+			viewportHeight - 8);
+
+		return (float) scrollable / (viewportHeight - handleHeight);
+	}
+}

--- a/shader/src/main/java/net/coderbot/iris/gui/element/widget/SliderElementWidget.java
+++ b/shader/src/main/java/net/coderbot/iris/gui/element/widget/SliderElementWidget.java
@@ -5,11 +5,9 @@ import net.coderbot.iris.shaderpack.option.menu.OptionMenuStringOptionElement;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.util.math.MathHelper;
 
 public class SliderElementWidget extends StringElementWidget {
 	private static final int PREVIEW_SLIDER_WIDTH = 4;
-	private static final int ACTIVE_SLIDER_WIDTH = 6;
 
 	private boolean mouseDown = false;
 
@@ -34,11 +32,9 @@ public class SliderElementWidget extends StringElementWidget {
 		}
 
 		if (this.mouseDown) {
-			// Release if the mouse went off the slider
-			if (!hovered) {
-				this.onReleased();
-			}
-
+			// The drag keeps tracking the cursor even when it leaves the row or widget,
+			// so the handle follows the mouse one-to-one; it only ends on mouse release
+			// (release events are broadcast to every widget, see ElementRowEntry).
 			whileDragging(x, width, mouseX);
 		}
 	}
@@ -51,12 +47,10 @@ public class SliderElementWidget extends StringElementWidget {
 		// Draw slider area
 		GuiUtil.drawButton(x + 2, y + 2, width - 4, height - 4, false, true);
 
-		// Range of x values the slider can occupy
-		final int sliderSpace = (width - 8) - ACTIVE_SLIDER_WIDTH;
 		// Position of slider
-		final int sliderPos = (x + 4) + (int)(((float)valueIndex / (valueCount - 1)) * sliderSpace);
+		final int sliderPos = SliderGeometry.sliderXForIndex(x, width, valueIndex, valueCount);
 		// Draw slider
-		GuiUtil.drawButton(sliderPos, y + 4, ACTIVE_SLIDER_WIDTH, height - 8, this.mouseDown, false);
+		GuiUtil.drawButton(sliderPos, y + 4, SliderGeometry.ACTIVE_SLIDER_WIDTH, height - 8, this.mouseDown, false);
 
 		// Draw value label
 		final FontRenderer font = Minecraft.getMinecraft().fontRenderer;
@@ -64,9 +58,7 @@ public class SliderElementWidget extends StringElementWidget {
 	}
 
 	private void whileDragging(int x, int width, int mouseX) {
-		final float mousePositionAcrossWidget = MathHelper.clamp((float)(mouseX - (x + 4)) / (width - 8), 0.0F, 1.0F);
-
-		final int newValueIndex = Math.min(valueCount - 1, (int)(mousePositionAcrossWidget * valueCount));
+		final int newValueIndex = SliderGeometry.valueIndexForMouseX(mouseX, x, width, valueCount);
 
 		if (valueIndex != newValueIndex) {
 			this.valueIndex = newValueIndex;

--- a/shader/src/main/java/net/coderbot/iris/gui/element/widget/SliderGeometry.java
+++ b/shader/src/main/java/net/coderbot/iris/gui/element/widget/SliderGeometry.java
@@ -1,0 +1,57 @@
+package net.coderbot.iris.gui.element.widget;
+
+/**
+ * Pure geometry shared by the shader option slider's rendering and dragging.
+ *
+ * <p>Motivation: the drag mapping must be the exact inverse of the render mapping,
+ * otherwise the handle visibly lags behind or jumps ahead of the cursor while dragging.
+ * Keeping both formulas in one dependency-free class lets that invariant be verified
+ * by unit tests without loading Minecraft client classes.</p>
+ */
+final class SliderGeometry {
+	/** Left inset of the slider track inside the widget, matching the widget texture border. */
+	static final int TRACK_INSET = 4;
+
+	/** Width of the draggable handle in its active (hovered) state. */
+	static final int ACTIVE_SLIDER_WIDTH = 6;
+
+	private SliderGeometry() {
+	}
+
+	/**
+	 * X coordinate of the handle's left edge for a value index, mirroring the formula
+	 * used to draw the handle so dragging can invert it exactly.
+	 *
+	 * @param x left edge of the widget
+	 * @param width width of the widget
+	 * @param index selected value index
+	 * @param valueCount number of allowed values (must be at least 2)
+	 */
+	static int sliderXForIndex(int x, int width, int index, int valueCount) {
+		// Range of x values the handle can occupy
+		final int sliderSpace = (width - 8) - ACTIVE_SLIDER_WIDTH;
+
+		return (x + TRACK_INSET) + (int) (((float) index / (valueCount - 1)) * sliderSpace);
+	}
+
+	/**
+	 * Value index selected by a cursor x position: the nearest value to the cursor,
+	 * using the same track geometry as {@link #sliderXForIndex}. Rounding (instead of
+	 * the previous floor-onto-a-wider-range formula) keeps the handle centered under
+	 * the cursor at both endpoints instead of lagging behind it.
+	 *
+	 * @param mouseX cursor x position
+	 * @param x left edge of the widget
+	 * @param width width of the widget
+	 * @param valueCount number of allowed values
+	 */
+	static int valueIndexForMouseX(int mouseX, int x, int width, int valueCount) {
+		final float mousePositionAcrossWidget = clamp((float) (mouseX - (x + TRACK_INSET)) / (width - 8), 0.0F, 1.0F);
+
+		return Math.round(mousePositionAcrossWidget * (valueCount - 1));
+	}
+
+	private static float clamp(float value, float min, float max) {
+		return value < min ? min : Math.min(value, max);
+	}
+}

--- a/src/test/java/net/coderbot/iris/gui/element/ScrollBarGeometryTest.java
+++ b/src/test/java/net/coderbot/iris/gui/element/ScrollBarGeometryTest.java
@@ -1,0 +1,51 @@
+package net.coderbot.iris.gui.element;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that the scrollbar drag factor maps "handle travels the whole track" to
+ * "content scrolls from top to bottom", so the handle keeps up with the cursor on
+ * long lists instead of crawling behind it.
+ */
+class ScrollBarGeometryTest {
+    // Vanilla GuiSlot handle sizing: viewport^2 / contentHeight, clamped to [32, viewport - 8]
+    private static int handleHeight(int contentHeight, int viewportHeight) {
+        return Math.min(Math.max((int) ((float) viewportHeight * viewportHeight / contentHeight), 32), viewportHeight - 8);
+    }
+
+    @Test
+    void fullHandleTravelCoversTheWholeScrollRange() {
+        final int viewportHeight = 400;
+
+        for (int contentHeight : new int[] {500, 800, 2000, 5000}) {
+            final float factor = ScrollBarGeometry.dragFactor(contentHeight, viewportHeight, 0);
+            final int travel = viewportHeight - handleHeight(contentHeight, viewportHeight);
+            final int scrollable = contentHeight - viewportHeight;
+
+            assertEquals((float) scrollable, factor * travel, 0.01f,
+                "contentHeight=" + contentHeight);
+        }
+    }
+
+    @Test
+    void longListScalesHandleSpeedUpToContentRatio() {
+        // 2000px of content in a 400px viewport: the handle is 80px tall, its track is
+        // 320px, so one cursor pixel must scroll 1600/320 = 5 content pixels.
+        assertEquals(5.0f, ScrollBarGeometry.dragFactor(2000, 400, 0), 0.0001f);
+    }
+
+    @Test
+    void headerPaddingExtendsTheScrollRange() {
+        // 10px of header padding adds 10px of scrollable content
+        assertEquals(1610f / 320f, ScrollBarGeometry.dragFactor(2000, 400, 10), 0.0001f);
+    }
+
+    @Test
+    void shortListFallsBackToVanillaMinimumFactor() {
+        // Content shorter than the viewport: nothing to scroll, factor collapses to
+        // vanilla's 1/(viewport - (viewport - 8)) = 1/8 without dividing by zero
+        assertEquals(0.125f, ScrollBarGeometry.dragFactor(300, 400, 0), 0.0001f);
+    }
+}

--- a/src/test/java/net/coderbot/iris/gui/element/widget/SliderGeometryTest.java
+++ b/src/test/java/net/coderbot/iris/gui/element/widget/SliderGeometryTest.java
@@ -1,0 +1,69 @@
+package net.coderbot.iris.gui.element.widget;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that the shader option slider's drag mapping is the inverse of its render
+ * mapping, so the handle tracks the cursor one-to-one instead of lagging behind it.
+ */
+class SliderGeometryTest {
+    private static final int X = 40;
+    private static final int WIDTH = 200;
+
+    @Test
+    void handleCenterDragsBackToTheSameIndexWhenCellsAreWiderThanTheHandle() {
+        // Typical shader option counts: each cell is wider than the 6px handle, so
+        // grabbing the handle center and moving must select the very same index.
+        for (int valueCount : new int[] {2, 3, 5, 21}) {
+            for (int index = 0; index < valueCount; index++) {
+                final int handleCenter = SliderGeometry.sliderXForIndex(X, WIDTH, index, valueCount)
+                    + SliderGeometry.ACTIVE_SLIDER_WIDTH / 2;
+
+                assertEquals(index, SliderGeometry.valueIndexForMouseX(handleCenter, X, WIDTH, valueCount),
+                    "valueCount=" + valueCount + " index=" + index);
+            }
+        }
+    }
+
+    @Test
+    void trackEndpointsMapToFirstAndLastValue() {
+        assertEquals(0, SliderGeometry.valueIndexForMouseX(X + SliderGeometry.TRACK_INSET, X, WIDTH, 21));
+        assertEquals(20, SliderGeometry.valueIndexForMouseX(X + WIDTH - SliderGeometry.TRACK_INSET, X, WIDTH, 21));
+
+        // Positions beyond the track clamp to the endpoints instead of overflowing
+        assertEquals(0, SliderGeometry.valueIndexForMouseX(X - 50, X, WIDTH, 21));
+        assertEquals(20, SliderGeometry.valueIndexForMouseX(X + WIDTH + 50, X, WIDTH, 21));
+    }
+
+    @Test
+    void mappingIsMonotonicallyNonDecreasingAcrossTheTrack() {
+        int previous = SliderGeometry.valueIndexForMouseX(0, X, WIDTH, 21);
+
+        for (int mouseX = 1; mouseX <= X + WIDTH; mouseX++) {
+            final int current = SliderGeometry.valueIndexForMouseX(mouseX, X, WIDTH, 21);
+
+            assertTrue(current >= previous, "mouseX=" + mouseX);
+            previous = current;
+        }
+    }
+
+    @Test
+    void largeValueCountsKeepDriftWithinHalfAHandleWidth() {
+        // When a cell is narrower than the handle the grab point can shift by at most
+        // about half a handle width (3px); at 101 values a cell is 1.86px wide, so the
+        // worst drift rounds out to 2 cells. The selection must never drift further.
+        final int valueCount = 101;
+
+        for (int index = 0; index < valueCount; index++) {
+            final int handleCenter = SliderGeometry.sliderXForIndex(X, WIDTH, index, valueCount)
+                + SliderGeometry.ACTIVE_SLIDER_WIDTH / 2;
+            final int mapped = SliderGeometry.valueIndexForMouseX(handleCenter, X, WIDTH, valueCount);
+
+            assertTrue(Math.abs(mapped - index) <= 2,
+                "valueCount=" + valueCount + " index=" + index + " mapped=" + mapped);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Two fixes for the shader pack screen so both kinds of slider track the cursor one-to-one:

1. **Option sliders** (`SliderElementWidget`) lagged behind the mouse because the drag was aborted as soon as the cursor left the narrow row/widget cell (forcing release-and-regrab mid-drag), one extra drag update ran after `onReleased`, and the drag mapping (floor onto a wider range) was not the inverse of the render mapping.
   - Keep dragging until the mouse button is actually released (release events are already broadcast to every widget).
   - Stop updating the value after release to avoid display drift.
   - Share one dependency-free geometry (`SliderGeometry`) for both mappings with symmetric nearest-value rounding, covered by unit tests.

2. **Scrollbar** (`IrisGuiSlot`) moved 1:1 with the cursor while the content scrolled 1:1 too, so on long lists the handle lagged far behind the mouse and the bottom of the list could not be reached within one screen height of dragging.
   - Map the drag through vanilla `GuiSlot`'s scroll multiplier (`ScrollBarGeometry`): the handle crossing its full track scrolls the content across its full range, keeping the handle under the cursor.

## Testing
- New unit tests: `SliderGeometryTest` (grab-point round-trip, endpoint clamping, monotonicity, drift bound), `ScrollBarGeometryTest` (full-track/full-range identity, scale factor, header padding, short-list fallback).
- Full suite: 119 suites / 425 tests, 0 failures.
- `./gradlew build` passes.