### PR TITLE
fix(compat): restore texture enablement after Botania world overlay

### DIFF
--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -141,4 +141,8 @@ dependencies {
     modImplementation 'curse.maven:oldresearchreborn-1632015:8642028'
     modImplementation 'curse.maven:thaumcraft-223628:2629023'
     modImplementation 'curse.maven:baubles-227083:2518667'
+
+    // Botania CEU (issue: held items render flat white because its RenderWorldLastEvent handlers leave
+    // GL_TEXTURE_2D disabled in the GLSM cache; the conditional botania mixin restores it)
+    modImplementation 'curse.maven:botania-ceu-1179448:8706250'
 }

--- a/src/main/java/com/dhj/actinium/compat/botania/BotaniaGlStateCompat.java
+++ b/src/main/java/com/dhj/actinium/compat/botania/BotaniaGlStateCompat.java
@@ -1,0 +1,25 @@
+package com.dhj.actinium.compat.botania;
+
+import com.gtnewhorizons.angelica.glsm.GLStateManager;
+
+/**
+ * Restores GL_TEXTURE_2D enablement after Botania's RenderWorldLastEvent handlers run.
+ *
+ * <p>Botania's {@code BlockHighlightRenderHandler} and {@code BoundTileRenderer} switch
+ * {@code GL_TEXTURE_2D} off to draw wireframe overlays, pairing each
+ * {@code disableTexture} with an {@code enableTexture}. Under the GLSM state cache the
+ * attrib-stack interaction can leave the active texture unit disabled when the handler
+ * returns, so the held-item pass that follows (RenderWorldLastEvent fires just before
+ * hand rendering) samples no texture and renders flat white. Item rendering always
+ * samples the block atlas, so re-enable the active texture unit after the handler.</p>
+ */
+public final class BotaniaGlStateCompat {
+
+    private BotaniaGlStateCompat() {
+    }
+
+    /** Re-enables GL_TEXTURE_2D on the active texture unit so item rendering samples the atlas. */
+    public static void restoreTextureEnablement() {
+        GLStateManager.enableTexture();
+    }
+}

--- a/src/main/java/com/dhj/actinium/mixin/mod/botania/MixinBlockHighlightRenderHandler.java
+++ b/src/main/java/com/dhj/actinium/mixin/mod/botania/MixinBlockHighlightRenderHandler.java
@@ -1,0 +1,27 @@
+package com.dhj.actinium.mixin.mod.botania;
+
+import com.dhj.actinium.compat.botania.BotaniaGlStateCompat;
+import net.minecraftforge.client.event.RenderWorldLastEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import vazkii.botania.client.core.handler.BlockHighlightRenderHandler;
+
+/**
+ * Restores GL_TEXTURE_2D enablement after Botania's block-highlight overlay pass.
+ *
+ * <p>Botania's {@code onWorldRenderLast} disables texture sampling to draw wireframe
+ * overlays; under the GLSM state cache its {@code glPushAttrib}/{@code disableTexture}
+ * pairing can leave the active texture unit disabled when the method returns, which
+ * makes the immediately following held-item pass render without texture (flat white).
+ * Re-enable the units so item rendering samples the atlas again.</p>
+ */
+@Mixin(value = BlockHighlightRenderHandler.class, remap = false)
+public abstract class MixinBlockHighlightRenderHandler {
+
+    @Inject(method = "onWorldRenderLast", at = @At("RETURN"))
+    private static void actinium$restoreTextureAfterHighlight(RenderWorldLastEvent event, CallbackInfo ci) {
+        BotaniaGlStateCompat.restoreTextureEnablement();
+    }
+}

--- a/src/main/java/com/dhj/actinium/mixin/mod/botania/MixinBoundTileRenderer.java
+++ b/src/main/java/com/dhj/actinium/mixin/mod/botania/MixinBoundTileRenderer.java
@@ -1,0 +1,26 @@
+package com.dhj.actinium.mixin.mod.botania;
+
+import com.dhj.actinium.compat.botania.BotaniaGlStateCompat;
+import net.minecraftforge.client.event.RenderWorldLastEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import vazkii.botania.client.core.handler.BoundTileRenderer;
+
+/**
+ * Restores GL_TEXTURE_2D enablement after Botania's bound-tile wireframe pass.
+ *
+ * <p>Same GLSM state-cache leak as {@code BlockHighlightRenderHandler}: the handler
+ * disables texture sampling to draw coordinate-bound outlines and can leave the active
+ * texture unit disabled when it returns, so the following held-item pass renders flat
+ * white. Re-enable the units so item rendering samples the atlas again.</p>
+ */
+@Mixin(value = BoundTileRenderer.class, remap = false)
+public abstract class MixinBoundTileRenderer {
+
+    @Inject(method = "onWorldRenderLast", at = @At("RETURN"))
+    private static void actinium$restoreTextureAfterBoundTiles(RenderWorldLastEvent event, CallbackInfo ci) {
+        BotaniaGlStateCompat.restoreTextureEnablement();
+    }
+}

--- a/src/main/resources/mixins.actinium.botania.json
+++ b/src/main/resources/mixins.actinium.botania.json
@@ -1,0 +1,17 @@
+{
+  "package": "com.dhj.actinium.mixin.mod.botania",
+  "required": true,
+  "refmap": "mixins.actinium-refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8.5",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [],
+  "server": [],
+  "client": [
+    "MixinBlockHighlightRenderHandler",
+    "MixinBoundTileRenderer"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/main/resources/mixins.actinium.conditions.properties
+++ b/src/main/resources/mixins.actinium.conditions.properties
@@ -13,3 +13,4 @@ mixins.actinium.voxelmap.json=voxelmap
 mixins.actinium.extrautils2.json=extrautils2
 mixins.actinium.cofhcore.json=cofhcore
 mixins.actinium.oldresearch.json=oldresearch
+mixins.actinium.botania.json=botania

--- a/src/test/java/com/dhj/actinium/mixin/MixinConfigurationTest.java
+++ b/src/test/java/com/dhj/actinium/mixin/MixinConfigurationTest.java
@@ -53,7 +53,8 @@ class MixinConfigurationTest {
         "mixins.actinium.voxelmap.json",
         "mixins.actinium.extrautils2.json",
         "mixins.actinium.cofhcore.json",
-        "mixins.actinium.oldresearch.json"
+        "mixins.actinium.oldresearch.json",
+        "mixins.actinium.botania.json"
     );
     private static final List<String> CONFIGS = Stream.concat(
         Stream.of(BRIDGE_CONFIG),

--- a/src/test/java/com/dhj/actinium/mixins/MixinLateTest.java
+++ b/src/test/java/com/dhj/actinium/mixins/MixinLateTest.java
@@ -43,7 +43,8 @@ class MixinLateTest {
                 "mixins.actinium.voxelmap.json",
                 "mixins.actinium.extrautils2.json",
                 "mixins.actinium.cofhcore.json",
-                "mixins.actinium.oldresearch.json"
+                "mixins.actinium.oldresearch.json",
+                "mixins.actinium.botania.json"
             ),
             Set.copyOf(MixinLate.configsFor(modId -> true))
         );


### PR DESCRIPTION
## 背景

加入 Botania CEU 后，手持物品渲染成全白（同时丢失透明度）。任何手持物品都会触发，且开启/关闭 Actinium 的物品 fast-path 设置都无法解决。

## 根因

Botania 的 `BlockHighlightRenderHandler` / `BoundTileRenderer` 在 `RenderWorldLastEvent`（紧邻手持物品渲染之前触发）里调用 `disableTexture` 来画线框覆盖层。在 GLSM 状态缓存下，`disableTexture`/`enableTexture` 与 `glPushAttrib` 的交互会让方法返回后活跃纹理单元仍处于禁用状态，导致紧随其后的手持物品渲染不采样纹理、FFP shader 输出纯白（并丢透明）。

`renderLitItem` 调试日志确认：物品渲染时 `tex2d=false`（纹理被禁用）、`boundTex=atlasTex`（纹理绑定正确但被禁用）。关闭 fast-path 走原版 Forge `drawSegment` 同样全白——问题不在 Actinium 的物品 fast-path。

## 修复

新增按 mod 存在性 gated 的 conditional mixin（`mixins.actinium.botania.json`）：
- `MixinBlockHighlightRenderHandler` / `MixinBoundTileRenderer`：在 `onWorldRenderLast` 返回后调用 `BotaniaGlStateCompat.restoreTextureEnablement()` 恢复 `GL_TEXTURE_2D` 启用。
- 业务逻辑放在 `compat/botania/BotaniaGlStateCompat`（mixin 类保持薄注入）。
- 依赖加入 `curse.maven:botania-ceu-1179448:8706250`。

## 验证

- 运行时日志确认物品渲染 `tex2d=true`（修复前 false），`lighting/l0/l1` 正常，用户实测正常。
- `./gradlew check` 全绿（含 `MixinConfigurationTest` / `MixinLateTest` 对新增 mixin 配置的校验）。
