### PR TITLE
fix(celeritas): skip non-dynamic sort states in chunk sort task

### DIFF
--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/compile/tasks/ChunkBuilderSortTask.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/compile/tasks/ChunkBuilderSortTask.java
@@ -34,6 +34,15 @@ public class ChunkBuilderSortTask extends ChunkBuilderTask<ChunkSortOutput> {
         var meshes = new Reference2ReferenceOpenHashMap<TerrainRenderPass, ChunkSortOutput.SortedMesh>();
         for(Map.Entry<TerrainRenderPass, TranslucentQuadAnalyzer.SortState> entry : translucentMeshes.entrySet()) {
             var sortInfo = entry.getValue();
+
+            // Only passes that need dynamic re-sorting (camera-dependent) should produce a new index
+            // buffer here. Static and none-sorted states were compacted for storage (their centers were
+            // dropped), so centersLength() is 0 and a zero-length index buffer would be allocated, which
+            // later breaks the GL buffer arena (GlBufferSegment.mergeInto throws "len <= 0").
+            if (!sortInfo.requiresDynamicSorting()) {
+                continue;
+            }
+
             var primitiveType = this.renderPassConfiguration.getPrimitiveTypeForPass(entry.getKey());
             var newIndexBuffer = new NativeBuffer(primitiveType.getIndexBufferSize(sortInfo.centersLength() / 3));
             primitiveType.generateSortedIndexBuffer(newIndexBuffer.getDirectBuffer(), sortInfo.centersLength() / 3, sortInfo, cameraX - this.render.getOriginX(), cameraY - this.render.getOriginY(), cameraZ - this.render.getOriginZ());

--- a/src/test/java/org/embeddedt/embeddium/impl/render/chunk/sorting/TranslucentQuadAnalyzerSortStateTest.java
+++ b/src/test/java/org/embeddedt/embeddium/impl/render/chunk/sorting/TranslucentQuadAnalyzerSortStateTest.java
@@ -1,0 +1,56 @@
+package org.embeddedt.embeddium.impl.render.chunk.sorting;
+
+import org.joml.Vector3f;
+import org.junit.jupiter.api.Test;
+
+import java.util.BitSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for the {@code GlBufferSegment len <= 0} crash (issue: translucent sorting
+ * allocated a zero-length index buffer).
+ *
+ * <p>A section that mixes a dynamically-sorted pass (camera-dependent) with a statically-sorted
+ * one (quads on the same plane) triggers a sort task for the whole section. The statically-sorted
+ * state is compacted for storage, which drops its quad centers ({@code centersLength == 0}). The
+ * sort task must only re-generate index buffers for states that require dynamic sorting; otherwise
+ * it would allocate a zero-length index buffer that later breaks the GL buffer arena when freed.</p>
+ */
+class TranslucentQuadAnalyzerSortStateTest {
+    @Test
+    void dynamicSortStateKeepsCentersAfterCompaction() {
+        TranslucentQuadAnalyzer.SortState state = new TranslucentQuadAnalyzer.SortState(
+                TranslucentQuadAnalyzer.Level.DYNAMIC,
+                new float[] { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f },
+                6,
+                new BitSet(),
+                new Vector3f());
+
+        assertTrue(state.requiresDynamicSorting());
+        assertEquals(6, state.centersLength());
+
+        TranslucentQuadAnalyzer.SortState compacted = state.compactForStorage();
+        assertEquals(6, compacted.centersLength(), "dynamic sort state must keep its centers");
+        assertTrue(compacted.requiresDynamicSorting());
+    }
+
+    @Test
+    void staticSortStateDropsCentersAfterCompaction() {
+        TranslucentQuadAnalyzer.SortState state = new TranslucentQuadAnalyzer.SortState(
+                TranslucentQuadAnalyzer.Level.STATIC,
+                new float[] { 1.0f, 2.0f, 3.0f },
+                3,
+                new BitSet(),
+                new Vector3f());
+
+        assertFalse(state.requiresDynamicSorting(), "static sort does not depend on the camera");
+        assertEquals(3, state.centersLength());
+
+        TranslucentQuadAnalyzer.SortState compacted = state.compactForStorage();
+        assertEquals(0, compacted.centersLength(), "static sort state is compacted to zero centers");
+        assertFalse(compacted.requiresDynamicSorting());
+    }
+}


### PR DESCRIPTION
## What

A translucent section that mixes a dynamically-sorted pass with a statically-sorted one triggers a `ChunkBuilderSortTask` for the whole section. Static sort states are compacted for storage (`compactForStorage()` drops their quad centers, so `centersLength() == 0`), so the sort task allocated a **zero-length index buffer** for those passes. Uploading it produced a zero-length GL buffer arena segment whose later merge threw `IllegalArgumentException: len <= 0` in `GlBufferSegment`.

This PR makes the sort task only re-generate index buffers for states that require **dynamic** (camera-dependent) sorting, skipping static / none-sorted passes — those already hold a correct index buffer produced during meshing.

## Why

- `TranslucentQuadAnalyzer.SortState.compactForStorage()` sets `centersLength` to 0 for `STATIC` and `NONE` levels; only `DYNAMIC` states keep their centers.
- `ChunkBuilderSortTask.execute()` previously sized a new index buffer from `sortInfo.centersLength() / 3` for **every** pass in the map, so a compacted static state produced a zero-length `NativeBuffer` → zero-length segment in the GL buffer arena → `GlBufferSegment.mergeInto` threw `len <= 0` on merge.

## How verified

- New `TranslucentQuadAnalyzerSortStateTest` (2 direct-call tests, no source-contain checks): a `DYNAMIC` sort state keeps its centers after `compactForStorage()`, while a `STATIC` state drops them to 0 — the exact condition the sort task now relies on.
- `.\gradlew.bat check --no-daemon` (JDK 25, `GRADLE_USER_HOME=D:/gradle`) → BUILD SUCCESSFUL (includes `:test`, module-boundary and remap-jar validation).

## Commits

- `fix(celeritas): skip non-dynamic sort states in chunk sort task`
