### PR TITLE
fix(compat): render ArchitectureCraft blocks via the vanilla dispatcher

### DIFF
--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -145,4 +145,8 @@ dependencies {
     // Botania CEU (issue: held items render flat white because its RenderWorldLastEvent handlers leave
     // GL_TEXTURE_2D disabled in the GLSM cache; the conditional botania mixin restores it)
     modImplementation 'curse.maven:botania-ceu-1179448:8706250'
+
+    // ArchitectureCraft 1.12-3.108 TridenMC (issue #101: its blocks are invisible / sawbench hits
+    // FancyMissingModel inside the fast chunk meshing path; dev-verifies the shape rendering compat)
+    modImplementation 'curse.maven:architecturecraft-tridev-277631:4344128'
 }

--- a/src/main/java/com/dhj/actinium/compat/architecturecraft/ArchitectureCraftCompat.java
+++ b/src/main/java/com/dhj/actinium/compat/architecturecraft/ArchitectureCraftCompat.java
@@ -1,0 +1,44 @@
+package com.dhj.actinium.compat.architecturecraft;
+
+import net.minecraft.block.Block;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.Loader;
+
+/**
+ * Compatibility for ArchitectureCraft (mod id {@code architecturecraft}; the TridentMC and Spocel
+ * releases share it).
+ *
+ * <p>ArchitectureCraft never relies on baked models for its world rendering. Its blockstates only
+ * publish a {@code normal} variant (the runtime definition comes from its generated resource pack),
+ * so every {@code facing=*} state resolves to Forge's {@code FancyMissingModel} in the bake
+ * registry, and the real geometry is emitted by a {@code BlockRendererDispatcher} replacement that
+ * {@code CustomBlockDispatcher.inject()} installs into {@code Minecraft.blockRenderDispatcher}
+ * during postInit. The vanilla chunk rebuild calls that entry point and the blocks stay visible;
+ * Actinium's fast chunk path reads {@code BlockModelShapes.getModelForState} directly, hits the
+ * missing model and skips the block (#101). The dispatcher replacement must therefore not be
+ * bypassed: the compat forces ArchitectureCraft blocks down the vanilla dispatcher fallback,
+ * whose {@code RenderTargetWorld} target writes into a {@code BufferBuilder} without touching GL,
+ * which keeps it safe on mesh worker threads.</p>
+ */
+public final class ArchitectureCraftCompat {
+    /**
+     * The mod ID used by both maintained ArchitectureCraft releases.
+     */
+    public static final String MODID = "architecturecraft";
+    public static final boolean IS_LOADED = Loader.isModLoaded(MODID);
+
+    private ArchitectureCraftCompat() {
+    }
+
+    /**
+     * Returns whether {@code block} belongs to ArchitectureCraft and must be rendered through the
+     * vanilla {@code BlockRendererDispatcher}, which ArchitectureCraft replaces with its own
+     * dispatcher providing the real shape geometry.
+     */
+    public static boolean shouldForceVanillaRender(Block block) {
+        if (!IS_LOADED) {
+            return false;
+        }
+        return ArchitectureCraftRenderRouting.isArchitectureCraftNamespace(block.getRegistryName());
+    }
+}

--- a/src/main/java/com/dhj/actinium/compat/architecturecraft/ArchitectureCraftRenderRouting.java
+++ b/src/main/java/com/dhj/actinium/compat/architecturecraft/ArchitectureCraftRenderRouting.java
@@ -1,0 +1,24 @@
+package com.dhj.actinium.compat.architecturecraft;
+
+import net.minecraft.util.ResourceLocation;
+
+import javax.annotation.Nullable;
+
+/**
+ * Render-path routing decisions for ArchitectureCraft blocks, kept free of live-client
+ * dependencies so they can be exercised without an FML bootstrap.
+ */
+public final class ArchitectureCraftRenderRouting {
+    private ArchitectureCraftRenderRouting() {
+    }
+
+    /**
+     * Returns whether {@code registryName} belongs to the ArchitectureCraft namespace and
+     * therefore must stay on the vanilla dispatcher path. Identified by the registry namespace,
+     * which covers every block of both maintained releases without referencing any
+     * ArchitectureCraft class.
+     */
+    public static boolean isArchitectureCraftNamespace(@Nullable ResourceLocation registryName) {
+        return registryName != null && ArchitectureCraftCompat.MODID.equals(registryName.getNamespace());
+    }
+}

--- a/src/main/java/com/dhj/actinium/render/terrain/compile/task/ChunkBuilderMeshingTask.java
+++ b/src/main/java/com/dhj/actinium/render/terrain/compile/task/ChunkBuilderMeshingTask.java
@@ -33,6 +33,7 @@ import org.joml.Vector3d;
 import org.embeddedt.embeddium.api.shader.BlockRenderLayer;
 import org.embeddedt.embeddium.api.shader.ShaderProvider;
 import org.embeddedt.embeddium.api.shader.ShaderProviderHolder;
+import com.dhj.actinium.compat.architecturecraft.ArchitectureCraftCompat;
 import com.dhj.actinium.compat.fluidlogged.FluidloggedCompat;
 import com.dhj.actinium.compat.snowrealmagic.SnowRealMagicCompat;
 import com.dhj.actinium.runtime.ActiniumRuntime;
@@ -124,7 +125,9 @@ public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> 
                             net.minecraft.util.BlockRenderLayer layer = shaderLayerOverride.toVanillaLayer();
                             ForgeHooksClient.setRenderLayer(layer);
                             block.canRenderInLayer(blockState, layer);
-                            if (blockState.getRenderType() == EnumBlockRenderType.MODEL && ActiniumRuntime.options().performance.useFastBlockRenderer && !SnowRealMagicCompat.shouldForceVanillaRender(block)) {
+                            if (blockState.getRenderType() == EnumBlockRenderType.MODEL && ActiniumRuntime.options().performance.useFastBlockRenderer
+                                    && !SnowRealMagicCompat.shouldForceVanillaRender(block)
+                                    && !ArchitectureCraftCompat.shouldForceVanillaRender(block)) {
                                 buildContext.getBlockRenderer().renderBlock(blockState, blockPos, slice, layer, false);
                             } else {
                                 var buffer = buildContext.getBufferForLayer(layer);
@@ -139,7 +142,9 @@ public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> 
                             for (net.minecraft.util.BlockRenderLayer layer : VintageChunkBuildContext.LAYERS) {
                                 if (block.canRenderInLayer(blockState, layer)) {
                                     ForgeHooksClient.setRenderLayer(layer);
-                                    if (blockState.getRenderType() == EnumBlockRenderType.MODEL && ActiniumRuntime.options().performance.useFastBlockRenderer && !SnowRealMagicCompat.shouldForceVanillaRender(block)) {
+                                    if (blockState.getRenderType() == EnumBlockRenderType.MODEL && ActiniumRuntime.options().performance.useFastBlockRenderer
+                                            && !SnowRealMagicCompat.shouldForceVanillaRender(block)
+                                            && !ArchitectureCraftCompat.shouldForceVanillaRender(block)) {
                                         buildContext.getBlockRenderer().renderBlock(blockState, blockPos, slice, layer);
                                     } else {
                                         var buffer = buildContext.getBufferForLayer(layer);

--- a/src/test/java/com/dhj/actinium/compat/architecturecraft/ArchitectureCraftRenderRoutingTest.java
+++ b/src/test/java/com/dhj/actinium/compat/architecturecraft/ArchitectureCraftRenderRoutingTest.java
@@ -1,0 +1,26 @@
+package com.dhj.actinium.compat.architecturecraft;
+
+import net.minecraft.util.ResourceLocation;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ArchitectureCraftRenderRoutingTest {
+    @Test
+    void architectureCraftBlocksAreForcedOntoTheVanillaDispatcher() {
+        assertTrue(ArchitectureCraftRenderRouting.isArchitectureCraftNamespace(
+                new ResourceLocation("architecturecraft", "sawbench")));
+        assertTrue(ArchitectureCraftRenderRouting.isArchitectureCraftNamespace(
+                new ResourceLocation("architecturecraft", "shape")));
+    }
+
+    @Test
+    void foreignAndMissingRegistryNamesStayOnTheFastPath() {
+        assertFalse(ArchitectureCraftRenderRouting.isArchitectureCraftNamespace(
+                new ResourceLocation("minecraft", "stone")));
+        assertFalse(ArchitectureCraftRenderRouting.isArchitectureCraftNamespace(
+                new ResourceLocation("chisel", "marble")));
+        assertFalse(ArchitectureCraftRenderRouting.isArchitectureCraftNamespace(null));
+    }
+}


### PR DESCRIPTION
## 问题 / Issue

Closes #101

ArchitectureCraft（TridenMC 3.108 / Spocel 3.109）的所有方块不可见；alpha-0.0.6 上还会在构建 chunk mesh 时崩溃。

## 根因 / Root cause

ArchitectureCraft 的世界渲染完全不依赖烘焙模型：

- 它在 postInit 通过 `CustomBlockDispatcher.inject()` 把 `Minecraft.blockRenderDispatcher` 替换为自己的 dispatcher，shape / sawbench 等方块的真实几何（OBJSON 模型）由 `dispatcher.renderBlock` 拦截后直接写入 BufferBuilder。
- 其 blockstate 运行时由 `ConcreteResourcePack` 模板生成，只有 `normal` variant，而方块都带 `facing` 属性——烘焙注册表里 `architecturecraft:sawbench#facing=south` 等状态本来就是 Forge 的 `FancyMissingModel`（模组设计如此，烘焙模型仅作粒子占位）。
- Actinium 的 fast chunk path 直接读 `BlockModelShapes.getModelForState`，绕过被替换的 dispatcher，拿到 missing model 后被 `MissingModelCompat`（#90）跳过 → 方块不可见。
- 0.0.6 崩溃：`FancyMissingModel.getQuads` 惰性渲染 "MISSING" 字样，字体渲染在 meshing worker 线程要求 GL 上下文（#90 已把该崩溃转为跳过）。

## 修复 / Fix

复用 SnowRealMagicCompat（#35）已验证的 vanilla dispatcher 回退管线：

- 新增 `compat/architecturecraft/ArchitectureCraftCompat`：按 registry namespace `architecturecraft` 识别该模组方块（不引用其任何类），强制走 `dispatcher.renderBlock` 回退。此时 dispatcher 已是 AC 替换后的实例，真实几何写入 vanilla BufferBuilder，再由既有的 `convertVanillaDataToCeleritasData` 并进 chunk mesh。
- 线程安全：AC 的世界渲染目标 `RenderTargetWorld` 继承 `RenderTargetBase`，纯 BufferBuilder 顶点写入 + CPU 光照计算，无 GL 依赖，在 meshing worker 线程安全。
- `compatBridge` 未触碰，celeritasleafculling 的第三方 mixin 绑定契约（JarTest 锁定）不受影响。
- 判定逻辑提取为无 FML 环境依赖的 `ArchitectureCraftRenderRouting`，配套单元测试。

## 验证 / Verification

- `./gradlew build --no-daemon` 全绿（含桥契约 JarTest、MixinConfigurationTest）。
- 新增 `ArchitectureCraftRenderRoutingTest` 通过。
- dev 环境加入 `curse.maven:architecturecraft-tridev-277631:4344128`（3.108）实机验证通过（shape / sawbench 渲染与光照正常）。