### PR TITLE
fix(shader): don't treat empty MC_VERSION fallback as legacy section

### DIFF
--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -1,6 +1,6 @@
 # Actinium 兼容性矩阵
 
-最后更新：2026-08-20。
+最后更新：2026-08-31。
 
 状态定义：`已验证` 表示在记录的版本和场景中通过；`部分` 表示能运行但存在已知缺口；
 `无法启用` 表示光影包不能成功开启；`未验证` 不代表不兼容。更新记录时必须填写 Actinium commit、
@@ -8,6 +8,17 @@
 
 本轮验证环境：Actinium `30c7ffb`、Java 25.0.3、Cleanroom 0.5.12-alpha、Distant Horizons 3.1.2-b、
 Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
+
+> 2026-08-31 追加：Photon v1.3b 水面不生效（水面保持原版贴图、仅余微弱反光）的修复——
+> 根因不在水面渲染路径，而在 block.properties 的版本条件求值：Photon 把全部 modern 方块映射
+> 放在 `#if MC_VERSION >= 11300` 段内，`#else`（1.12 段）为空；`IdMap#hasLegacySection` 此前
+> 只要见到 MC_VERSION 条件的 `#else` 分支就判定包内含 legacy 段，于是以真实 MC_VERSION=11202
+> 交给 jcpp 求值，modern 映射段被整体剔除，方块 ID 映射表为空（`block-meta-map present=false`、
+> 全部方块 `shaderBlockId=-1`），`mc_Entity` 全部失效，水面因此不被识别为 `MATERIAL_WATER`。
+> 修复后 `#else` 分支必须含实际映射行才判 legacy 段（空 fallback 的包如 Photon 继续走
+> MC_VERSION=260101 的 modern 伪装路径 + legacy 名展平）；Complementary 的 `#elif >= 10800`
+> 实质段路径不受影响。验证：dev 运行，`block-meta-map present=true`、水面采样
+> `blockId=10001`（water 与 flowing_water 双映射），水面效果正常（用户实机确认）。
 
 > 2026-08-24 追加：改 mipmap 后地形方块概率性消失（无光影与光影下均出现）的修复——见下方
 > [mipmap 与地形渲染](#mipmap-与地形渲染)。根因有两点：(1) terrain shader 用三参数 `texture()`
@@ -54,6 +65,7 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 | Bliss                              | 2.1.2         | 已验证  | 开启、世界渲染、Distant Horizons LOD、地形、实体、方块实体、水、天空、天气、阴影、手部、GUI、重载   | -         | `28d976d`   |
 | iterationT                         | 3.2.0         | 已验证  | 开启、世界渲染、Distant Horizons LOD、地形、实体、方块实体、水、天空、天气、阴影、手部、GUI、重载   | -         | `30c7ffb`   |
 | iterationRP                        | 0.7.7 / 0.8.7 | 已验证  | 开启、世界渲染、Distant Horizons LOD、地形、实体、方块实体、水、天空、天气、阴影、手部、GUI、重载   | -         | `28d976d`   |
+| Photon                             | v1.3b         | 部分    | 开启、世界渲染、地形、水（2026-08-31 水面修复后）、GUI                                     | 阴影/实体/维度切换/重载等场景待补充验证；选项菜单部分元素缺失（GTAO 等 profile 项告警，与水面无关） | `fix/photon-water-surface` |
 | SEUS PTGI HRR                      | Test 2.1      | 无法启用 | -                                                              | 光影包不能成功开启 | `f261611`   |
 
 ## 模组与环境

--- a/shader/src/main/java/net/coderbot/iris/shaderpack/IdMap.java
+++ b/shader/src/main/java/net/coderbot/iris/shaderpack/IdMap.java
@@ -116,27 +116,65 @@ public class IdMap {
         }
 
         Deque<Boolean> mcVersionConditionals = new ArrayDeque<>();
-        for (String line : rawBlockProperties.split("\\R")) {
-            String trimmed = line.trim();
+        String[] lines = rawBlockProperties.split("\\R");
+        for (int i = 0; i < lines.length; i++) {
+            String trimmed = lines[i].trim();
             if (!trimmed.startsWith("#")) {
                 continue;
             }
 
             String directive = trimmed.substring(1).trim();
             if (directive.startsWith("if ") || directive.startsWith("ifdef ") || directive.startsWith("ifndef ")) {
-                mcVersionConditionals.push(MC_VERSION_CONDITIONAL_PATTERN.matcher(line).find());
+                mcVersionConditionals.push(MC_VERSION_CONDITIONAL_PATTERN.matcher(lines[i]).find());
             } else if (directive.startsWith("elif ")) {
                 if (!mcVersionConditionals.isEmpty()
-                        && (mcVersionConditionals.peek() || MC_VERSION_CONDITIONAL_PATTERN.matcher(line).find())) {
+                        && (mcVersionConditionals.peek() || MC_VERSION_CONDITIONAL_PATTERN.matcher(lines[i]).find())) {
                     return true;
                 }
             } else if (directive.startsWith("else")) {
-                if (!mcVersionConditionals.isEmpty() && mcVersionConditionals.peek()) {
+                // An MC_VERSION conditional whose fallback branch carries actual mappings (e.g.
+                // Complementary's 1.8-1.12 numeric-ID section) requires legacy evaluation on 1.12.2.
+                // Photon v1.3b instead ships an EMPTY 1.12 #else section: with legacy evaluation the
+                // jcpp preprocessor would strip the whole modern mapping section and leave the ID map
+                // empty, so those packs must stay on the modern path (forced MC_VERSION 260101).
+                if (!mcVersionConditionals.isEmpty() && mcVersionConditionals.peek()
+                        && hasSubstantiveLines(lines, i)) {
                     return true;
                 }
             } else if (directive.startsWith("endif")) {
                 if (!mcVersionConditionals.isEmpty()) {
                     mcVersionConditionals.pop();
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Scans forward from an {@code #else} line to its matching {@code #endif} and reports whether the
+     * branch body contains any substantive properties line. Comment lines ({@code #...}) and blank
+     * lines are ignored; nested conditionals inside the branch are tracked so the scan stops at the
+     * right boundary.
+     */
+    private static boolean hasSubstantiveLines(String[] lines, int elseIndex) {
+        int depth = 1;
+        for (int i = elseIndex + 1; i < lines.length; i++) {
+            String trimmed = lines[i].trim();
+            if (!trimmed.startsWith("#")) {
+                if (!trimmed.isEmpty()) {
+                    return true;
+                }
+                continue;
+            }
+
+            String directive = trimmed.substring(1).trim();
+            if (directive.startsWith("if ") || directive.startsWith("ifdef ") || directive.startsWith("ifndef ")) {
+                depth++;
+            } else if (directive.startsWith("endif")) {
+                depth--;
+                if (depth == 0) {
+                    return false;
                 }
             }
         }


### PR DESCRIPTION
## What

`IdMap#hasLegacySection` now requires an `MC_VERSION` conditional's `#else` branch to contain substantive mapping lines before the pack is treated as a legacy pack. Packs whose fallback branch is empty (comments only) stay on the modern evaluation path (forced `MC_VERSION=260101` + modern-to-legacy name flattening).

## Why

Photon v1.3b keeps **all** modern block mappings (`block.10001 = water`, ...) inside `#if MC_VERSION >= 11300`, and its `#else` (1.12 section) is empty. The previous logic flagged any `MC_VERSION` conditional carrying an `#else` as a legacy pack, so `block.properties` was preprocessed with the real `MC_VERSION=11202`: jcpp stripped the entire modern section, the `#else` body was empty, and the resulting block ID map was empty. With no ID map, `mc_Entity` was dead for every block, so Photon never recognized water (`MATERIAL_WATER`) - the surface kept its vanilla texture with only a faint specular highlight, no wave animation, no water color/refraction.

Runtime evidence from `block-meta-map` / `terrain-material` diagnostics (before fix): `present=false`, `shaderBlockId=-1` for every block (sand, gravel, dirt, stone, ...).

The fix only changes behavior for packs with an *empty* fallback branch. Packs with real numeric-ID fallbacks keep the legacy path: Complementary r5.5.1 still resolves through its `#elif MC_VERSION >= 10800` section, and BSL (no `MC_VERSION` conditionals at all) is untouched.

## How verified

- `.\gradlew.bat :test --no-daemon` - all tests pass, including `IdMapTest` and `FlatteningMapCoverageTest`
- `.\gradlew.bat compileJava compileCompatBridgeJava --no-daemon` - clean
- Dev client (Cleanroom, `runClient`) with Photon v1.3b active: after the fix the block-meta map reports `present=true`, `minecraft:water`/`minecraft:flowing_water` both map to `10001`, and encoder samples report `blockId=10001` on the water surface. Water surface rendering confirmed working in-game.

## Shader packs verified

| Pack | Version | Result |
| --- | --- | --- |
| Photon | v1.3b | water surface renders with pack effects (previously vanilla-looking surface) |
| BSL | v10.0 | unaffected (no `MC_VERSION` conditionals; regressions covered by existing tests) |
| Complementary Reimagined | r5.5.1 | unaffected (`#elif >= 10800` numeric-ID section still takes the legacy path) |

`docs/compatibility-matrix.md` updated with the root-cause record and the Photon row.