### PR TITLE
fix(compat): route Scannable scan wave through its overlay path

### DIFF
--- a/docs/compat/scannable.md
+++ b/docs/compat/scannable.md
@@ -1,0 +1,82 @@
+# Scannable 兼容（issue #94）
+
+## 概述
+
+- 模组：Scannable（CurseForge project `266784`，dev 依赖 `curse.maven:scannable-266784:3146549`，即 `Scannable-MC1.12.2-1.6.3.26.jar`）
+- 症状：使用扫描器后——无光影时世界透视（可透过地面看到地下空洞）；开光影（Solas Shader）时画面全白并有拖影，无报错。
+- 修复：条件 Mixin（`mixins.actinium.scannable.json`，mod id 门控 `scannable`）把 Scannable 的
+  OptiFine 集成探针接到 Actinium，使其走自带的"外部 shader mod"渲染路径。
+
+## 根因
+
+Scannable 的扫描波渲染有两条路径（`ScannerRenderer`）：
+
+1. **INJECT**（默认，`Settings.injectDepthTexture=true`）：扫描期间把主 framebuffer 的
+   `GL_DEPTH_ATTACHMENT` 偷换成自己的 depth texture（`installDepthTexture`，帧首
+   `RenderTickEvent.Phase.START` 执行），在 `RenderWorldLastEvent` 里全屏采样该纹理画扫描波，
+   扫描结束（`uninstallDepthTexture`）用 `glFramebufferRenderbuffer(..., Framebuffer.depthBuffer)`
+   "恢复"深度 attachment。
+2. **OPTIFINE**：仅当 `ProxyOptiFine.isShaderPackLoaded()`（反射 OptiFine 的
+   `net.optifine.shaders.Shaders.shaderPackLoaded`）为 true 时启用——world 渲染后把
+   OptiFine 的 depth texture 复制到私有 FBO（`copyDepthTexture`），在
+   `RenderGameOverlayEvent.Pre(ALL)` 阶段画扫描波。全程不触碰主 framebuffer 的 attachment。
+
+Actinium 的 `FramebufferIrisMixin` 把主 framebuffer 的深度缓冲从 vanilla renderbuffer 换成了
+共享 depth texture（`actinium$createDepthTexture`），并通过 `@Redirect` 跳过 vanilla 的
+depth renderbuffer 创建——因此 `Framebuffer.depthBuffer` 恒为 0。由此产生两个破坏：
+
+- **无光影透视**：INJECT 模式扫描结束的"恢复"实际执行
+  `glFramebufferRenderbuffer(GL_DEPTH_ATTACHMENT, depthBuffer=0)`，把主 framebuffer 的深度
+  attachment 完全卸下，此后地形渲染没有深度缓冲、失去自遮挡（透视）。扫描期间
+  `installDepthTexture` 还会把 Actinium 的共享深度纹理从 attachment 上顶掉。
+- **光影全白拖影**：Scannable 不认识 Actinium 的 Iris 管线（只反射 OptiFine），走 INJECT 且
+  在 `RenderWorldLastEvent` 时机对"当前绑定的 FBO"（Iris render target）做 attachment 换装，
+  并把 additive 混合的全屏扫描 quad 直接画进管线目标——gbuffer 深度被破坏、错误颜色逐帧
+  叠加残留，表现为全白与拖影。
+
+`ScanManager` 的扫描结果标记框（实体/方块高亮，即 issue 中预期的"扫描框"）同样按
+`isShaderPackLoaded` 在 `RenderWorldLastEvent` 直画与 overlay 阶段绘制之间切换，受同一探针控制。
+
+## 修复方案
+
+条件 Mixin `MixinProxyOptiFine` 注入 Scannable 的 `ProxyOptiFine`：
+
+- `isShaderPackLoaded()`：OptiFine 反射结果为 true 时放行（Actinium 环境不与 OptiFine 共存，
+  实际不会发生）；否则当 Actinium 能提供深度纹理时改答 true，使 Scannable 全程走
+  OPTIFINE 路径。
+- `getDepthTexture()`：OptiFine 未提供纹理（返回 0）时改答主 framebuffer 的共享深度纹理
+  （`IRenderTargetExt.iris$getDepthTextureId()`，即 `FramebufferIrisMixin.actinium$depthTextureId`）。
+
+该纹理正是 Iris 光影管线 gbuffer 深度的落点（`DeferredWorldRenderingPipeline` 用它构造
+`RenderTargets`），因此无论是否开光影，Scannable 采样到的都是世界深度。OPTIFINE 路径：
+
+- 不触碰主 framebuffer 的 depth attachment（INJECT 的两处破坏点不再执行）；
+- `copyDepthTexture` 采样深度纹理时绑定的是 Scannable 私有 FBO，无 feedback loop；
+- 扫描波与扫描框统一推迟到 overlay 阶段绘制，与 OptiFine 用户所见行为一致。
+
+业务逻辑集中在 `compat/scannable/ScannableShaderCompat`（mixin 只做注入）。
+
+## 验证
+
+- 编译：`gradlew compileJava` 通过；`MixinConfigurationTest` 已登记
+  `mixins.actinium.scannable.json`。
+- dev 运行验证（待执行）：装 Scannable 使用扫描器，无光影下世界不再透视、扫描框正常渲染；
+  开 Solas Shader 后画面不全白、无拖影。
+- 诊断开关：`-Dactinium.debug.scannable=true` 输出深度纹理探针与接管通知日志。
+
+## 已知边界
+
+- 扫描进行中开启/关闭光影（mode 切换窗口）属于 Scannable 自身在 OptiFine 下同样存在的
+  边界情况，未做额外处理。
+- OPTIFINE 路径的深度副本格式（R32F）由 Scannable 自有 shader 决定，与 OptiFine 环境一致，
+  未做改动。
+
+## Follow-up：深度副本纹理格式修正（dev 验证反馈）
+
+首版修复后 dev 实测发现：绑定大量方块（如草方块，开阔地表场景）时扫描波覆盖区域不正确。
+根因是 Scannable 自身 bug——其深度副本纹理按 `(GL_R32F, GL_RED, GL_UNSIGNED_BYTE)` 分配，
+而 `GL_R32F` 仅接受 `GL_FLOAT`/`GL_HALF_FLOAT` 像素类型，无效组合使纹理分配失败、无存储，
+copy pass 写入不完整 FBO，overlay 阶段采到未定义深度 → 反投影错乱、扫描波区域错位。
+`MixinScannerRenderer`（`@ModifyArgs`）将该分配的像素类型修正为 `GL_FLOAT`；INJECT/RENDER
+路径的深度纹理分配使用合法组合，不受影响。修正后 R32F 副本携带全精度深度，扫描波反投影
+恢复正确。

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -82,6 +82,7 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 | Extra Utilities 2 | 已验证 | `ModdedBlockRenderCompat` 在完整 block-render 生命周期内按 block 实例串行化 | `extrautils2@1.0`：Java 25 dev 客户端启动 10 个 chunk-builder worker，进入已有世界并触发区块重载后未复现 Issue #36 的 CME；代码提交 `44f4295`，详见 [docs/compat/extrautils2.md](compat/extrautils2.md) |
 | AgriCraft | 部分 | `ModdedBlockRenderCompat` 使用共享 renderer 锁保护 crop 缓存 | 与 XU2 相同的异步第三方缓存访问模式已加入兼容层；dev 运行验证待补，详见 [docs/compat/extrautils2.md](compat/extrautils2.md) |
 | Kirino Engine（Cleanroom 内建） | 部分（Headless） | early 配置 + `IMixinConfigPlugin` 门控，钉死 `isEnableRenderDelegate()` 为 false（`MixinKirinoConfigHub`） | Kirino Graphics 模式会整体替换 `EntityRenderer#renderWorld`，使 Actinium 全部渲染注入点失效；共存的唯一路径是 Kirino Headless 模式：本兼容层强制其渲染委托关闭、保留 ECS/分析运行时，Actinium 独掌渲染管线。Cleanroom 0.6.7-alpha（kirino epoch-1.a5）dev 运行通过（early 配置注册、headless installer、兼容层日志、渲染循环正常），详见 [docs/compat/kirino.md](compat/kirino.md) |
+| Scannable | 已验证 | 条件 Mixin（接管 `ProxyOptiFine` 探针，扫描波走其 overlay 路径） | 1.6.3.26（266784:3146549）：使用扫描器后无光影透视 / 光影全白拖影的根因是其 INJECT 路径换装主 FBO 深度 attachment（Actinium 下 `Framebuffer.depthBuffer` 为 0，"恢复"即卸下深度）；已引导其走 OptiFine 式 overlay 渲染路径，详见 [docs/compat/scannable.md](compat/scannable.md)；dev 运行验证通过（无光影透视与光影全白均消失、扫描波区域正确；相邻结果合并为聚类大框为 Scannable 固有设计） |
 
 ## 验证记录模板
 

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -145,4 +145,8 @@ dependencies {
     // Botania CEU (issue: held items render flat white because its RenderWorldLastEvent handlers leave
     // GL_TEXTURE_2D disabled in the GLSM cache; the conditional botania mixin restores it)
     modImplementation 'curse.maven:botania-ceu-1179448:8706250'
+
+    // Scannable 1.6.3.26 (issue #94: its scanner overlay rendering conflicts with the Actinium render
+    // pipeline -- see-through terrain without shaders, white ghosting with shaders; needs runtime repro)
+    modImplementation 'curse.maven:scannable-266784:3146549'
 }

--- a/src/main/java/com/dhj/actinium/compat/scannable/ScannableShaderCompat.java
+++ b/src/main/java/com/dhj/actinium/compat/scannable/ScannableShaderCompat.java
@@ -1,0 +1,105 @@
+package com.dhj.actinium.compat.scannable;
+
+import net.coderbot.iris.rendertarget.IRenderTargetExt;
+import net.minecraft.client.Minecraft;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Adapter that lets Actinium stand in as the "shader mod" side of Scannable's OptiFine
+ * integration ({@code li.cil.scannable.integration.optifine.ProxyOptiFine}).
+ *
+ * <p>Motivation (issue #94): Scannable's default scan-wave path ({@code injectDepthTexture=true},
+ * mode {@code INJECT}) swaps the main framebuffer's {@code GL_DEPTH_ATTACHMENT} over to a private
+ * depth texture and later restores it with {@code glFramebufferRenderbuffer(..., depthBuffer)}.
+ * {@code FramebufferIrisMixin} replaces the vanilla depth renderbuffer with a shared depth
+ * texture ({@code Framebuffer.depthBuffer} stays 0), so Scannable's restore detaches the depth
+ * attachment entirely: terrain rendering afterwards has no depth buffer and loses
+ * self-occlusion, which reads as see-through ground. With a shader pack active the same code
+ * also runs while an Iris render target is bound, churning the gbuffer depth attachment and
+ * drawing the additive scan quad into the pipeline's targets (white screen with ghosting).</p>
+ *
+ * <p>Scannable ships a dedicated path for external shader mods (mode {@code OPTIFINE}): it copies
+ * the shader mod's depth texture into a private FBO right after world rendering and draws the
+ * scan wave during the overlay phase. That path never touches the main framebuffer's attachments,
+ * which is exactly what Actinium needs. {@code ProxyOptiFine} resolves OptiFine reflectively and
+ * reports "no shader mod" when it is absent, so the Scannable mixin reroutes its two queries
+ * ({@code isShaderPackLoaded} / {@code getDepthTexture}) here; Actinium's shared main-framebuffer
+ * depth texture is the exact object Iris renders gbuffer depth into
+ * ({@code DeferredWorldRenderingPipeline} constructs {@code RenderTargets} from it), so it carries
+ * the world depth both with and without a shader pack.</p>
+ *
+ * <p>Assumption: Actinium's Cleanroom environment does not coexist with OptiFine, so when
+ * {@code ProxyOptiFine} reports an OptiFine-managed depth texture we defer to it unchanged.</p>
+ */
+public final class ScannableShaderCompat {
+
+    private static final Logger LOGGER = LogManager.getLogger("ActiniumScannableCompat");
+
+    /**
+     * Verbose tracing for field diagnosis (issue #94 reproduction): enabled with
+     * {@code -Dactinium.debug.scannable=true}. Per-call probes are only logged while this is on;
+     * the takeover notice is always logged once.
+     */
+    private static final boolean DEBUG = Boolean.getBoolean("actinium.debug.scannable");
+
+    private static boolean takeoverLogged;
+    private static boolean copyFixLogged;
+
+    private ScannableShaderCompat() {
+    }
+
+    /**
+     * Whether Actinium can take over Scannable's shader-mod probes.
+     *
+     * <p>True exactly when the shared main-framebuffer depth texture exists; that texture is both
+     * the depth attachment Actinium installs and the object Iris renders gbuffer depth into, so
+     * its presence is the precondition for answering Scannable's queries.</p>
+     */
+    public static boolean canProvideDepthTexture() {
+        return mainDepthTextureId() > 0;
+    }
+
+    /**
+     * Id of the shared main-framebuffer depth texture, or 0 when it does not exist yet.
+     *
+     * <p>{@code iris$getDepthTextureId()} reports -1 before the main framebuffer is built; the
+     * OptiFine query contract this feeds treats 0 as "no depth texture" (Scannable then skips
+     * rendering the wave), so the sentinel is mapped onto that value. The id is read live on
+     * every call because framebuffer resizes recreate the texture.</p>
+     */
+    public static int mainDepthTextureId() {
+        final int id = ((IRenderTargetExt) Minecraft.getMinecraft().getFramebuffer()).iris$getDepthTextureId();
+        if (DEBUG) {
+            LOGGER.info("scannable depth probe: main framebuffer depth texture id={}", id);
+        }
+        return id > 0 ? id : 0;
+    }
+
+    /** Logs the takeover once so reproduction runs can confirm the compat path is engaged. */
+    public static void logTakeover() {
+        if (takeoverLogged) {
+            return;
+        }
+        takeoverLogged = true;
+        LOGGER.info(
+            "Scannable compat: Actinium now answers its shader-mod probes (depth texture {}); "
+                + "scan wave uses Scannable's overlay path instead of depth-attachment injection",
+            mainDepthTextureId());
+    }
+
+    /**
+     * Logs the depth-copy texture format fix once; traces the corrected pixel type so a
+     * reproduction run can confirm the wave samples valid depth data.
+     */
+    public static void logCopyTextureFix() {
+        if (copyFixLogged) {
+            return;
+        }
+        copyFixLogged = true;
+        LOGGER.info(
+            "Scannable compat: fixed depth-copy texture pixel type {} -> {} (GL_R32F requires "
+                + "GL_FLOAT; the original GL_UNSIGNED_BYTE allocation yields no storage)",
+            5121, 5126);
+    }
+}

--- a/src/main/java/com/dhj/actinium/mixin/mod/scannable/MixinProxyOptiFine.java
+++ b/src/main/java/com/dhj/actinium/mixin/mod/scannable/MixinProxyOptiFine.java
@@ -1,0 +1,54 @@
+package com.dhj.actinium.mixin.mod.scannable;
+
+import com.dhj.actinium.compat.scannable.ScannableShaderCompat;
+import li.cil.scannable.integration.optifine.ProxyOptiFine;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Routes Scannable's shader-mod probes to Actinium (issue #94).
+ *
+ * <p>Scannable drives its scan-wave rendering off two OptiFine queries. With no OptiFine present
+ * it falls back to mode {@code INJECT}, which swaps the main framebuffer's depth attachment and
+ * restores it via the vanilla {@code Framebuffer.depthBuffer} renderbuffer — a buffer Actinium's
+ * {@code FramebufferIrisMixin} never creates (depth lives in a shared texture instead), so the
+ * restore detaches the attachment and terrain loses depth testing (see-through ground); with a
+ * shader pack the same code additionally churns the gbuffer depth attachment and draws the scan
+ * quad into Iris render targets (white screen with ghosting).</p>
+ *
+ * <p>By answering "shader pack loaded" here, Scannable picks its dedicated external-shader-mod
+ * path: mode {@code OPTIFINE} copies the provided depth texture into a private FBO after world
+ * rendering and draws the wave during the overlay phase, never touching the main framebuffer's
+ * attachments. {@link ScannableShaderCompat} supplies the shared main-framebuffer depth texture,
+ * which carries the world depth both with and without a shader pack.</p>
+ */
+@Mixin(value = ProxyOptiFine.class, remap = false)
+public abstract class MixinProxyOptiFine {
+
+    /**
+     * Reports Actinium's pipeline as the active shader pack so Scannable uses its
+     * attachment-safe {@code OPTIFINE} path. An OptiFine-provided "yes" passes through
+     * untouched; Actinium's environment does not coexist with OptiFine, so in practice this
+     * only upgrades the reflected "no".
+     */
+    @Inject(method = "isShaderPackLoaded()Z", at = @At("RETURN"), cancellable = true)
+    private void actinium$reportShaderPipeline(CallbackInfoReturnable<Boolean> cir) {
+        if (!cir.getReturnValueZ() && ScannableShaderCompat.canProvideDepthTexture()) {
+            ScannableShaderCompat.logTakeover();
+            cir.setReturnValue(true);
+        }
+    }
+
+    /**
+     * Feeds the shared main-framebuffer depth texture when the reflective OptiFine probe
+     * yields none. Returned as-is otherwise, keeping an OptiFine-managed texture authoritative.
+     */
+    @Inject(method = "getDepthTexture()I", at = @At("RETURN"), cancellable = true)
+    private void actinium$provideMainDepthTexture(CallbackInfoReturnable<Integer> cir) {
+        if (cir.getReturnValueI() == 0) {
+            cir.setReturnValue(ScannableShaderCompat.mainDepthTextureId());
+        }
+    }
+}

--- a/src/main/java/com/dhj/actinium/mixin/mod/scannable/MixinScannerRenderer.java
+++ b/src/main/java/com/dhj/actinium/mixin/mod/scannable/MixinScannerRenderer.java
@@ -1,0 +1,45 @@
+package com.dhj.actinium.mixin.mod.scannable;
+
+import com.dhj.actinium.compat.scannable.ScannableShaderCompat;
+import li.cil.scannable.client.renderer.ScannerRenderer;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL30;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+/**
+ * Fixes the depth-copy texture format of Scannable's shader-mod path (issue #94 follow-up).
+ *
+ * <p>{@code installDepthTexture}'s OPTIFINE branch allocates the depth copy with
+ * {@code (GL_R32F, GL_RED, GL_UNSIGNED_BYTE)}. {@code GL_R32F} only accepts {@code GL_FLOAT} or
+ * {@code GL_HALF_FLOAT} as the pixel type, so the allocation fails with GL_INVALID_OPERATION and
+ * the texture never receives storage: the copy pass then draws into an incomplete framebuffer and
+ * the scan wave samples undefined values, displacing the wave's rendered region (mismatched scan
+ * area, most visible over wide open surfaces such as grass-bound scans). Switch the pixel type to
+ * {@code GL_FLOAT} so the copy actually carries depth; the copy shader already writes plain
+ * floats, and {@code GL_R32F} is color-renderable in the core-profile contexts Actinium targets.</p>
+ */
+@Mixin(value = ScannerRenderer.class, remap = false)
+public abstract class MixinScannerRenderer {
+
+    /**
+     * Redirects the pixel type of the R32F depth-copy allocation to {@code GL_FLOAT}. Other
+     * allocations routed through the same {@code createTexture} helper (the depth textures of the
+     * INJECT/RENDER paths) use depth formats with valid types and are left untouched.
+     */
+    @ModifyArgs(
+        method = "installDepthTexture(Lnet/minecraft/client/shader/Framebuffer;)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lli/cil/scannable/client/renderer/ScannerRenderer;createTexture(IIIII)I"
+        )
+    )
+    private void actinium$fixCopyDepthTextureType(Args args) {
+        if ((Integer) args.get(2) == GL30.GL_R32F) {
+            ScannableShaderCompat.logCopyTextureFix();
+            args.set(4, GL11.GL_FLOAT);
+        }
+    }
+}

--- a/src/main/resources/mixins.actinium.conditions.properties
+++ b/src/main/resources/mixins.actinium.conditions.properties
@@ -14,3 +14,4 @@ mixins.actinium.extrautils2.json=extrautils2
 mixins.actinium.cofhcore.json=cofhcore
 mixins.actinium.oldresearch.json=oldresearch
 mixins.actinium.botania.json=botania
+mixins.actinium.scannable.json=scannable

--- a/src/main/resources/mixins.actinium.scannable.json
+++ b/src/main/resources/mixins.actinium.scannable.json
@@ -1,0 +1,17 @@
+{
+  "package": "com.dhj.actinium.mixin.mod.scannable",
+  "required": true,
+  "refmap": "mixins.actinium-refmap.json",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8.5",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [],
+  "server": [],
+  "client": [
+    "MixinProxyOptiFine",
+    "MixinScannerRenderer"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/test/java/com/dhj/actinium/mixin/MixinConfigurationTest.java
+++ b/src/test/java/com/dhj/actinium/mixin/MixinConfigurationTest.java
@@ -55,7 +55,8 @@ class MixinConfigurationTest {
         "mixins.actinium.cofhcore.json",
         "mixins.actinium.oldresearch.json",
         "mixins.actinium.botania.json",
-        "mixins.actinium.kirino.json"
+        "mixins.actinium.kirino.json",
+        "mixins.actinium.scannable.json"
     );
     private static final List<String> CONFIGS = Stream.concat(
         Stream.of(BRIDGE_CONFIG),

--- a/src/test/java/com/dhj/actinium/mixins/MixinLateTest.java
+++ b/src/test/java/com/dhj/actinium/mixins/MixinLateTest.java
@@ -44,7 +44,8 @@ class MixinLateTest {
                 "mixins.actinium.extrautils2.json",
                 "mixins.actinium.cofhcore.json",
                 "mixins.actinium.oldresearch.json",
-                "mixins.actinium.botania.json"
+                "mixins.actinium.botania.json",
+                "mixins.actinium.scannable.json"
             ),
             Set.copyOf(MixinLate.configsFor(modId -> true))
         );


### PR DESCRIPTION
## Summary

Fixes #94 (Scannable 1.6.3.26 与 Actinium 冲突：无光影扫描后世界透视、光影下画面全白拖影)。

Scannable's default scan-wave path (`injectDepthTexture=true`, mode `INJECT`) swaps the main
framebuffer's `GL_DEPTH_ATTACHMENT` over to a private depth texture and later restores it with
`glFramebufferRenderbuffer(..., Framebuffer.depthBuffer)`.

`FramebufferIrisMixin` already replaces the vanilla depth renderbuffer with a shared depth texture
(`Framebuffer.depthBuffer` stays 0), so Scannable's restore **detaches the depth attachment
entirely**: terrain rendering afterwards has no depth buffer and loses self-occlusion
(see-through ground). With a shader pack active the same code runs while an Iris render target is
bound — it churns the gbuffer depth attachment and draws the additive scan quad into the
pipeline's targets (white screen with ghosting).

## Fix

- **Answer Scannable's OptiFine probes from Actinium** (`MixinProxyOptiFine` +
  `compat/scannable/ScannableShaderCompat`): `isShaderPackLoaded()` → true, `getDepthTexture()` →
  the shared main-framebuffer depth texture. Scannable then uses its dedicated external-shader-mod
  path (mode `OPTIFINE`): copy the depth texture into a private FBO right after world rendering and
  draw the wave during the overlay phase — it never touches the main framebuffer's attachments.
  That depth texture is exactly what Iris renders gbuffer depth into
  (`DeferredWorldRenderingPipeline` builds `RenderTargets` from it), so it carries correct world
  depth both with and without a shader pack.
- **Fix the depth-copy texture format** (`MixinScannerRenderer`, `@ModifyArgs`): Scannable
  allocates the copy as `(GL_R32F, GL_RED, GL_UNSIGNED_BYTE)` — an invalid combination (`GL_R32F`
  only accepts `GL_FLOAT`/`GL_HALF_FLOAT`), so the texture never receives storage, the copy pass
  draws into an incomplete framebuffer, and the wave samples undefined values, displacing the
  rendered scan region (visible when scanning large surfaces like grass). Redirect the pixel type
  to `GL_FLOAT`.

The scan-result cube outlines are Scannable's built-in cluster merging (adjacent matched blocks
are unioned into one bounding box, default color `0x4466CC`) and behave identically on OptiFine.

## Verification

- `gradlew compileJava test` — 442 tests pass (mixin config registries updated:
  `MixinConfigurationTest`, `MixinLateTest`).
- dev runtime (issue reporter's scenario): no shaders → no see-through terrain, scan wave and
  result outlines render correctly; Solas Shader V3.7 → no white screen/ghosting.
- Diagnostic switch `-Dactinium.debug.scannable=true` logs the takeover and depth-copy format fix.
