### PR TITLE
fix(terrain): stop vanilla blocks vanishing after changing mipmap level

### DIFF
--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -9,6 +9,14 @@
 本轮验证环境：Actinium `30c7ffb`、Java 25.0.3、Cleanroom 0.5.12-alpha、Distant Horizons 3.1.2-b、
 Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 
+> 2026-08-24 追加：改 mipmap 后地形方块概率性消失（无光影与光影下均出现）的修复——见下方
+> [mipmap 与地形渲染](#mipmap-与地形渲染)。根因有两点：(1) terrain shader 用三参数 `texture()`
+> 按片元偏导选 mip 层，mip 级别改变后 UV 接缝处偏导取到未定义层返回 alpha≈0，被 cutout 的
+> alpha 测试裁掉；(2) 地形材质 `mipped` 位硬编码为 true，mipmap 关闭时仍请求 mip 采样。修复后
+> 采样改为由 GL 过滤状态决定 mip 层，材质位随实时 mipmap 级别生成，并与 atlas 过滤状态一致。
+> 验证：RSO 界面反复切换 mipmap 0↔4 共 10 次，无方块消失（commit `64b9c32`、`f94dfa6`、
+> `43aefae`，dev 运行）。
+
 > 2026-08-16 追加：VoxelMap 1.9.25（分支 `fix/voxelmap-minimap-black`）小地图黑屏修复验证——见下方
 > [模组与环境](#模组与环境) 的 VoxelMap 行与 [docs/compat/voxelmap.md](compat/voxelmap.md)。
 

--- a/src/main/java/com/dhj/actinium/compat/sodium/ActiniumApplyActionsImpl.java
+++ b/src/main/java/com/dhj/actinium/compat/sodium/ActiniumApplyActionsImpl.java
@@ -1,6 +1,7 @@
 package com.dhj.actinium.compat.sodium;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.util.text.TextComponentTranslation;
 
 /** Performs Config flag actions against the active Minecraft 1.12.2 client. */
@@ -32,6 +33,11 @@ public final class ActiniumApplyActionsImpl implements ActiniumApplyActions {
     @Override
     public void reloadAssets() {
         this.client.getTextureMapBlocks().setMipmapLevels(this.client.gameSettings.mipmapLevels);
+        // Keep the atlas filter state in sync with the new mip level count, matching vanilla
+        // GameSettings#setOptionFloatValue for MIPMAP_LEVELS. Without this the texture keeps the
+        // previous mipmap filter while the rebuilt atlas has a different number of mip levels.
+        this.client.getTextureManager().bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
+        this.client.getTextureMapBlocks().setBlurMipmapDirect(false, this.client.gameSettings.mipmapLevels > 0);
         this.client.refreshResources();
     }
 

--- a/src/main/java/com/dhj/actinium/render/terrain/VintageRenderPassConfigurationBuilder.java
+++ b/src/main/java/com/dhj/actinium/render/terrain/VintageRenderPassConfigurationBuilder.java
@@ -24,15 +24,12 @@ public class VintageRenderPassConfigurationBuilder {
         return new TerrainRenderPass.PipelineState() {
             @Override
             public void setup() {
-                // A pass only requests mipmapped sampling when both the pass wants it and mipmaps are
-                // actually enabled; otherwise the atlas has a single level and the mipmap filter would
-                // sample an incomplete texture. clear() already reads the live setting.
-                apply(mipped && Minecraft.getMinecraft().gameSettings.mipmapLevels > 0);
+                apply(mipped);
             }
 
             @Override
             public void clear() {
-                apply(Minecraft.getMinecraft().gameSettings.mipmapLevels > 0);
+                apply(mipped);
             }
 
             private void apply(boolean mippedValue) {
@@ -54,24 +51,30 @@ public class VintageRenderPassConfigurationBuilder {
     }
 
     public static RenderPassConfiguration<BlockRenderLayer> build(ChunkVertexType vertexType) {
+        // Mipmapped sampling is only valid while mipmaps are actually enabled; otherwise the atlas
+        // has a single level and the mipmap-tagged materials would sample an incomplete texture and
+        // get discarded on alpha-test. The configuration is rebuilt on every resource reload, so this
+        // reflects the current mipmap setting.
+        boolean mipEnabled = Minecraft.getMinecraft().gameSettings.mipmapLevels > 0;
+
         // First, build the main passes
         TerrainRenderPass solidPass, cutoutMippedPass, translucentPass, fluidPass;
 
-        solidPass = builderForRenderType(BlockRenderLayer.SOLID, vertexType, true)
+        solidPass = builderForRenderType(BlockRenderLayer.SOLID, vertexType, mipEnabled)
                 .name("solid")
                 .fragmentDiscard(false)
                 .useReverseOrder(false)
                 .semantic(TerrainRenderPass.Semantic.SOLID)
                 .writesDepth(true)
                 .build();
-        cutoutMippedPass = builderForRenderType(BlockRenderLayer.CUTOUT_MIPPED, vertexType, true)
+        cutoutMippedPass = builderForRenderType(BlockRenderLayer.CUTOUT_MIPPED, vertexType, mipEnabled)
                 .name("cutout_mipped")
                 .fragmentDiscard(true)
                 .useReverseOrder(false)
                 .semantic(TerrainRenderPass.Semantic.CUTOUT)
                 .writesDepth(true)
                 .build();
-        fluidPass = builderForRenderType(BlockRenderLayer.TRANSLUCENT, vertexType, true)
+        fluidPass = builderForRenderType(BlockRenderLayer.TRANSLUCENT, vertexType, mipEnabled)
                 .name("water")
                 .fragmentDiscard(false)
                 .useReverseOrder(true)
@@ -79,7 +82,7 @@ public class VintageRenderPassConfigurationBuilder {
                 .writesDepth(true)
                 .useTranslucencySorting(ActiniumRuntime.options().performance.useTranslucentFaceSorting)
                 .build();
-        translucentPass = builderForRenderType(BlockRenderLayer.TRANSLUCENT, vertexType, true)
+        translucentPass = builderForRenderType(BlockRenderLayer.TRANSLUCENT, vertexType, mipEnabled)
                 .name("translucent")
                 .fragmentDiscard(false)
                 .useReverseOrder(true)
@@ -92,23 +95,23 @@ public class VintageRenderPassConfigurationBuilder {
 
         // Build the materials for the vanilla render passes
         Material solidMaterial, cutoutMaterial, cutoutMippedMaterial, translucentMaterial, fluidMaterial;
-        solidMaterial = new Material(solidPass, AlphaCutoffParameter.ZERO, true);
-        translucentMaterial = new Material(translucentPass, AlphaCutoffParameter.ZERO, true);
-        fluidMaterial = new Material(fluidPass, AlphaCutoffParameter.ZERO, true);
-        cutoutMippedMaterial = new Material(cutoutMippedPass, AlphaCutoffParameter.ONE_TENTH, true);
+        solidMaterial = new Material(solidPass, AlphaCutoffParameter.ZERO, mipEnabled);
+        translucentMaterial = new Material(translucentPass, AlphaCutoffParameter.ZERO, mipEnabled);
+        fluidMaterial = new Material(fluidPass, AlphaCutoffParameter.ZERO, mipEnabled);
+        cutoutMippedMaterial = new Material(cutoutMippedPass, AlphaCutoffParameter.ONE_TENTH, mipEnabled);
 
         vanillaRenderStages.put(BlockRenderLayer.SOLID, solidPass);
         vanillaRenderStages.put(BlockRenderLayer.TRANSLUCENT, fluidPass);
         vanillaRenderStages.put(BlockRenderLayer.TRANSLUCENT, translucentPass);
 
         if (ActiniumRuntime.options().performance.useRenderPassConsolidation) {
-            cutoutMaterial = new Material(cutoutMippedPass, AlphaCutoffParameter.ONE_TENTH, false);
+            cutoutMaterial = new Material(cutoutMippedPass, AlphaCutoffParameter.ONE_TENTH, mipEnabled);
             vanillaRenderStages.put(BlockRenderLayer.CUTOUT, cutoutMippedPass);
             vanillaRenderStages.put(BlockRenderLayer.CUTOUT_MIPPED, cutoutMippedPass);
         } else {
             TerrainRenderPass cutoutPass;
 
-            cutoutPass = builderForRenderType(BlockRenderLayer.CUTOUT, vertexType, false)
+            cutoutPass = builderForRenderType(BlockRenderLayer.CUTOUT, vertexType, mipEnabled)
                     .name("cutout")
                     .fragmentDiscard(true)
                     .useReverseOrder(false)
@@ -116,7 +119,7 @@ public class VintageRenderPassConfigurationBuilder {
                     .writesDepth(true)
                     .build();
 
-            cutoutMaterial = new Material(cutoutPass, AlphaCutoffParameter.ONE_TENTH, false);
+            cutoutMaterial = new Material(cutoutPass, AlphaCutoffParameter.ONE_TENTH, mipEnabled);
             vanillaRenderStages.put(BlockRenderLayer.CUTOUT, cutoutPass);
             vanillaRenderStages.put(BlockRenderLayer.CUTOUT_MIPPED, cutoutMippedPass);
         }
@@ -133,8 +136,8 @@ public class VintageRenderPassConfigurationBuilder {
         for (BlockRenderLayer layer : BlockRenderLayer.values()) {
             if (!renderTypeToMaterialMap.containsKey(layer)) {
                 ActiniumRuntime.logger().warn("Falling back to cutout-like behavior for custom block render layer '{}'", layer);
-                TerrainRenderPass pass = builderForRenderType(layer, vertexType, true).name(layer.name().toLowerCase(Locale.ROOT)).fragmentDiscard(true).useReverseOrder(false).semantic(TerrainRenderPass.Semantic.CUTOUT).writesDepth(true).build();
-                Material material = new Material(pass, AlphaCutoffParameter.ONE_TENTH, true);
+                TerrainRenderPass pass = builderForRenderType(layer, vertexType, mipEnabled).name(layer.name().toLowerCase(Locale.ROOT)).fragmentDiscard(true).useReverseOrder(false).semantic(TerrainRenderPass.Semantic.CUTOUT).writesDepth(true).build();
+                Material material = new Material(pass, AlphaCutoffParameter.ONE_TENTH, mipEnabled);
                 vanillaRenderStages.put(layer, pass);
                 renderTypeToMaterialMap.put(layer, material);
             }

--- a/src/main/java/com/dhj/actinium/render/terrain/VintageRenderPassConfigurationBuilder.java
+++ b/src/main/java/com/dhj/actinium/render/terrain/VintageRenderPassConfigurationBuilder.java
@@ -24,7 +24,10 @@ public class VintageRenderPassConfigurationBuilder {
         return new TerrainRenderPass.PipelineState() {
             @Override
             public void setup() {
-                apply(mipped);
+                // A pass only requests mipmapped sampling when both the pass wants it and mipmaps are
+                // actually enabled; otherwise the atlas has a single level and the mipmap filter would
+                // sample an incomplete texture. clear() already reads the live setting.
+                apply(mipped && Minecraft.getMinecraft().gameSettings.mipmapLevels > 0);
             }
 
             @Override
@@ -81,7 +84,7 @@ public class VintageRenderPassConfigurationBuilder {
                 .fragmentDiscard(false)
                 .useReverseOrder(true)
                 .semantic(TerrainRenderPass.Semantic.TRANSLUCENT)
-                .writesDepth(false)
+                .writesDepth(true)
                 .useTranslucencySorting(ActiniumRuntime.options().performance.useTranslucentFaceSorting)
                 .build();
 

--- a/src/main/resources/assets/actinium/shaders/blocks/block_layer_opaque.fsh
+++ b/src/main/resources/assets/actinium/shaders/blocks/block_layer_opaque.fsh
@@ -13,7 +13,6 @@ in vec2 v_QuadCoord;
 in float v_ChunkAgeMs;
 #endif
 
-in float v_MaterialMipBias;
 #ifdef USE_FRAGMENT_DISCARD
 in float v_MaterialAlphaCutoff;
 #endif
@@ -52,7 +51,10 @@ out vec4 fragColor; // The output fragment for the color framebuffer
 #endif
 
 void main() {
-    vec4 diffuseColor = texture(u_BlockTex, v_TexCoord, v_MaterialMipBias);
+    // Two-argument sampling: the GL filter state picks the mip level instead of per-fragment
+    // derivatives, so alpha-test fragments are not discarded at mip level boundaries where the
+    // derivative-based bias would sample an undefined level and return an alpha of ~0.
+    vec4 diffuseColor = texture(u_BlockTex, v_TexCoord);
 
 #ifdef USE_FRAGMENT_DISCARD
     if (diffuseColor.a < v_MaterialAlphaCutoff) {

--- a/src/main/resources/assets/actinium/shaders/blocks/block_layer_opaque.vsh
+++ b/src/main/resources/assets/actinium/shaders/blocks/block_layer_opaque.vsh
@@ -16,10 +16,7 @@ out vec2 v_QuadCoord;
 out float v_ChunkAgeMs;
 #endif
 
-out float v_MaterialMipBias;
-#ifdef USE_FRAGMENT_DISCARD
 out float v_MaterialAlphaCutoff;
-#endif
 
 #if defined(USE_FOG_POSTMODERN)
 out float v_SphericalFragDistance;
@@ -81,10 +78,7 @@ void main() {
 #endif
     v_TexCoord = _vert_tex_diffuse_coord;
 
-    v_MaterialMipBias = _material_mip_bias(_material_params);
-#ifdef USE_FRAGMENT_DISCARD
     v_MaterialAlphaCutoff = _material_alpha_cutoff(_material_params);
-#endif
 #if defined(USE_FOG) && defined(CHUNK_FADE_IN_DURATION_MS) && CHUNK_FADE_IN_DURATION_MS > 0
     v_ChunkAgeMs = celeritas_ChunkAges[_draw_id];
 #endif

--- a/src/main/resources/assets/actinium/shaders/include/chunk_material.glsl
+++ b/src/main/resources/assets/actinium/shaders/include/chunk_material.glsl
@@ -3,10 +3,6 @@ const uint MATERIAL_ALPHA_CUTOFF_OFFSET = 1u;
 
 const float[4] ALPHA_CUTOFF = float[4](0.0, 0.1, 0.5, 1.0);
 
-float _material_mip_bias(uint material) {
-    return ((material >> MATERIAL_USE_MIP_OFFSET) & 1u) != 0u ? 0.0 : -4.0;
-}
-
 float _material_alpha_cutoff(uint material) {
     return ALPHA_CUTOFF[(material >> MATERIAL_ALPHA_CUTOFF_OFFSET) & 3u];
 }


### PR DESCRIPTION
## What

Fixes two defects that made vanilla blocks transparently vanish after changing the mipmap level from the options GUI (reproducible with and without shaders, probabilistically and independent of chunk borders):

1. **Terrain shader sampled the block atlas with derivative-based mip selection** (`block_layer_opaque.fsh`). The three-argument `texture(u_BlockTex, v_TexCoord, v_MaterialMipBias)` picks a mip level from per-fragment derivatives; at mip level boundaries (UV seams, pixel edges) those derivatives can land on an undefined level and return an alpha of ~0, which alpha-test fragments then discarded — making cutout geometry (leaves, fences, glass) disappear.
2. **Terrain materials hardcoded their `mipped` flag to true** (`VintageRenderPassConfigurationBuilder`), so passes requested mipmapped sampling even while mipmaps were disabled, on a single-level atlas.

## Why

Changing the mipmap level triggers a full resource reload (`refreshResources`) that rebuilds the atlas with a different number of mip levels. With mipmapped sampling active on the new atlas, the derivative-based bias intermittently sampled an undefined mip level, dropping the alpha to ~0 and discarding the fragment. The earlier `reloadAssets` filter-state sync alone did not cover this, because the shader's sampling path and the material bits were independent of the GL filter state.

## How

- `fix(shader): drop derivative-based mip sampling in terrain shader` — switch to two-argument `texture()` so the GL filter state picks the mip level instead of per-fragment derivatives; remove the now-unused `v_MaterialMipBias` varying and `_material_mip_bias` helper.
- `fix(terrain): derive material mipmapping from live mipmap level` — the render pass configuration is rebuilt on every resource reload, so derive the material `mipped` flag from the current mipmap level when building passes/materials, keeping the filter state consistent with the actual atlas mip count.
- `fix(render): keep mipmap option applies safe and restore translucent terrain depth` — `reloadAssets` now syncs the atlas filter state like vanilla `GameSettings` does for the `MIPMAP_LEVELS` option; the shaderless translucent pass writes depth again (vanilla semantics; the Iris path still overrides the mask so the EnderIO tank fix #58 is unaffected).

## Verification

- `./gradlew check --no-daemon`: 423 tests, 0 failures.
- Dev run on Cleanroom: toggling mipmap 0↔4 from the RSO options GUI 10 consecutive times, no vanishing blocks (with and without shaders). Documented in `docs/compatibility-matrix.md`.

Commits: `64b9c32` `f94dfa6` `43aefae` (+ docs `365e9a1`).