### PR TITLE
perf(celeritas): sync upstream to f15085d4 (update dispatch + task submission fixes)

### DIFF
--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/RenderSectionManager.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/RenderSectionManager.java
@@ -269,8 +269,6 @@ public abstract class RenderSectionManager {
     private void scheduleTranslucencyUpdates(int camSectionX, int camSectionY, int camSectionZ) {
         var renderListManager = this.getCurrentRenderListManager();
         var rebuildLists = renderListManager.getRebuildLists().byUpdateType();
-        var sortRebuildList = rebuildLists.get(ChunkUpdateType.SORT);
-        var importantSortRebuildList = rebuildLists.get(ChunkUpdateType.IMPORTANT_SORT);
         var allowImportant = allowImportantRebuilds();
         var translucentPass = this.renderPassConfiguration.defaultTranslucentMaterial().pass;
         if (!this.hasTranslucencySortedSections()) {
@@ -317,8 +315,8 @@ public abstract class RenderSectionManager {
 
                 if (cameraChangedSection || section.isAlignedWithSectionOnGrid(camSectionX, camSectionY, camSectionZ)) {
                     section.setPendingUpdate(update);
-                    // Inject it into the rebuild lists
-                    (update == ChunkUpdateType.IMPORTANT_SORT ? importantSortRebuildList : sortRebuildList).add(section);
+                    // Inject it into the appropriate list
+                    rebuildLists.get(update).add(section);
 
                     section.lastCameraX = cameraPosition.x;
                     section.lastCameraY = cameraPosition.y;
@@ -478,10 +476,25 @@ public abstract class RenderSectionManager {
      * Inject sections that requested a rebuild between graph updates into the appropriate rebuild lists.
      */
     private void promoteInterimRebuildList() {
-        var rebuildLists = this.getCurrentRenderListManager().getRebuildLists().byUpdateType();
-        for (var section : this.sectionsRequestingUpdate) {
-            rebuildLists.get(section.getPendingUpdate()).add(section);
+        if (this.sectionsRequestingUpdate.isEmpty()) {
+            return;
         }
+
+        var rebuildLists = this.getCurrentRenderListManager().getRebuildLists().byUpdateType();
+        boolean graphUpdatePending = this.getCurrentRenderListManager().isNeedsUpdate();
+
+        for (var section : this.sectionsRequestingUpdate) {
+            var updateType = section.getPendingUpdate();
+            if (updateType == null) {
+                // should never happen, but be defensive
+                continue;
+            }
+            if (!graphUpdatePending || updateType.isImportant()) {
+                rebuildLists.get(updateType).add(section);
+            }
+        }
+
+        this.sectionsRequestingUpdate.clear();
     }
 
     public void updateChunks(boolean updateImmediately) {
@@ -497,13 +510,7 @@ public abstract class RenderSectionManager {
             this.builder.tickSchedulingBudget();
         }
 
-        // Promotion of the interim rebuild list is not required if a graph update is requested, as the graph
-        // generates a new rebuild list anyway
-        if (!this.renderListManager.isNeedsUpdate() && !sectionsRequestingUpdate.isEmpty()) {
-            this.promoteInterimRebuildList();
-        }
-
-        this.sectionsRequestingUpdate.clear();
+        this.promoteInterimRebuildList();
 
         if (!rebuildListHasUpdates()) {
             // Nothing was dispatched, so the workers cannot have been starved for lack of budget.
@@ -873,7 +880,12 @@ public abstract class RenderSectionManager {
             }
 
             if (section.requestUpdate(pendingUpdate) || cancelledInFlightBuild) {
-                if (!this.getCurrentRenderListManager().isNeedsUpdate() && this.sectionsRequestingUpdate.size() < this.builder.getSchedulingBudget()) {
+                // Check importance using the section's new update type, as it may not be exactly what we requested
+                important = section.getPendingUpdate().isImportant();
+
+                if (important ||
+                        (!this.getCurrentRenderListManager().isNeedsUpdate() &&
+                            this.sectionsRequestingUpdate.size() < this.builder.getSchedulingBudget())) {
                     this.sectionsRequestingUpdate.add(section);
                 } else {
                     this.markGraphDirty();

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/compile/executor/ChunkBuilder.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/compile/executor/ChunkBuilder.java
@@ -5,6 +5,7 @@ import org.embeddedt.embeddium.impl.render.chunk.compile.tasks.ChunkBuilderTask;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.embeddedt.embeddium.impl.render.chunk.compile.GlobalChunkBuildContext;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -186,7 +187,7 @@ public class ChunkBuilder {
     }
 
     public <TASK extends ChunkBuilderTask<OUTPUT>, OUTPUT> ChunkJobTyped<TASK, OUTPUT> scheduleTask(TASK task, boolean important,
-                                                                                                    Consumer<ChunkJobResult<OUTPUT>> consumer)
+                                                                                                    Consumer<@Nullable ChunkJobResult<OUTPUT>> consumer)
     {
         Objects.requireNonNull(task, "Task must be non-null");
 

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/compile/executor/ChunkJobCollector.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/compile/executor/ChunkJobCollector.java
@@ -1,6 +1,7 @@
 package org.embeddedt.embeddium.impl.render.chunk.compile.executor;
 
 import org.embeddedt.embeddium.impl.render.chunk.compile.ChunkTaskOutput;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,9 +21,11 @@ public class ChunkJobCollector {
         this.collector = collector;
     }
 
-    public void onJobFinished(ChunkJobResult<? extends ChunkTaskOutput> result) {
+    public void onJobFinished(@Nullable ChunkJobResult<? extends ChunkTaskOutput> result) {
         this.semaphore.release(1);
-        this.collector.accept(result);
+        if (result != null) {
+            this.collector.accept(result);
+        }
     }
 
     public void awaitCompletion(ChunkBuilder builder) {
@@ -31,7 +34,8 @@ public class ChunkJobCollector {
         }
 
         for (var job : this.submitted) {
-            if (job.isStarted() || job.isCancelled()) {
+            // Don't try to steal jobs that already started (cancelled jobs are harmless to steal)
+            if (job.isStarted()) {
                 continue;
             }
 

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/compile/executor/ChunkJobTyped.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/compile/executor/ChunkJobTyped.java
@@ -2,6 +2,7 @@ package org.embeddedt.embeddium.impl.render.chunk.compile.executor;
 
 import org.embeddedt.embeddium.impl.render.chunk.compile.ChunkBuildContext;
 import org.embeddedt.embeddium.impl.render.chunk.compile.tasks.ChunkBuilderTask;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Consumer;
 
@@ -9,12 +10,12 @@ public class ChunkJobTyped<TASK extends ChunkBuilderTask<OUTPUT>, OUTPUT>
         implements ChunkJob
 {
     private final TASK task;
-    private final Consumer<ChunkJobResult<OUTPUT>> consumer;
+    private final Consumer<@Nullable ChunkJobResult<OUTPUT>> consumer;
 
     private volatile boolean cancelled;
     private volatile boolean started;
 
-    ChunkJobTyped(TASK task, Consumer<ChunkJobResult<OUTPUT>> consumer) {
+    ChunkJobTyped(TASK task, Consumer<@Nullable ChunkJobResult<OUTPUT>> consumer) {
         this.task = task;
         this.consumer = consumer;
     }
@@ -31,29 +32,24 @@ public class ChunkJobTyped<TASK extends ChunkBuilderTask<OUTPUT>, OUTPUT>
 
     @Override
     public void execute(ChunkBuildContext context) {
-        // Task was cancelled before starting
-        if (this.cancelled) {
-            return;
-        }
+        ChunkJobResult<OUTPUT> result = null;
 
-        this.started = true;
+        if (!this.cancelled) {
+            this.started = true;
 
-        ChunkJobResult<OUTPUT> result;
+            long startTime = System.nanoTime();
 
-        long startTime = System.nanoTime();
+            try {
+                var output = this.task.execute(context, this);
 
-        try {
-            var output = this.task.execute(context, this);
-
-            // Task was cancelled while executing
-            if (output == null) {
-                return;
+                // A null output means the task was cancelled while executing
+                if (output != null) {
+                    result = new ChunkJobResult.Success<>(output, System.nanoTime() - startTime);
+                }
+            } catch (Throwable throwable) {
+                result = new ChunkJobResult.Failure<>(throwable);
+                ChunkBuilder.LOGGER.error("Chunk build failed", throwable);
             }
-
-            result = new ChunkJobResult.Success<>(output, System.nanoTime() - startTime);
-        } catch (Throwable throwable) {
-            result = new ChunkJobResult.Failure<>(throwable);
-            ChunkBuilder.LOGGER.error("Chunk build failed", throwable);
         }
 
         try {

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/lists/ChunkRebuildLists.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/lists/ChunkRebuildLists.java
@@ -13,8 +13,6 @@ import java.util.Map;
  * @param hasAdditionalUpdates whether there were additional updates not queued for efficiency reasons
  */
 public record ChunkRebuildLists(Map<ChunkUpdateType, ArrayDeque<RenderSection>> byUpdateType, boolean hasAdditionalUpdates, Map<ChunkUpdateType, Integer> queueOverflowCounts) {
-    public static final ChunkRebuildLists EMPTY;
-
     public int getUpdateCount(ChunkUpdateType type) {
         return byUpdateType.get(type).size() + queueOverflowCounts.getOrDefault(type, 0);
     }
@@ -31,13 +29,13 @@ public record ChunkRebuildLists(Map<ChunkUpdateType, ArrayDeque<RenderSection>> 
         return true;
     }
 
-    static {
+    public static ChunkRebuildLists empty() {
         Map<ChunkUpdateType, ArrayDeque<RenderSection>> rebuildLists = new EnumMap<>(ChunkUpdateType.class);
 
         for (var type : ChunkUpdateType.values()) {
             rebuildLists.put(type, new ArrayDeque<>());
         }
 
-        EMPTY = new ChunkRebuildLists(rebuildLists, false, new EnumMap<>(ChunkUpdateType.class));
+        return new ChunkRebuildLists(rebuildLists, false, new EnumMap<>(ChunkUpdateType.class));
     }
 }

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/lists/RenderListManager.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/lists/RenderListManager.java
@@ -95,7 +95,7 @@ public class RenderListManager {
         this.async = mode == AsyncOcclusionMode.EVERYTHING || (shadow && mode == AsyncOcclusionMode.ONLY_SHADOW);
         this.sectionTicker = sectionTicker;
         this.renderLists = SortedRenderLists.empty();
-        this.rebuildLists = ChunkRebuildLists.EMPTY;
+        this.rebuildLists = ChunkRebuildLists.empty();
     }
 
     /**


### PR DESCRIPTION
## 概述 / Summary

移植 celeritas 上游 `cdafa232..` 之后仅有的 2 个提交（`b4f69b8f`、`f15085d4`，即 `cdafa232..f15085d4`），对应 celeritas-common 子项目的 6 个文件。

## 上游内容 / Upstream commits

### b4f69b8f — Fix important updates not taking effect sometimes

- `ChunkRebuildLists`：静态共享的 `EMPTY` record 内含可变 `EnumMap`，两个 pass 的 rebuild list 会互相污染；改为每次调用 `empty()` 工厂返回全新实例（`RenderListManager` 同步改用）。
- `RenderSectionManager.promoteInterimRebuildList`：不再在 graph update pending 时整体跳过——重要更新类型仍会被提升注入，普通更新推迟；空集早退；null pending update 防御跳过；请求集合由该方法自行清空。
- `scheduleTranslucencyUpdates`：直接 `rebuildLists.get(update).add(section)`，删除 SORT/IMPORTANT_SORT 手工二选一。
- `scheduleSectionForRebuild`：按 section 的新 update type（`requestUpdate` 可将 REBUILD 提升为 IMPORTANT_REBUILD）判定是否立即调度，而不是按最初请求的 importance。

### f15085d4 — Improve robustness of task submission

- `ChunkJobTyped.execute`：已取消的任务不再提前返回，而是带着 null result 走到 consumer——等待中的 collector 一定能收回 semaphore permit，不再有 permit 泄漏；`started` 标志仅对未取消任务置位。
- `ChunkJobCollector.onJobFinished`：接受 nullable result，仅非 null 时转发给 collector。唯一的 `scheduleTask` consumer 是 `collector::onJobFinished`（RenderSectionManager:727），null 不再进入 build 结果列表。
- `awaitCompletion`：不再跳过窃取已取消（未开始）的任务。
- `ChunkBuilder.scheduleTask`：consumer 类型标注 `@Nullable`。

## 移植方式 / Porting notes

- 不直接 git cherry-pick（两仓库历史独立，Actinium 的 celeritas-common 基于上次同步点 376d8199 带本地改造），按上游 diff 逐块手工移植。
- 移植后与 mirror `f15085d4` 逐文件比对：`ChunkRebuildLists`/`ChunkJobCollector`/`ChunkJobTyped` 与上游逐字节一致；`RenderSectionManager`(59)/`RenderListManager`(2)/`ChunkBuilder`(124) 的差异行数与移植前对 376d8199 的差异完全相同——均为 Actinium 既有本地适配（如 cancelled in-flight build 处理），无回退、无遗漏。
- 上游原文照搬（含其 defensive 注释），未做本地化改写。

## 验证 / Verification

- `./gradlew build --no-daemon` 全绿（含 Mixin 配置测试与桥契约 JarTest）。