### PR TITLE
fix(shader): keep noise texture linear-filtered after upload

### DIFF
--- a/shader/src/main/java/net/coderbot/iris/pipeline/transform/CommonTransformer.java
+++ b/shader/src/main/java/net/coderbot/iris/pipeline/transform/CommonTransformer.java
@@ -22,6 +22,14 @@ public class CommonTransformer {
 		if (parameters.type == ShaderType.VERTEX) {
 			root.injectVariable("out vec4 iris_FrontColor;");
 			root.rename("gl_FrontColor", "iris_FrontColor");
+			// Legacy packs read gl_Color in the composite vertex stage (e.g. Sildur's
+			// Enhanced Default). The full-screen quad has no color attribute, so map it
+			// to the same white-initialized out variable that gl_FrontColor uses.
+			// Only COMPOSITE: other patches map gl_Color themselves (ATTRIBUTES to the
+			// vertex color / modulator, Celeritas and DH terrain to _vert_color).
+			if (parameters.patch == Patch.COMPOSITE) {
+				root.rename("gl_Color", "iris_FrontColor");
+			}
 			root.prependMain("iris_FrontColor = vec4(1.0);");
 		} else if (parameters.type == ShaderType.FRAGMENT) {
 			root.injectVariable("in vec4 iris_FrontColor;");

--- a/shader/src/main/java/net/coderbot/iris/rendertarget/NativeImageBackedNoiseTexture.java
+++ b/shader/src/main/java/net/coderbot/iris/rendertarget/NativeImageBackedNoiseTexture.java
@@ -29,9 +29,14 @@ public class NativeImageBackedNoiseTexture extends DynamicTexture {
 
 	@Override
     public void updateDynamicTexture() {
+        // DynamicTexture's upload path (TextureUtil.uploadTextureSub) resets the
+        // filtering to GL_NEAREST, which turns the per-pixel random noise into harsh
+        // pixel stripes when sampled (Sildur-style water waves show as crossing
+        // straight lines). Re-apply linear filtering after the upload so the noise
+        // interpolates into smooth ripples.
+        super.updateDynamicTexture();
         GLStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR);
         GLStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_LINEAR);
-        super.updateDynamicTexture();
     }
 
 }

--- a/src/test/java/net/coderbot/iris/pipeline/transform/TransformPatcherTest.java
+++ b/src/test/java/net/coderbot/iris/pipeline/transform/TransformPatcherTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -40,5 +41,70 @@ class TransformPatcherTest {
         String patchedFragment = patched.get(PatchShaderType.FRAGMENT);
         assertTrue(patchedFragment.contains("out vec4 iris_FragData0"), patchedFragment);
         assertTrue(patchedFragment.contains("iris_FragData0 = vec4"), patchedFragment);
+    }
+
+    @Test
+    void compositeVertexLegacyGlColorIsRewritten() {
+        // Sildur's Enhanced Default reads gl_Color in the composite vertex stage. Under
+        // core profile (GLSL >= 330) that builtin does not exist, so it must be renamed
+        // to the white-initialized iris_FrontColor the transformer already declares.
+        String vertex = """
+            #version 120
+            varying vec2 texcoord;
+            varying vec4 color;
+            void main() {
+                gl_Position = ftransform();
+                texcoord = gl_MultiTexCoord0.xy;
+                color = gl_Color;
+            }
+            """;
+        String fragment = """
+            #version 120
+            varying vec2 texcoord;
+            varying vec4 color;
+            void main() {
+                gl_FragColor = vec4(color.rgb * texcoord.x, 1.0);
+            }
+            """;
+
+        Map<PatchShaderType, String> patched = TransformPatcher.patchComposite(vertex, null, fragment);
+
+        assertNotNull(patched);
+        String patchedVertex = patched.get(PatchShaderType.VERTEX);
+        assertTrue(patchedVertex.startsWith("#version 330 core"), patchedVertex);
+        // The legacy read must be redirected so it compiles on core profile.
+        assertTrue(patchedVertex.replaceAll("\\s+", " ").contains("color = iris_FrontColor ;"), patchedVertex);
+        assertTrue(patchedVertex.replaceAll("\\s+", " ").contains("iris_FrontColor = vec4 ( 1.0 ) ;"), patchedVertex);
+    }
+
+    @Test
+    void terrainVertexGlColorStaysOnCeleritasVertexColor() {
+        // Terrain shaders must keep gl_Color routed to Celeritas' _vert_color (the real
+        // baked per-vertex color, e.g. grass/foliage tint). CommonTransformer must not
+        // intercept it for non-composite patches or every plant turns grey.
+        String vertex = """
+            #version 120
+            varying vec4 color;
+            void main() {
+                gl_Position = ftransform();
+                color = gl_Color;
+            }
+            """;
+        String fragment = """
+            #version 120
+            varying vec4 color;
+            void main() {
+                gl_FragColor = vec4(color.rgb, 1.0);
+            }
+            """;
+
+        Map<PatchShaderType, String> patched = TransformPatcher.patchCeleritasTerrain(vertex, null, fragment);
+
+        assertNotNull(patched);
+        String patchedVertex = patched.get(PatchShaderType.VERTEX);
+        // The terrain read must be mapped to the baked vertex color, not the composite
+        // white front-color.
+        assertTrue(patchedVertex.replaceAll("\\s+", " ").contains("color = _vert_color ;"), patchedVertex);
+        assertFalse(patchedVertex.replaceAll("\\s+", " ").contains("color = iris_FrontColor"), patchedVertex);
     }
 }


### PR DESCRIPTION
## 问题

Sildur's 系列光影包的水面波纹呈现为"交叉的几条直线"而不是平滑的自然波纹（Enhanced Default / Vibrant 均受影响）。

## 根因

Iris 内置噪声纹理（`NativeImageBackedNoiseTexture`）供光影包的 `noisetex` sampler 使用（Sildur 系通过 `calcWaves`/`calcBump` 采样它生成水波法线）。纹理内容本身是逐像素随机（正常），但：

- `updateDynamicTexture()` 原本**先**设置 `GL_LINEAR` 过滤，**再**调用 `super.updateDynamicTexture()` 上传。
- 1.12.2 的 `DynamicTexture` 上传路径（`TextureUtil.uploadTextureSub` → `setTextureBlurMipmap(false,false)`）会把过滤**重置为 `GL_NEAREST`**，覆盖掉之前设置的 LINEAR。
- 最终噪声纹理以**最近邻**过滤采样：逐像素随机噪声不再插值，配合 `calcBump` 的相邻差分和 `coord.y *= 3.0` 拉伸，形成尖锐的交叉直线/条纹，而非平滑波纹。

上游 Iris 用新版 `NativeImage` + GPU 上传 + sampler 统一 LINEAR，所以正常；Actorium 因 `DynamicTexture` 上传重置过滤而回归。

## 修复

把 `GL_LINEAR` 设置移到 `super.updateDynamicTexture()` **之后**——先上传（此时被重置为 NEAREST），再重新设为 LINEAR，让噪声插值为平滑波纹。

## 验证

- 分支基于 `fix/composite-gl-color`（含 `4dd2c84` gl_Color 修复）。
- 本地运行：Sildur's Enhanced Default 正常加载，水面波纹恢复平滑自然。