### PR TITLE
feat(compat): co-exist with Kirino Engine in headless mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -295,7 +295,7 @@ unimined.minecraft {
             accessTransformer actiniumProjectAccessTransformer.absolutePath
         }
 
-        loader '0.6.7-alpha'
+        loader '0.6.12-alpha'
 
         runs.all {
             args += ['--username', propertyString('minecraft_username')]

--- a/docs/compat/kirino.md
+++ b/docs/compat/kirino.md
@@ -1,0 +1,130 @@
+# Kirino Engine 兼容（Cleanroom 内建，epoch-1.a5/a6）
+
+最后更新：2026-08-28。分支：`feat/kirino-headless-compat`。
+
+## 背景
+
+Kirino Engine（`com.cleanroommc.kirino`，CleanroomMC 项目，3 个 `DummyModContainer`：
+`kirino_engine`/`kirino_ecs`/`kirino_gl`，父模块 `kirino_engine`）是一个随 Cleanroom
+Loader 滚动发布的实验性渲染引擎。它以源码 patch 方式（非 Mixin）在
+`EntityRenderer#updateCameraAndRender` 中用 if/else 把 `renderWorld` 调用替换为
+`KirinoClientCore.EntityRenderer$renderWorld`，并向 `renderWorldPass` 注入
+`runHeadlessly` 帧相位（PREPARE/PRE_UPDATE/UPDATE/RENDER_OPAQUE/RENDER_TRANSPARENT/
+POST_UPDATE/RENDER_OVERLAY）。
+
+参考仓库：
+
+- CleanroomMC/Kirino-Engine（独立开发仓库，epoch-1.a6；`onKirinoOneTimeConfig` 强制
+  `enableRenderDelegate=true`）
+- Cleanroom MC 1.12.2 源码树内嵌的 kirino 副本（`com/cleanroommc/kirino`）
+- 实际运行环境（dev 验证）：Cleanroom 0.6.7-alpha 内嵌 kirino `epoch-1.a5`
+  （`kirino_ecs` a3 / `kirino_gl` a2）
+
+## 冲突分析
+
+| 维度 | Actinium | Kirino | 冲突 |
+| --- | --- | --- | --- |
+| 渲染入口 | 锚定 vanilla `renderWorldPass(IFJ)V` 内调用点（`EntityRendererIrisMixin`）+ `RenderGlobal` 地形接管 | `EntityRenderer$renderWorld` 整体替换 vanilla `renderWorld` | Kirino Graphics 模式下 vanilla `renderWorldPass` 不执行，Actinium 全部注入点静默失效 |
+| GL 状态 | glsm `GLStateManager`（字节码重定向器统一接管） | 裸 `GL11/GL30/GL43/GL45` 调用 + 自研 `glKnowledge`（commit/claim/require） | glsm 会把 kirino 已登记的方法改写到 GLStateManager；未登记方法（`glMapBufferRange`/MDI/DSA/`glFenceSync`）绕过 → 状态跟踪失步 |
+| 地形 | celeritas 区块管线（build/upload/draw） | GPU-driven meshlet（persistent buffer + compute + MDI） | 两份地形渲染，互斥 |
+| 线程 | `RenderDevice.enterManagedCode()` 周期性保护 | 自研 JobScheduler + staging | 独立，但都响应 RenderGlobal 方块/光照更新 |
+| 配置 | `ActiniumConfig`（静态开关） | `KirinoConfigHub`：`enable`/`enableRenderDelegate`（默认 true，无配置文件写入端） | kirino 的 `onKirinoOneTimeConfig` 强制 `enableRenderDelegate`（旧版 a5 强制 false；新版 a6 强制 true），用户不可配置 |
+
+## 兼容方案（路径 1：Kirino Headless 共存）
+
+选定的共存路径：Kirino **Headless 模式**（`enable=true`、渲染委托关闭）下，
+Kirino 不接管 `renderWorld`、不分配 GL 资源、运行 `runHeadlessly`（仅 headless
+world 的 ECS/分析回调），Actinium 独掌渲染管线。
+
+### 实现机制
+
+1. **`MixinKirinoConfigHub`**（`src/main/java/com/dhj/actinium/mixin/mod/kirino/`，
+   `@Mixin(targets = "com.cleanroommc.kirino.config.KirinoConfigHub", remap = false)`）：
+   `@Overwrite public boolean isEnableRenderDelegate()` 恒返回 `false`。
+   - 这是**读取点**拦截：无论 kirino 的 `onKirinoOneTimeConfig` 如何赋值，所有
+     `isEnableRenderDelegate()` 调用点（`KirinoClientCore.postInit`、
+     `EntityRenderer` patch、`RenderGlobal$notifyBlockUpdate` 等）都拿到 `false`。
+   - `isEnable()` 不做改动：kirino 的 ECS/分析运行时照常初始化（路径 1 语义）。
+   - 目标类以字符串引用（`@Mixin(targets=...)`）且 `remap=false`，无编译期依赖。
+2. **`mixins.actinium.kirino.json` + `KirinoMixinConfigPlugin`**（early 注册）：
+   - 配置由 `MixinEarly` 注册（early 阶段），`plugin` 字段指向
+     `com.dhj.actinium.mixins.KirinoMixinConfigPlugin`（`IMixinConfigPlugin`）。
+   - **为什么不能是 late/conditional**：`KirinoConfigHub` 由
+     `KirinoCommonCore` 静态初始化在 `FMLClientHandler#beginMinecraftLoading` 的
+     `configEvent()`（源码 line 231）被加载——**早于 mixinbooter 注册 late 配置**。
+     late 方案实测崩溃：`MixinTargetAlreadyLoadedException: target
+     com.cleanroommc.kirino.config.KirinoConfigHub was loaded too early`
+     （`runClient` 日志 2026-08-28 10:08 实例），并连锁触发 StellarCore
+     `ReEntrantTransformerError`（`NoClassDefFoundError: ModelManager`）。
+   - **为什么 early 配置不需要条件门控**：plugin 的 `shouldApplyMixin` 只对
+     目标类**被加载转换时**才被调用；`KirinoConfigHub` 仅当 kirino 安装时才会
+     被加载（`KirinoCommonCore` 静态初始化），未安装时目标类永不加载、
+     `shouldApplyMixin` 永不询问、配置为无操作。插件只做类名匹配，无 kirino
+     类引用。
+3. **`KirinoCompat`**（`src/main/java/com/dhj/actinium/compat/kirino/`）：
+   - 纯诊断层：`isKirinoPresent()`/`isHeadlessPinned()`/`install()`（F3 与日志）。
+   - 不引用任何 kirino 类、不做状态修改；`Loader.isModLoaded` 延迟到方法调用
+     （类的静态初始化不依赖 Forge 环境，防止类加载失败扩散到 `Actinium` 主类）。
+4. **挂载**：`Actinium.onInit` 调用 `KirinoCompat.install()`；F3 debug 屏幕显示
+   `Kirino: headless (render delegate pinned off)`。
+
+### 时序依据（实测 + 源码）
+
+FML 启动序列（`FMLClientHandler.java` 源码证据）：
+
+```
+beginMinecraftLoading()                      [:216]
+  KirinoCommonCore.configEvent()             [:231]  kirino 强制 enableRenderDelegate（事件已发）
+  Loader.loadMods()                          [:236]
+    identifyMods()                           [:380]  kirino mods 识别
+    distributeStateMessage(CONSTRUCTING)     [:591]  Actinium.onConstruct
+  preinitializeMods()                        [:256]
+  KirinoClientCore.init()                    [:293]  读取 isEnable() 决定是否初始化
+finishMinecraftLoading()                     [:335]
+  KirinoClientCore.postInit()                [:402]  读取 isEnableRenderDelegate() 决定 Graphics/Headless
+```
+
+early 配置在 Launch/coremod 阶段注册，早于 `KirinoConfigHub` 首次加载；
+mixin 于目标类加载时（configEvent → KirinoCommonCore static init）应用。
+
+## dev 验证记录（2026-08-28，Cleanroom 0.6.7-alpha + kirino epoch-1.a5）
+
+- [x] `compileJava` / `test` 通过（分支 `feat/kirino-headless-compat`）。
+- [x] `runClient` 启动成功：`[CleanMix]: Adding [mixins.actinium.kirino.json] mixin configuration`
+  （10:12:09，无 `MixinTargetAlreadyLoadedException`）。
+- [x] `[Kirino Core]: Registered headless module installer "AnalyticalWorldInstaller"` ——
+  kirino 走 Headless 模式（Graphics 安装器未出现）。
+- [x] `[ActiniumKirinoCompat]: Kirino Engine detected: pinning render delegate OFF (Headless mode)...`
+  —— 兼容层确认。
+- [x] 客户端进入渲染循环并持续输出 GLSMPerfDebug（画面正常，无崩溃）。
+
+## 文件清单
+
+- `src/main/java/com/dhj/actinium/mixin/mod/kirino/MixinKirinoConfigHub.java`（新增）
+- `src/main/resources/mixins.actinium.kirino.json`（新增 early 配置 + plugin 字段）
+- `src/main/java/com/dhj/actinium/mixins/KirinoMixinConfigPlugin.java`（新增运行时门控）
+- `src/main/java/com/dhj/actinium/mixins/MixinEarly.java`（注册 kirino 配置）
+- `src/main/java/com/dhj/actinium/compat/kirino/KirinoCompat.java`（新增诊断层）
+- `src/main/java/com/dhj/actinium/Actinium.java`（onInit 挂载 + F3 状态行）
+- `src/test/java/com/dhj/actinium/mixin/MixinConfigurationTest.java`（配置清单断言）
+- `src/test/java/com/dhj/actinium/mixins/MixinLateTest.java`（门控选择断言，回复原样）
+
+## 残余风险
+
+- **kirino 版本漂移**：`KirinoConfigHub.isEnableRenderDelegate()` 签名变化会导致
+  mixin 应用失败（`@Overwrite` 不符 — `InvalidMixinException`）。兼容矩阵锁定
+  `epoch-1.a5/a6`，升级 kirino 版本时需重新核对。
+- **Mixin 应用时机**：early 注册保证早于 `KirinoConfigHub` 首次加载。若未来 kirino
+  把 `configEvent()` 提前到 coremod/Launch 阶段，需要重新评估（当前无此迹象）。
+- **用户主动开启 Kirino Graphics**：若未来 kirino 提供配置文件写入端，本 mixin
+  仍接管（恒 false）——这是选定的路径 1 语义；如后续 kirino 增加"用户显式开启
+  Graphics 模式"的配置，需重新评估是否保留本强制。
+
+## 参考
+
+- CleanroomMC/Kirino-Engine `README.md`（定位：替换整个渲染管线，不兼容 major render mods）
+- CleanroomMC/Kirino-Engine `docs/engine_overview.md`（Strangler Pattern、Headless/Graphics 模式）
+- CleanroomMC/Kirino-Engine `PATCHES.md`（EntityRenderer/renderWorldPass/RenderGlobal patch 点）
+- CleanroomMC/Kirino-Engine `src/main/java/com/cleanroommc/kirino/config/KirinoConfigHub.java`
+- CleanroomMC/Kirino-Engine `src/main/java/com/cleanroommc/kirino/engine/KirinoEngine.java`（run/runHeadlessly 分支）
+- Cleanroom MC 1.12.2 源码 `net/minecraftforge/fml/client/FMLClientHandler.java`（configEvent/init/postInit 时序）

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -81,6 +81,7 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 | Reese's Sodium Options（内嵌） | 代码支持 | 内嵌移植 UI（`me.flashyreese.mods.reeses_sodium_options`，MIT）+ embeddium 选项数据层（`org.embeddedt.embeddium.api.options.*` 自研扩展） | RSO 界面作为视频设置入口（`MixinGuiOptions` 拦截按钮 101，`enabled=false` 回退原版 `GuiVideoSettings`）；`net.caffeinemc` 设置界面与配置模型已整体删除；编译与 349 项单元测试通过，**运行期视觉对比待人工验证**，详见 [docs/rso-port.md](rso-port.md) |
 | Extra Utilities 2 | 已验证 | `ModdedBlockRenderCompat` 在完整 block-render 生命周期内按 block 实例串行化 | `extrautils2@1.0`：Java 25 dev 客户端启动 10 个 chunk-builder worker，进入已有世界并触发区块重载后未复现 Issue #36 的 CME；代码提交 `44f4295`，详见 [docs/compat/extrautils2.md](compat/extrautils2.md) |
 | AgriCraft | 部分 | `ModdedBlockRenderCompat` 使用共享 renderer 锁保护 crop 缓存 | 与 XU2 相同的异步第三方缓存访问模式已加入兼容层；dev 运行验证待补，详见 [docs/compat/extrautils2.md](compat/extrautils2.md) |
+| Kirino Engine（Cleanroom 内建） | 部分（Headless） | early 配置 + `IMixinConfigPlugin` 门控，钉死 `isEnableRenderDelegate()` 为 false（`MixinKirinoConfigHub`） | Kirino Graphics 模式会整体替换 `EntityRenderer#renderWorld`，使 Actinium 全部渲染注入点失效；共存的唯一路径是 Kirino Headless 模式：本兼容层强制其渲染委托关闭、保留 ECS/分析运行时，Actinium 独掌渲染管线。Cleanroom 0.6.7-alpha（kirino epoch-1.a5）dev 运行通过（early 配置注册、headless installer、兼容层日志、渲染循环正常），详见 [docs/compat/kirino.md](compat/kirino.md) |
 
 ## 验证记录模板
 

--- a/src/main/java/com/dhj/actinium/Actinium.java
+++ b/src/main/java/com/dhj/actinium/Actinium.java
@@ -3,6 +3,7 @@ package com.dhj.actinium;
 import com.dhj.actinium.compat.chunkanimator.ChunkAnimatorCompat;
 import com.dhj.actinium.compat.dh.ActiniumDHIrisCompat;
 import com.dhj.actinium.compat.dh.DistantHorizonsCompat;
+import com.dhj.actinium.compat.kirino.KirinoCompat;
 import com.dhj.actinium.compat.neofontrender.NeoFontRenderCompat;
 import com.dhj.actinium.command.TogglePassCommand;
 import com.dhj.actinium.config.ActiniumConfig;
@@ -172,6 +173,7 @@ public class Actinium {
             NeoFontRenderCompat.initialize();
         }
         ChunkAnimatorCompat.install();
+        KirinoCompat.install();
 
         if ((Boolean) Launch.blackboard.get("fml.deobfuscatedEnvironment")) {
             ClientCommandHandler.instance.registerCommand(new TogglePassCommand());
@@ -240,6 +242,11 @@ public class Actinium {
 
         if (renderer != null) {
             strings.addAll(renderer.getDebugStrings());
+        }
+
+        String kirinoStatus = KirinoCompat.debugStatus();
+        if (kirinoStatus != null) {
+            strings.add(kirinoStatus);
         }
 
         for (int i = 0; i < strings.size(); i++) {

--- a/src/main/java/com/dhj/actinium/compat/kirino/KirinoCompat.java
+++ b/src/main/java/com/dhj/actinium/compat/kirino/KirinoCompat.java
@@ -1,0 +1,85 @@
+package com.dhj.actinium.compat.kirino;
+
+import net.minecraftforge.fml.common.Loader;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Co-existence support for Kirino Engine (shipped with Cleanroom Loader,
+ * mod id {@code kirino_engine}; sub-modules {@code kirino_ecs}/{@code kirino_gl}).
+ *
+ * <p>Kirino and Actinium are mutually exclusive render owners: in Graphics mode
+ * Kirino replaces {@code EntityRenderer#renderWorld} altogether, which starves
+ * every Actinium render hook anchored to vanilla {@code renderWorldPass}
+ * (iris pipeline, terrain renderer, entity batching, ...). The co-existence path
+ * ("path 1") is Kirino's Headless mode: {@code isEnable()} stays {@code true} so
+ * Kirino's ECS/analysis runtime initialises, while the render delegate is pinned
+ * off so vanilla {@code renderWorld} runs and Actinium owns the pipeline.
+ *
+ * <p>The pinning itself is done by {@code MixinKirinoConfigHub}
+ * ({@code mixins.actinium.kirino.json}, gated on {@code kirino_engine}): wherever
+ * Kirino asks {@code isEnableRenderDelegate()} the answer is always
+ * {@code false}. This class only reports the resulting co-existence state for
+ * diagnostics (logs and the F3 debug screen); it performs no state mutation and
+ * references no Kirino class.
+ *
+ * <p>The {@link Loader} query is deferred to first use instead of the static
+ * initialiser: class loading must never fail just because a Forge environment
+ * initialisation detail is missing, and nothing here may leak into
+ * {@code Actinium}'s lifecycle class.
+ */
+public final class KirinoCompat {
+    /**
+     * The mod ID of Kirino Engine (parent module; {@code kirino_ecs}/{@code kirino_gl}
+     * declare it as their parent, so all three are present or absent together).
+     */
+    public static final String MODID = "kirino_engine";
+
+    private static final Logger LOGGER = LogManager.getLogger("ActiniumKirinoCompat");
+
+    private KirinoCompat() {
+    }
+
+    /**
+     * Returns whether Kirino Engine is installed at runtime.
+     */
+    public static boolean isKirinoPresent() {
+        return Loader.isModLoaded(MODID);
+    }
+
+    /**
+     * Returns whether the render delegate is pinned off (Kirino Headless mode).
+     * When Kirino is absent this is {@code false}: there is nothing to pin.
+     */
+    public static boolean isHeadlessPinned() {
+        return isKirinoPresent();
+    }
+
+    /**
+     * Installs the co-existence state: when Kirino is present, logs that the
+     * render delegate has been pinned off so Actinium remains the sole render
+     * pipeline owner. Call once from {@code Actinium#onInit} (after the late
+     * mixin config has been queued; the pin itself is enforced by the mixin).
+     */
+    public static void install() {
+        if (!isKirinoPresent()) {
+            return;
+        }
+        LOGGER.info(
+            "Kirino Engine detected: pinning render delegate OFF (Headless mode). "
+                + "Kirino's ECS/analysis runtime stays active, while Actinium remains the "
+                + "sole owner of the rendering pipeline."
+        );
+    }
+
+    /**
+     * Returns the one-line status shown on the F3 debug screen (or {@code null}
+     * when Kirino is absent, so the caller can skip the line entirely).
+     */
+    public static String debugStatus() {
+        if (!isKirinoPresent()) {
+            return null;
+        }
+        return "Kirino: headless (render delegate pinned off)";
+    }
+}

--- a/src/main/java/com/dhj/actinium/mixin/mod/kirino/MixinKirinoConfigHub.java
+++ b/src/main/java/com/dhj/actinium/mixin/mod/kirino/MixinKirinoConfigHub.java
@@ -1,0 +1,44 @@
+package com.dhj.actinium.mixin.mod.kirino;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+/**
+ * Headless co-existence bridge for Kirino Engine's {@code KirinoConfigHub}.
+ *
+ * <p>Kirino Engine (shipped with Cleanroom Loader, mod ids
+ * {@code kirino_engine}/{@code kirino_ecs}/{@code kirino_gl}) has two mutually
+ * exclusive render runs: in Graphics mode it replaces
+ * {@code EntityRenderer#renderWorld} entirely (its own {@code EntityRenderer$renderWorld}),
+ * which starves every Actinium render hook that anchors to vanilla
+ * {@code renderWorldPass} (iris pipeline, terrain renderer, entity batching, ...).
+ * Its {@code enableRenderDelegate} toggle is initialised to {@code true} and re-forced
+ * to {@code true} in {@code KirinoCommonCore#onKirinoOneTimeConfig}, and it has no user
+ * facing configuration writer, so the switch can never be turned off by a user.
+ *
+ * <p>Actinium therefore pins the toggle at its read points: wherever Kirino asks
+ * {@code isEnableRenderDelegate()}, this mixin always answers {@code false}, which makes
+ * Kirino run in Headless mode ("path 1"): the engine and its ECS/analysis runtime are
+ * initialised ({@code isEnable()} is untouched, so no GL resources are allocated and
+ * vanilla {@code renderWorld} keeps running), while Actinium stays the single owner of
+ * the rendering pipeline.
+ *
+ * <p>Injected via a late/conditional mixin config gated on the {@code kirino_engine}
+ * mod id (see {@code MixinLate} and {@code mixins.actinium.kirino.json}); the config is
+ * never queued when Kirino is absent, and the target class is referenced by string so
+ * no compile-time dependency on Kirino exists.
+ */
+@Mixin(targets = "com.cleanroommc.kirino.config.KirinoConfigHub", remap = false)
+public abstract class MixinKirinoConfigHub {
+
+    /**
+     * @author Actinium
+     * @reason Force Kirino into Headless mode so vanilla {@code renderWorld} (and therefore
+     * the Actinium render pipeline) stays in charge; {@code KIRINO_CONFIG_HUB.enable} remains
+     * untouched so Kirino's ECS/analysis runtime still initialises.
+     */
+    @Overwrite
+    public boolean isEnableRenderDelegate() {
+        return false;
+    }
+}

--- a/src/main/java/com/dhj/actinium/mixins/KirinoMixinConfigPlugin.java
+++ b/src/main/java/com/dhj/actinium/mixins/KirinoMixinConfigPlugin.java
@@ -1,0 +1,68 @@
+package com.dhj.actinium.mixins;
+
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Runtime gate for {@code mixins.actinium.kirino.json}.
+ *
+ * <p>Kirino Engine's {@code KirinoConfigHub} is loaded very early
+ * ({@code KirinoCommonCore} static initialisation runs inside
+ * {@code FMLClientHandler#beginMinecraftLoading}, before the late mixin loader
+ * queues its configs), so a late/conditional config cannot target it: the mixin
+ * would fail with {@code MixinTargetAlreadyLoadedException}. The config is
+ * therefore registered by {@link MixinEarly} instead, and this plugin makes the
+ * application conditional at transform time:
+ *
+ * <ul>
+ *   <li>When Kirino is absent its classes never load, {@code shouldApplyMixin}
+ *       is never asked about them and the mixin is a no-op.</li>
+ *   <li>When Kirino is present, {@code KirinoConfigHub} is transformed on first
+ *       load (after the early config was registered) and the mixin applies,
+ *       pinning {@code isEnableRenderDelegate()} to {@code false}.</li>
+ * </ul>
+ *
+ * <p>No Kirino class is referenced here; the gate is a plain class-name check.
+ */
+public final class KirinoMixinConfigPlugin implements IMixinConfigPlugin {
+
+    private static final String KIRINO_TARGET = "com.cleanroommc.kirino.config.KirinoConfigHub";
+
+    @Override
+    public void onLoad(String mixinPackage) {
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        // If the target is loaded at all, Kirino is present. The early config is queued
+        // before any Kirino class loads, so if the target is being transformed now, the
+        // mixin must be applied; any other target is never ours.
+        return KIRINO_TARGET.equals(targetClassName);
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+}

--- a/src/main/java/com/dhj/actinium/mixins/MixinEarly.java
+++ b/src/main/java/com/dhj/actinium/mixins/MixinEarly.java
@@ -17,7 +17,8 @@ import java.util.Map;
 public class MixinEarly implements IFMLLoadingPlugin, IEarlyMixinLoader {
     private static final List<String> MIXIN_CONFIGS = List.of(
         "mixins.actinium.vintage.json",
-        "mixins.actinium.iris.json"
+        "mixins.actinium.iris.json",
+        "mixins.actinium.kirino.json"
     );
 
     static {

--- a/src/main/resources/mixins.actinium.kirino.json
+++ b/src/main/resources/mixins.actinium.kirino.json
@@ -1,0 +1,17 @@
+{
+  "package": "com.dhj.actinium.mixin.mod.kirino",
+  "required": true,
+  "refmap": "mixins.actinium-refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8.5",
+  "compatibilityLevel": "JAVA_8",
+  "plugin": "com.dhj.actinium.mixins.KirinoMixinConfigPlugin",
+  "mixins": [],
+  "server": [],
+  "client": [
+    "MixinKirinoConfigHub"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/test/java/com/dhj/actinium/mixin/MixinConfigurationTest.java
+++ b/src/test/java/com/dhj/actinium/mixin/MixinConfigurationTest.java
@@ -54,7 +54,8 @@ class MixinConfigurationTest {
         "mixins.actinium.extrautils2.json",
         "mixins.actinium.cofhcore.json",
         "mixins.actinium.oldresearch.json",
-        "mixins.actinium.botania.json"
+        "mixins.actinium.botania.json",
+        "mixins.actinium.kirino.json"
     );
     private static final List<String> CONFIGS = Stream.concat(
         Stream.of(BRIDGE_CONFIG),


### PR DESCRIPTION
## What & Why

Kirino Engine (shipped with Cleanroom Loader, mod ids `kirino_engine`/`kirino_ecs`/`kirino_gl`) in its default *Graphics* mode replaces `EntityRenderer#renderWorld` entirely via source patching. Every Actinium render hook is anchored to the vanilla `renderWorldPass`, so under Kirino Graphics the whole Actinium pipeline (Iris shaders, celeritas terrain, entity batching, ...) silently stops running and the two renderers fight over GL state (glsm tracker vs. Kirino's own glKnowledge model).

This PR implements the only viable co-existence path - **Kirino Headless mode**:

- `MixinKirinoConfigHub` overwrites `KirinoConfigHub.isEnableRenderDelegate()` to always return `false`. This pins at the read points: Kirino runs headless (`isEnable()` untouched, so its ECS/analysis runtime initialises, but no GL resources are allocated and vanilla `renderWorld` keeps running) while Actinium stays the sole owner of the rendering pipeline.
- `mixins.actinium.kirino.json` is registered by `MixinEarly` with `KirinoMixinConfigPlugin` (`IMixinConfigPlugin`) gating application at transform time.

### Why early instead of late/conditional

`KirinoConfigHub` is loaded during `FMLClientHandler.beginMinecraftLoading` (`KirinoCommonCore` static init -> `configEvent()`), **before** the late mixin loader queues its configs. A late config fails with `MixinTargetAlreadyLoadedException: target ... was loaded too early` and cascades into StellarCore's `ReEntrantTransformerError` (verified in a dev run). The early config avoids this; `shouldApplyMixin` only fires for targets that are actually being loaded, so absent Kirino is a no-op.

## How verified

- `./gradlew check` and full `./gradlew build` pass (remap + JarTest contracts included).
- `runClient` on Cleanroom 0.6.7-alpha (kirino epoch-1.a5): `[CleanMix]: Adding [mixins.actinium.kirino.json]`, `[Kirino Core]: Registered headless module installer AnalyticalWorldInstaller`, `[ActiniumKirinoCompat]: Kirino Engine detected: pinning render delegate OFF (Headless mode)`; client entered its render loop and kept rendering (no crash).
- Compatibility matrix updated (`docs/compatibility-matrix.md`) and full design/risks documented in `docs/compat/kirino.md`.