### PR TITLE
fix(bridge): unify render material routing and lock renderer contract

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Actinium 架构说明
 
-最后更新：2026-08-13。
+最后更新：2026-08-27。
 
 ## 概述
 
@@ -405,7 +405,14 @@ LWJGL 后端（并入本子项目）：
   `CeleritasTileEntityRendererDispatcherMixin`（恢复旧六参 TE render ABI）、
   `LegacyRendererAccessMixin`、`LegacyRendererConstructionMixin`、`LegacyWorldSliceMixin`。
 - **`impl/`**：`gui/MinecraftOptionsStorage`（旧存储门面）、
-  `render/terrain/compile/pipeline`（`VintageBlockRenderer`、`ActiniumVintageBlockRenderer`）、
+  `render/terrain/compile/pipeline`（`VintageBlockRenderer`、`ActiniumVintageBlockRenderer`
+  —— 注意：桥内 renderBlock 编排及其私有成员是 Celeritas 2.4.0 兼容契约的一部分，
+  第三方 addon（celeritasleafculling 的 VintageBlockRendererMixin）会 @Shadow 其私有
+  字段与 renderQuadList，并 redirect renderBlock 内部的 renderQuadList 调用点，
+  因此编排不可收缩为纯转发别名；易漂移的渲染决策（如流体材质路由）经主实现共享
+  helper（`VintageBlockRenderer#resolveRenderMaterial`）保持单份实现，契约由
+  `CeleritasCompatBridgeJarTest#legacyRendererRetainsThirdPartyMixinBindingContract`
+  锁定）、
   `world/cloned`（`CeleritasBlockAccess` 旧名接口）。
 
 桥通过 `com.dhj.actinium.*`（`ActiniumRuntime`、`compat.sodium.LegacyOptionPageProvider`/

--- a/src/compatBridge/java/org/taumc/celeritas/impl/render/terrain/compile/pipeline/VintageBlockRenderer.java
+++ b/src/compatBridge/java/org/taumc/celeritas/impl/render/terrain/compile/pipeline/VintageBlockRenderer.java
@@ -91,7 +91,7 @@ public class VintageBlockRenderer extends ActiniumVintageBlockRenderer {
         access.actiniumLegacy$setCurrentRenderLayer(layer);
 
         ChunkBuildBuffers buffers = access.actiniumLegacy$getContext().buffers;
-        Material material = buffers.getRenderPassConfiguration().getMaterialForRenderType(layer);
+        Material material = this.resolveRenderMaterial(buffers, state, layer);
         ChunkModelBuilder buffer = buffers.get(material);
         long random = MathHelper.getPositionRandom(pos);
         IBlockColor colorProvider = access.actiniumLegacy$getBlockColors().get(state.getBlock().delegate);

--- a/src/main/java/com/dhj/actinium/render/terrain/compile/pipeline/VintageBlockRenderer.java
+++ b/src/main/java/com/dhj/actinium/render/terrain/compile/pipeline/VintageBlockRenderer.java
@@ -100,6 +100,19 @@ public class VintageBlockRenderer {
     public void resetSharedState() {
     }
 
+    /**
+     * Resolves the terrain material for one block render pass. Translucent water and lava are
+     * routed to the dedicated fluid material so they keep depth writes without forcing ordinary
+     * translucent terrain into the fluid pass (#79). The compat-bridge renderer inherits this
+     * decision so both render paths cannot drift apart again.
+     */
+    protected Material resolveRenderMaterial(ChunkBuildBuffers buffers, IBlockState state, BlockRenderLayer layer) {
+        boolean isFluid = state.getMaterial() == WATER || state.getMaterial() == LAVA;
+        return isFluid && layer == BlockRenderLayer.TRANSLUCENT
+                ? buffers.getRenderPassConfiguration().defaultFluidMaterial()
+                : buffers.getRenderPassConfiguration().getMaterialForRenderType(layer);
+    }
+
     public void renderBlock(IBlockState state, BlockPos pos, ActiniumBlockAccess blockAccess, BlockRenderLayer layer) {
         this.renderBlock(state, pos, blockAccess, layer, true);
     }
@@ -131,10 +144,7 @@ public class VintageBlockRenderer {
         this.currentRenderLayer = layer;
 
         var buffers = this.context.buffers;
-        boolean isFluid = state.getMaterial() == WATER || state.getMaterial() == LAVA;
-        var material = isFluid && layer == BlockRenderLayer.TRANSLUCENT
-                ? buffers.getRenderPassConfiguration().defaultFluidMaterial()
-                : buffers.getRenderPassConfiguration().getMaterialForRenderType(layer);
+        var material = resolveRenderMaterial(buffers, state, layer);
         var buffer = buffers.get(material);
 
         long rand = MathHelper.getPositionRandom(pos);

--- a/src/test/java/org/taumc/celeritas/CeleritasCompatBridgeJarTest.java
+++ b/src/test/java/org/taumc/celeritas/CeleritasCompatBridgeJarTest.java
@@ -41,6 +41,8 @@ class CeleritasCompatBridgeJarTest {
             "org/taumc/celeritas/compat/LegacyRendererAccess.class";
     private static final String LEGACY_RENDERER_CLASS =
             "org/taumc/celeritas/impl/render/terrain/compile/pipeline/VintageBlockRenderer.class";
+    private static final String LEGACY_RENDERER_INTERNAL_NAME =
+            "org/taumc/celeritas/impl/render/terrain/compile/pipeline/VintageBlockRenderer";
     private static final String MIXIN_CONFIG = "celeritas-compat-bridge.mixin.json";
     private static final String TARGET_OWNER =
             "net/minecraft/client/renderer/tileentity/TileEntityRendererDispatcher";
@@ -118,6 +120,60 @@ class CeleritasCompatBridgeJarTest {
                     renderer.methods, BLOCK_ACCESS_OWNER, WORLD_TYPE_DESCRIPTOR);
 
             assertEquals("func_175624_G", worldTypeCall.name);
+        }
+    }
+
+    private static final String RENDER_QUAD_LIST_DESCRIPTOR =
+            "(Lorg/embeddedt/embeddium/impl/render/chunk/compile/buffers/ChunkModelBuilder;"
+                    + "Lorg/embeddedt/embeddium/impl/render/chunk/compile/ChunkBuildBuffers;"
+                    + "Lorg/embeddedt/embeddium/impl/render/chunk/terrain/material/Material;"
+                    + "Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/EnumFacing;"
+                    + "Lorg/embeddedt/embeddium/impl/model/light/LightPipeline;"
+                    + "Lnet/minecraft/client/renderer/color/IBlockColor;Lnet/minecraft/util/math/Vec3d;"
+                    + "Ljava/util/List;)V";
+
+    /**
+     * Third-party renderer addons (celeritasleafculling's VintageBlockRendererMixin) shadow this
+     * class's private fields and its private renderQuadList method, and redirect the renderQuadList
+     * call sites inside renderBlock. Those internals are part of the Celeritas 2.4.0 compatibility
+     * contract: removing any of them fails addon mixin application and crashes world join
+     * (2026-08-27 production crash). The orchestration body may delegate decisions to shared
+     * helpers, but its shape and these members must stay.
+     */
+    @Test
+    void legacyRendererRetainsThirdPartyMixinBindingContract() throws IOException {
+        try (JarFile jar = openBridgeJar();
+             InputStream stream = jar.getInputStream(jar.getJarEntry(LEGACY_RENDERER_CLASS))) {
+            ClassNode renderer = readClass(stream);
+
+            assertTrue(renderer.fields.stream().anyMatch(field -> field.name.equals("currentState")
+                            && field.desc.equals("Lnet/minecraft/block/state/IBlockState;")),
+                    "The shadowed currentState field must stay declared");
+            assertTrue(renderer.fields.stream().anyMatch(field -> field.name.equals("currentBlockAccess")
+                            && field.desc.equals("Lorg/taumc/celeritas/impl/world/cloned/CeleritasBlockAccess;")),
+                    "The shadowed currentBlockAccess field must stay declared");
+            assertTrue(renderer.methods.stream().anyMatch(method -> method.name.equals("renderQuadList")
+                            && method.desc.equals(RENDER_QUAD_LIST_DESCRIPTOR)),
+                    "The shadowed renderQuadList method must stay declared");
+
+            int redirectableCallSites = 0;
+            for (MethodNode method : renderer.methods) {
+                if (!method.name.startsWith("renderBlock")) {
+                    continue;
+                }
+                for (AbstractInsnNode instruction = method.instructions.getFirst(); instruction != null;
+                        instruction = instruction.getNext()) {
+                    if (instruction instanceof MethodInsnNode call
+                            && call.owner.equals(LEGACY_RENDERER_INTERNAL_NAME)
+                            && call.name.equals("renderQuadList")
+                            && call.desc.equals(RENDER_QUAD_LIST_DESCRIPTOR)) {
+                        redirectableCallSites++;
+                    }
+                }
+            }
+            assertTrue(redirectableCallSites >= 2,
+                    "renderBlock must keep self-calls to renderQuadList for third-party redirects, found "
+                            + redirectableCallSites);
         }
     }
 


### PR DESCRIPTION
## Problem

The compat-bridge renderer (`celeritas-compat-bridge.jar`) carries a full copy of `VintageBlockRenderer.renderBlock`. Because it is a copy, decisions made in the main implementation silently miss the legacy path: the translucent fluid material routing added by #79 never reached the bridge copy (installing the bridge re-enables lost water depth writes), and #90 had to patch both renderers by hand for missing-model skipping and quad transformer wiring.

## Key finding: why the orchestration cannot simply be deleted

An intermediate attempt collapsed the bridge renderer into a thin forwarding alias. That crashed world join in a dev run with celeritasleafculling installed:

```
Mixin apply for mod celeritasleafculling failed
@Shadow method renderQuadList(...) was not located in the target class
→ NoClassDefFoundError → player dropped mid-login → null-player NPE cascade
```

Third-party addons bind Mixins against the bridge renderer's internals — celeritasleafculling shadows the private `currentState`/`currentBlockAccess` fields and the private `renderQuadList` method, and redirects every `renderQuadList` self-call inside `renderBlock` to implement leaf culling. The orchestration body is therefore part of the Celeritas 2.4.0 compatibility contract, not historical baggage. This PR documents that constraint instead of fighting it.

## Changes

- Extract translucent fluid material routing into one shared helper, `VintageBlockRenderer#resolveRenderMaterial(...)`, consumed by **both** the main and bridge orchestrations — #79-style fixes now cover the legacy path automatically.
- Add `CeleritasCompatBridgeJarTest#legacyRendererRetainsThirdPartyMixinBindingContract`: the compiled bridge renderer must keep the shadowed members plus at least two redirectable `renderQuadList` call sites, so a future "simplification" fails at build time instead of crashing client worlds.
- Document the contract in `docs/architecture.md`.

## Test plan

- [x] `./gradlew build --no-daemon` green, including the new jar contract test against the remapped bridge artifact.
- [x] dev client run with compat-bridge + celeritasleafculling installed: world join, chunk meshing, and shutdown complete with no mixin failures or crash report.