### PR TITLE
fix(glsm): implement outline mode to stop glowing entity crash

### DIFF
--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -5472,6 +5472,38 @@ public class GLStateManager {
         }
     }
 
+    /**
+     * Entity glow outline. Mirrors vanilla GlStateManager.enableOutlineMode: switches the active texture unit's texenv to
+     * GL_COMBINE wired so the fragment color is replaced by the given outline color, letting the entity render as a flat
+     * silhouette. All state changes flow through the tracked glTexEnv/glTexEnvi paths, so FFP shaders pick them up.
+     */
+    public static void enableOutlineMode(int color) {
+        final FloatBuffer envColor = BufferUtils.createFloatBuffer(4);
+        envColor.put(0, (color >> 16 & 255) / 255.0F);
+        envColor.put(1, (color >> 8 & 255) / 255.0F);
+        envColor.put(2, (color & 255) / 255.0F);
+        envColor.put(3, (color >> 24 & 255) / 255.0F);
+        glTexEnv(GL11.GL_TEXTURE_ENV, GL11.GL_TEXTURE_ENV_COLOR, envColor);
+        glTexEnvi(GL11.GL_TEXTURE_ENV, GL11.GL_TEXTURE_ENV_MODE, GL13.GL_COMBINE);
+        glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_COMBINE_RGB, GL13.GL_REPLACE);
+        glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_SOURCE0_RGB, GL13.GL_CONSTANT);
+        glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_OPERAND0_RGB, GL11.GL_SRC_COLOR);
+        glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_COMBINE_ALPHA, GL13.GL_REPLACE);
+        glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_SOURCE0_ALPHA, GL13.GL_PREVIOUS);
+        glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_OPERAND0_ALPHA, GL11.GL_SRC_ALPHA);
+    }
+
+    /** Reverts enableOutlineMode to the default modulate texenv. */
+    public static void disableOutlineMode() {
+        glTexEnvi(GL11.GL_TEXTURE_ENV, GL11.GL_TEXTURE_ENV_MODE, GL11.GL_MODULATE);
+        glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_COMBINE_RGB, GL11.GL_MODULATE);
+        glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_SOURCE0_RGB, GL11.GL_TEXTURE);
+        glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_OPERAND0_RGB, GL11.GL_SRC_COLOR);
+        glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_COMBINE_ALPHA, GL11.GL_MODULATE);
+        glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_SOURCE0_ALPHA, GL11.GL_TEXTURE);
+        glTexEnvi(GL11.GL_TEXTURE_ENV, GL13.GL_OPERAND0_ALPHA, GL11.GL_SRC_ALPHA);
+    }
+
     public static void glTexEnvi(int target, int pname, int param) {
         handleTexEnvScalar(target, pname, param);
     }

--- a/src/test/java/com/gtnewhorizons/angelica/glsm/redirect/GLSMRedirectorTest.java
+++ b/src/test/java/com/gtnewhorizons/angelica/glsm/redirect/GLSMRedirectorTest.java
@@ -55,6 +55,36 @@ class GLSMRedirectorTest {
     }
 
     @Test
+    void rewritesVanillaGlStateManagerOutlineModeToGlsmCache() {
+        byte[] classBytes = generateClassCallingVanillaOutlineMode();
+        GLSMRedirector redirector = new GLSMRedirector();
+
+        assertTrue(redirector.shouldTransform(classBytes), "class referencing GlStateManager.enableOutlineMode must be a redirect candidate");
+
+        ClassNode cn = new ClassNode();
+        new ClassReader(classBytes).accept(cn, 0);
+        boolean changed = redirector.transformClassNode("sample/Class", cn);
+        assertTrue(changed, "GlStateManager.enableOutlineMode call must be rewritten");
+
+        MethodNode render = cn.methods.stream()
+            .filter(m -> m.name.equals("render"))
+            .findFirst()
+            .orElseThrow();
+        boolean redirected = false;
+        for (AbstractInsnNode node : render.instructions) {
+            if (node instanceof MethodInsnNode call
+                && call.getOpcode() == Opcodes.INVOKESTATIC
+                && call.owner.equals(GLSM_GL_STATE_MANAGER)
+                && call.name.equals("enableOutlineMode")
+                && call.desc.equals("(I)V")) {
+                redirected = true;
+                break;
+            }
+        }
+        assertTrue(redirected, "call must be redirected to GLSM GLStateManager.enableOutlineMode(I)V");
+    }
+
+    @Test
     void untouchedClassWithoutGlReferencesIsNotTransformed() {
         ClassWriter cw = new ClassWriter(0);
         cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, "sample/Plain", null, "java/lang/Object", null);
@@ -82,6 +112,21 @@ class GLSMRedirectorTest {
         mv.visitMethodInsn(Opcodes.INVOKESTATIC, VANILLA_GL_STATE_MANAGER, "color", "(FFFF)V", false);
         mv.visitInsn(Opcodes.RETURN);
         mv.visitMaxs(4, 1);
+        mv.visitEnd();
+        cw.visitEnd();
+        return cw.toByteArray();
+    }
+
+    private static byte[] generateClassCallingVanillaOutlineMode() {
+        ClassWriter cw = new ClassWriter(0);
+        cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, "sample/Class", null, "java/lang/Object", null);
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, "render", "()V", null, null);
+        mv.visitCode();
+        mv.visitLdcInsn(0xFFFF00);
+        mv.visitMethodInsn(Opcodes.INVOKESTATIC, VANILLA_GL_STATE_MANAGER, "enableOutlineMode", "(I)V", false);
+        mv.visitMethodInsn(Opcodes.INVOKESTATIC, VANILLA_GL_STATE_MANAGER, "disableOutlineMode", "()V", false);
+        mv.visitInsn(Opcodes.RETURN);
+        mv.visitMaxs(1, 1);
         mv.visitEnd();
         cw.visitEnd();
         return cw.toByteArray();

--- a/src/test/java/com/gtnewhorizons/angelica/glsm/redirect/GLStateManagerRedirectContractTest.java
+++ b/src/test/java/com/gtnewhorizons/angelica/glsm/redirect/GLStateManagerRedirectContractTest.java
@@ -52,6 +52,36 @@ class GLStateManagerRedirectContractTest {
         );
     }
 
+    @Test
+    void outlineModeMethodsExistForVanillaGlowRendering() throws IOException {
+        assertTrue(
+            methodDescriptors("enableOutlineMode").contains("(I)V"),
+            "GLStateManager must expose enableOutlineMode(int): the GL redirector rewrites vanilla "
+                + "GlStateManager.func_187431_e(I)V to it, and RenderLivingBase calls it whenever a living entity "
+                + "is glowing (spectral arrow, glowing potion, etc.) — missing it crashes rendering with "
+                + "NoSuchMethodError"
+        );
+        assertTrue(
+            methodDescriptors("disableOutlineMode").contains("()V"),
+            "GLStateManager must expose disableOutlineMode() to match the redirector registration"
+        );
+    }
+
+    private static Set<String> methodDescriptors(String methodName) throws IOException {
+        ClassNode classNode = new ClassNode();
+        try (InputStream in = GLStateManagerRedirectContractTest.class.getClassLoader()
+            .getResourceAsStream(GL_STATE_MANAGER_FILE)) {
+            if (in == null) {
+                throw new IOException("Could not find " + GL_STATE_MANAGER_FILE + " on the test classpath");
+            }
+            new ClassReader(in).accept(classNode, 0);
+        }
+        return classNode.methods.stream()
+            .filter(method -> method.name.equals(methodName))
+            .map(method -> method.desc)
+            .collect(Collectors.toSet());
+    }
+
     private static Set<String> glGetActiveUniformDescriptors() throws IOException {
         ClassNode classNode = new ClassNode();
         try (InputStream in = GLStateManagerRedirectContractTest.class.getClassLoader()


### PR DESCRIPTION
## 背景

渲染处于发光状态的实体（被光灵箭击中、发光药水、发光被动效果）时，客户端直接崩溃。

## 根因

`run/client/logs/latest.log` 中的崩溃堆栈：

```
java.lang.NoSuchMethodError: 'void com.gtnewhorizons.angelica.glsm.GLStateManager.enableOutlineMode(int)'
    at net.minecraft.client.renderer.entity.RenderLivingBase.doRender(MixinRenderLivingBase.java:153)
    ...
Caused by: net.minecraft.util.ReportedException: Rendering entity in world
```

GLSM 重定向器（`GLSMRedirector`）把 vanilla `GlStateManager.enableOutlineMode/disableOutlineMode`
（SRG `func_187431_e/func_187417_n`）按方法名改写为 `GLStateManager` 的静态调用，但目标方法
从未实现。任何实体一旦 `isGlowing()` 为真（如被光灵箭击中），渲染即触发 `NoSuchMethodError`。

## 修复

- `glsm/.../GLStateManager.java`：新增 `enableOutlineMode(int)` / `disableOutlineMode()`，
  逐参数忠实还原 vanilla 1.12.2 语义（`GL_TEXTURE_ENV_MODE=GL_COMBINE` + RGB/Alpha combine
  子参数 + 环境色），并全部走既有 `glTexEnv`/`glTexEnvi` 状态跟踪路径，FFP shader 可自动感知。
- `GLSMRedirectorTest`：新增重定向契约测试，验证 outline 调用被改写到 `GLStateManager.enableOutlineMode(I)V`。
- `GLStateManagerRedirectContractTest`：新增字节码断言，确认 `GLStateManager` 存在这两个方法。

## 验证

- `./gradlew check` 全绿（24 个任务）
- 6 个相关测试用例全过
- 常量值与 vanilla/LWJGL 数值逐项核对一致
