### PR TITLE
fix(terrain): skip missing models and wire compat renderer to quad transformers

### DIFF
--- a/src/compatBridge/java/org/taumc/celeritas/impl/render/terrain/compile/pipeline/VintageBlockRenderer.java
+++ b/src/compatBridge/java/org/taumc/celeritas/impl/render/terrain/compile/pipeline/VintageBlockRenderer.java
@@ -1,5 +1,7 @@
 package org.taumc.celeritas.impl.render.terrain.compile.pipeline;
 
+import com.dhj.actinium.api.render.terrain.BlockQuadTransformerHolder;
+import com.dhj.actinium.compat.MissingModelCompat;
 import com.dhj.actinium.render.terrain.compile.VintageChunkBuildContext;
 import com.dhj.actinium.render.terrain.compile.light.LightDataCache;
 import com.dhj.actinium.render.terrain.compile.light.VintageDiffuseProvider;
@@ -69,6 +71,12 @@ public class VintageBlockRenderer extends ActiniumVintageBlockRenderer {
             state = state.getActualState(legacyAccess, pos);
         }
         var model = access.actiniumLegacy$getShapes().getModelForState(state);
+        if (MissingModelCompat.isMissingModel(model)) {
+            // Missing models have no renderable quads; Forge's fancy variant lazily renders a
+            // "missing" label through the font renderer, which requires a GL context and crashes
+            // when chunk meshes are built on worker threads.
+            return;
+        }
         this.currentBlockAccess = legacyAccess;
         access.actiniumLegacy$setCurrentBlockAccess(legacyAccess);
         int currentMetadata = state.getBlock().getMetaFromState(state);
@@ -98,6 +106,11 @@ public class VintageBlockRenderer extends ActiniumVintageBlockRenderer {
             if (quads.isEmpty() || !state.shouldSideBeRendered(legacyAccess, pos, direction)) {
                 continue;
             }
+            quads = BlockQuadTransformerHolder.transform(
+                    state, pos, legacyAccess, layer, direction, quads);
+            if (quads.isEmpty()) {
+                continue;
+            }
             access.actiniumLegacy$setCurrentQuadRenderingFlags(analyzer.getFlagsForRendering(
                     VintageDiffuseProvider.fromEnumFacing(direction),
                     BakedQuadView.ofList(quads)));
@@ -106,9 +119,13 @@ public class VintageBlockRenderer extends ActiniumVintageBlockRenderer {
 
         List<BakedQuad> quads = model.getQuads(state, null, random);
         if (!quads.isEmpty()) {
-            access.actiniumLegacy$setCurrentQuadRenderingFlags(analyzer.getFlagsForRendering(
-                    ModelQuadFacing.UNASSIGNED, BakedQuadView.ofList(quads)));
-            renderQuadList(buffer, buffers, material, pos, null, lighter, colorProvider, offset, quads);
+            quads = BlockQuadTransformerHolder.transform(
+                    state, pos, legacyAccess, layer, null, quads);
+            if (!quads.isEmpty()) {
+                access.actiniumLegacy$setCurrentQuadRenderingFlags(analyzer.getFlagsForRendering(
+                        ModelQuadFacing.UNASSIGNED, BakedQuadView.ofList(quads)));
+                renderQuadList(buffer, buffers, material, pos, null, lighter, colorProvider, offset, quads);
+            }
         }
 
         access.actiniumLegacy$getUsedContextEncoders().forEach(encoder -> encoder.finishRenderingBlock());

--- a/src/main/java/com/dhj/actinium/compat/MissingModelCompat.java
+++ b/src/main/java/com/dhj/actinium/compat/MissingModelCompat.java
@@ -1,0 +1,89 @@
+package com.dhj.actinium.compat;
+
+import java.lang.reflect.Field;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.block.model.IBakedModel;
+import net.minecraftforge.client.model.BakedModelWrapper;
+
+/**
+ * Missing-model detection for the terrain render pipeline.
+ *
+ * <p>Actinium builds chunk meshes on worker threads, where {@code getQuads} must not touch
+ * main-thread GL state. Forge's fallback for models that failed to load is
+ * {@code FancyMissingModel}, which lazily renders its "missing texture" label through the font
+ * renderer on the first {@code getQuads} call; the font renderer requires a current OpenGL
+ * context and throws {@link IllegalStateException} off the render thread (Extra Utilities 2
+ * red orchid block). The vanilla missing model has no renderable quads either, so both variants
+ * are skipped by the renderers instead of being drawn.</p>
+ *
+ * <p>Mods wrap every baked model at model-bake time (e.g. NeoContinuity's emissive wrapper), so
+ * the model handed to the renderer may be a {@link BakedModelWrapper} around a missing model.
+ * The wrapper chain is unwrapped before the missing-model check.</p>
+ */
+public final class MissingModelCompat {
+    private MissingModelCompat() {
+    }
+
+    /**
+     * Binary name of Forge's {@code FancyMissingModel.BakedModel}. The class is package-private,
+     * so its name is matched instead of using {@code instanceof}; it ships with Minecraft Forge.
+     */
+    public static final String FANCY_MISSING_MODEL_CLASS =
+            "net.minecraftforge.client.model.FancyMissingModel$BakedModel";
+
+    /**
+     * {@code BakedModelWrapper.originalModel}, read reflectively because the field is protected
+     * and Forge exposes no public unwrap accessor. Used only to walk wrapper chains; nothing is
+     * invoked through reflection.
+     */
+    private static final Field WRAPPER_ORIGINAL_MODEL;
+
+    static {
+        Field field = null;
+        try {
+            field = BakedModelWrapper.class.getDeclaredField("originalModel");
+            field.setAccessible(true);
+        } catch (NoSuchFieldException e) {
+            // Forge always provides this field; if it ever moves, treat candidates as unwrapped.
+        }
+        WRAPPER_ORIGINAL_MODEL = field;
+    }
+
+    /**
+     * Returns true when the given baked model is a missing model (vanilla fallback or Forge's
+     * fancy label variant) and must not be rendered from a chunk build worker thread.
+     */
+    public static boolean isMissingModel(IBakedModel model) {
+        IBakedModel missingModel = Minecraft.getMinecraft().getBlockRendererDispatcher()
+                .getBlockModelShapes().getModelManager().getMissingModel();
+        return isMissingModel(model, missingModel);
+    }
+
+    /**
+     * Pure form of {@link #isMissingModel(IBakedModel)} with the vanilla fallback model passed
+     * in explicitly, so the check can be verified without a live Minecraft client.
+     */
+    static boolean isMissingModel(IBakedModel model, IBakedModel missingModel) {
+        IBakedModel candidate = model;
+        while (candidate != null) {
+            if (candidate == missingModel || FANCY_MISSING_MODEL_CLASS.equals(candidate.getClass().getName())) {
+                return true;
+            }
+            candidate = unwrap(candidate);
+        }
+        return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static IBakedModel unwrap(IBakedModel model) {
+        if (WRAPPER_ORIGINAL_MODEL != null && model instanceof BakedModelWrapper<?> wrapper) {
+            try {
+                return (IBakedModel) WRAPPER_ORIGINAL_MODEL.get(wrapper);
+            } catch (IllegalAccessException e) {
+                // Field was made accessible in the static initializer; treat as unwrapped.
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/dhj/actinium/render/terrain/compile/pipeline/VintageBlockRenderer.java
+++ b/src/main/java/com/dhj/actinium/render/terrain/compile/pipeline/VintageBlockRenderer.java
@@ -1,6 +1,7 @@
 package com.dhj.actinium.render.terrain.compile.pipeline;
 
 import com.dhj.actinium.api.render.terrain.BlockQuadTransformerHolder;
+import com.dhj.actinium.compat.MissingModelCompat;
 import net.coderbot.iris.debug.ShaderRegressionDebug;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
@@ -115,6 +116,12 @@ public class VintageBlockRenderer {
             state = state.getActualState(blockAccess, pos);
         }
         var model = this.shapes.getModelForState(state);
+        if (MissingModelCompat.isMissingModel(model)) {
+            // Missing models have no renderable quads; Forge's fancy variant lazily renders a
+            // "missing" label through the font renderer, which requires a GL context and crashes
+            // when chunk meshes are built on worker threads.
+            return;
+        }
         this.currentBlockAccess = blockAccess;
         this.currentMetadata = state.getBlock().getMetaFromState(state);
         this.currentShaderMetadata = applyShaderStateBits(state, pos, blockAccess, this.currentMetadata);


### PR DESCRIPTION
## What

Chunk meshes are built on worker threads, where `getQuads` must not touch main-thread GL state. This PR skips missing models so they are never rendered from those threads, and routes the legacy Celeritas compat-bridge renderer through the quad-transformer pipeline so addons actually run there.

- **Skip missing models** in both the main and compat-bridge `VintageBlockRenderer`: Forge's `FancyMissingModel` lazily renders its "missing texture" label through the font renderer on the first `getQuads` call, which needs a GL context and throws off the render thread (observed with Extra Utilities 2's red orchid block). The vanilla fallback model has no renderable quads either, so both variants are skipped.
- **New `MissingModelCompat`**: unwraps `BakedModelWrapper` chains (mods wrap every baked model at bake time, e.g. NeoContinuity's emissive wrapper) before the missing-model check, and matches Forge's package-private `FancyMissingModel$BakedModel` by binary name.
- **Wire compat-bridge renderer to quad transformers**: its `getQuads` now goes through `BlockQuadTransformerHolder.transform` like the main renderer, so addons (e.g. NeoContinuity's connected textures) run in the legacy Celeritas render path too.

## Why

Without this, worker-thread chunk building crashes or silently drops quads for models that failed to load, and connected/emissive textures don't apply in the legacy compat render path.

## How verified

- `./gradlew check --no-daemon` passes (JUnit + remap jar / module boundary verification).
- Manual dev regression with the Extra Utilities 2 pack: red orchid no longer crashes chunk building; connected textures render in the legacy Celeritas path.
- No new mixins (no `MixinConfigurationTest` change needed); no shaderpack behavior change expected.