### PR TITLE
fix(shader): make shader pack option translations work in-world

### DIFF
--- a/src/main/java/com/dhj/actinium/gui/ShaderPackTranslationLookup.java
+++ b/src/main/java/com/dhj/actinium/gui/ShaderPackTranslationLookup.java
@@ -1,0 +1,68 @@
+package com.dhj.actinium.gui;
+
+import net.coderbot.iris.shaderpack.LanguageMap;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Lookup of shader pack language entries, delegated to by {@code LocaleIrisMixin}.
+ * <p>
+ * Motivation: keys provided by a shader pack's own lang files (en_us.lang, zh_CN.lang, ...)
+ * such as option.*, value.*, screen.* and profile.* are absent from the vanilla language
+ * table, so {@link LanguageMap} must be wired into the vanilla translation lookup chain for
+ * the shader pack GUI to follow the game language. The logic lives outside the mixin package
+ * to honor the "mixins only inject" convention and to keep the lookup directly unit-testable.
+ */
+public final class ShaderPackTranslationLookup {
+
+	private ShaderPackTranslationLookup() {}
+
+	/**
+	 * Looks up a translation in the shader pack language table.
+	 *
+	 * Motivation: vanilla {@code Locale.translateKeyPrivate/hasKey} needs a side lookup that
+	 * returns null on a miss, so shader pack translations can be layered on top without
+	 * polluting the vanilla translation table.
+	 *
+	 * @param languageMap language table of the currently loaded shader pack; null (pack not
+	 *                    loaded or disabled) provides no side lookup
+	 * @param vanillaTranslations translations already present in the vanilla Locale; keys
+	 *                            resolved by vanilla must be returned untouched and must not
+	 *                            be overridden by a same-named shader pack entry
+	 * @param key language key to look up
+	 * @param preferredLanguageCodes language lookup order, tried in sequence, first hit wins
+	 * @return the translation, or null when the pack does not provide the key (the caller
+	 *         then falls back to vanilla behavior)
+	 */
+	public static String lookup(LanguageMap languageMap, Map<String, String> vanillaTranslations, String key, Iterable<String> preferredLanguageCodes) {
+		if (languageMap == null || vanillaTranslations.containsKey(key)) {
+			return null;
+		}
+
+		for (String code : preferredLanguageCodes) {
+			Map<String, String> translations = languageMap.getTranslations(normalizeLanguageCode(code));
+			if (translations == null) {
+				continue;
+			}
+
+			String translation = translations.get(key);
+			if (translation != null) {
+				return translation;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Normalizes a language code to match {@link LanguageMap} keys.
+	 *
+	 * Motivation: LanguageMap keys are lang file names lower-cased as a whole
+	 * (en_US.lang -> "en_us"), while language codes from settings or caller constants may
+	 * carry case variants; lower-casing them makes the lookup hit.
+	 */
+	static String normalizeLanguageCode(String code) {
+		return code.toLowerCase(Locale.ROOT);
+	}
+}

--- a/src/main/java/com/dhj/actinium/mixin/features/iris/LocaleIrisMixin.java
+++ b/src/main/java/com/dhj/actinium/mixin/features/iris/LocaleIrisMixin.java
@@ -1,14 +1,10 @@
 package com.dhj.actinium.mixin.features.iris;
 
-import com.google.common.base.Splitter;
-import com.google.common.collect.Iterables;
+import com.dhj.actinium.gui.ShaderPackTranslationLookup;
 import net.coderbot.iris.Iris;
-import net.coderbot.iris.shaderpack.LanguageMap;
 import net.coderbot.iris.shaderpack.ShaderPack;
-import net.minecraft.client.resources.IResourceManager;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.Locale;
-import net.minecraftforge.fml.common.FMLCommonHandler;
-import org.apache.commons.io.IOUtils;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -17,15 +13,16 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
+/**
+ * Wires shader pack lang directory translations into the vanilla I18n lookup chain so the
+ * shader pack option GUI (option names, values, comments and sub-screen titles) follows the
+ * game language. The lookup logic lives in {@link ShaderPackTranslationLookup}; this class
+ * only injects and collects the language order.
+ */
 @Mixin(Locale.class)
 public class LocaleIrisMixin {
     @Shadow
@@ -34,14 +31,13 @@ public class LocaleIrisMixin {
     @Shadow
     private boolean unicode;
 
+    /**
+     * Fallback code of the language chain: en_us is the vanilla fallback language, so packs
+     * without a lang file for the current game language degrade to English instead of raw
+     * keys or numeric values.
+     */
     @Unique
-    private static final List<String> actinium$languageCodes = new ArrayList<>();
-
-    @Unique
-    private static final Splitter actinium$LANG_SPLITTER = Splitter.on('=').limit(2);
-
-    @Unique
-    private static final Pattern actinium$LANG_FORMAT_PATTERN = Pattern.compile("%(\\d+\\$)?[\\d\\.]*[df]");
+    private static final String actinium$FALLBACK_LANGUAGE_CODE = "en_us";
 
     @Inject(method = "translateKeyPrivate(Ljava/lang/String;)Ljava/lang/String;", at = @At("HEAD"), cancellable = true)
     private void actinium$overrideShaderpackLanguageEntry(String key, CallbackInfoReturnable<String> cir) {
@@ -58,12 +54,6 @@ public class LocaleIrisMixin {
         }
     }
 
-    @Inject(method = "loadLocaleDataFiles(Lnet/minecraft/client/resources/IResourceManager;Ljava/util/List;)V", at = @At("HEAD"))
-    private void actinium$trackLanguageCodes(IResourceManager resourceManager, List<String> languageList, CallbackInfo ci) {
-        actinium$languageCodes.clear();
-        new LinkedList<>(languageList).descendingIterator().forEachRemaining(actinium$languageCodes::add);
-    }
-
     @Inject(method = "checkUnicode()V", at = @At("HEAD"), cancellable = true)
     private void actinium$disableShaderpackUnicodeOverride(CallbackInfo ci) {
         this.unicode = false;
@@ -73,58 +63,30 @@ public class LocaleIrisMixin {
     @Unique
     private String actinium$lookupShaderpackEntry(String key) {
         ShaderPack pack = Iris.getCurrentPack().orElse(null);
-        if (pack == null || this.properties.containsKey(key)) {
+        if (pack == null) {
             return null;
         }
 
-        LanguageMap languageMap = pack.getLanguageMap();
-        for (String code : actinium$languageCodes) {
-            Map<String, String> translations = languageMap.getTranslations(code);
-            if (translations == null) {
-                translations = languageMap.getTranslations(actinium$normalizeShaderpackLanguageCode(code));
-            }
-            if (translations == null) {
-                continue;
-            }
-
-            String translation = translations.get(key);
-            if (translation != null) {
-                return translation;
-            }
-        }
-
-        Map<String, String> fallback = languageMap.getTranslations("en_US");
-        return fallback == null ? null : fallback.get(key);
+        return ShaderPackTranslationLookup.lookup(
+            pack.getLanguageMap(),
+            this.properties,
+            key,
+            actinium$preferredLanguageCodes());
     }
 
+    /**
+     * Collects the language lookup order: current game language first, en_us fallback, matching
+     * the vanilla Locale load order. Motivation: the order must be read live (gameSettings.language
+     * changes whenever the language settings screen is used); caching a snapshot from the resource
+     * reload callback breaks the whole chain when the snapshot goes stale or out of sync.
+     */
     @Unique
-    private static String actinium$normalizeShaderpackLanguageCode(String code) {
-        int separator = code.indexOf('_');
-        if (separator < 0 || separator == code.length() - 1) {
-            return code;
+    private static List<String> actinium$preferredLanguageCodes() {
+        List<String> codes = new ArrayList<>(2);
+        codes.add(Minecraft.getMinecraft().gameSettings.language);
+        if (!codes.contains(actinium$FALLBACK_LANGUAGE_CODE)) {
+            codes.add(actinium$FALLBACK_LANGUAGE_CODE);
         }
-
-        return code.substring(0, separator).toLowerCase(java.util.Locale.ROOT) + "_" + code.substring(separator + 1).toUpperCase(java.util.Locale.ROOT);
-    }
-
-    @Unique
-    private static void actinium$loadLanguageData(Map<String, String> translations, InputStream inputStream) throws IOException {
-        InputStream vanillaStream = FMLCommonHandler.instance().loadLanguage(translations, inputStream);
-        if (vanillaStream == null) {
-            return;
-        }
-
-        try {
-            for (String line : IOUtils.readLines(vanillaStream, StandardCharsets.UTF_8)) {
-                if (!line.isEmpty() && line.charAt(0) != '#') {
-                    String[] parts = Iterables.toArray(actinium$LANG_SPLITTER.split(line), String.class);
-                    if (parts != null && parts.length == 2) {
-                        translations.put(parts[0], actinium$LANG_FORMAT_PATTERN.matcher(parts[1]).replaceAll("%$1s"));
-                    }
-                }
-            }
-        } finally {
-            IOUtils.closeQuietly(vanillaStream);
-        }
+        return codes;
     }
 }

--- a/src/test/java/com/dhj/actinium/gui/ShaderPackTranslationLookupTest.java
+++ b/src/test/java/com/dhj/actinium/gui/ShaderPackTranslationLookupTest.java
@@ -1,0 +1,101 @@
+package com.dhj.actinium.gui;
+
+import net.coderbot.iris.shaderpack.LanguageMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ShaderPackTranslationLookupTest {
+    private static final List<String> GAME_LANGUAGE_FIRST = List.of("zh_cn", "en_us");
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void resolvesEntryFromGameLanguage() throws IOException {
+        LanguageMap languageMap = languageMap("zh_cn.lang", "option.CLOUD_DENSITY=云密度");
+
+        String translation = ShaderPackTranslationLookup.lookup(
+            languageMap, Map.of(), "option.CLOUD_DENSITY", GAME_LANGUAGE_FIRST);
+
+        assertEquals("云密度", translation);
+    }
+
+    @Test
+    void fallsBackToEnglishWhenGameLanguageFileMissing() throws IOException {
+        // BSL-style pack shipping only en_US.lang: zh_cn misses and must degrade to English instead of null
+        LanguageMap languageMap = languageMap("en_US.lang", "option.CLOUD_DENSITY=Cloud Density");
+
+        String translation = ShaderPackTranslationLookup.lookup(
+            languageMap, Map.of(), "option.CLOUD_DENSITY", GAME_LANGUAGE_FIRST);
+
+        assertEquals("Cloud Density", translation);
+    }
+
+    @Test
+    void prefersGameLanguageOverEnglishFallback() throws IOException {
+        // photon-style pack shipping both zh_CN.lang and en_US.lang: the game language hit must not be stolen by the en_us fallback
+        LanguageMap languageMap = languageMap(
+            "en_US.lang", "option.CLOUD_DENSITY=Cloud Density\n",
+            "zh_CN.lang", "option.CLOUD_DENSITY=云密度\n");
+
+        String translation = ShaderPackTranslationLookup.lookup(
+            languageMap, Map.of(), "option.CLOUD_DENSITY", GAME_LANGUAGE_FIRST);
+
+        assertEquals("云密度", translation);
+    }
+
+    @Test
+    void keepsVanillaTranslationWhenKeyCollides() throws IOException {
+        LanguageMap languageMap = languageMap("en_us.lang", "option.CLOUD_DENSITY=Cloud Density");
+
+        Map<String, String> vanilla = new HashMap<>();
+        vanilla.put("option.CLOUD_DENSITY", "vanilla wins");
+
+        String translation = ShaderPackTranslationLookup.lookup(
+            languageMap, vanilla, "option.CLOUD_DENSITY", GAME_LANGUAGE_FIRST);
+
+        assertNull(translation);
+    }
+
+    @Test
+    void returnsNullWhenLanguageMapAbsent() {
+        assertNull(ShaderPackTranslationLookup.lookup(
+            null, Map.of(), "option.CLOUD_DENSITY", GAME_LANGUAGE_FIRST));
+    }
+
+    @Test
+    void returnsNullWhenKeyMissingEverywhere() throws IOException {
+        LanguageMap languageMap = languageMap("en_US.lang", "option.OTHER=Other");
+
+        assertNull(ShaderPackTranslationLookup.lookup(
+            languageMap, Map.of(), "option.CLOUD_DENSITY", GAME_LANGUAGE_FIRST));
+    }
+
+    @Test
+    void matchesLanguageCodeCaseInsensitively() throws IOException {
+        LanguageMap languageMap = languageMap("zh_CN.lang", "option.CLOUD_DENSITY=云密度");
+
+        String translation = ShaderPackTranslationLookup.lookup(
+            languageMap, Map.of(), "option.CLOUD_DENSITY", List.of("zh_CN"));
+
+        assertEquals("云密度", translation);
+    }
+
+    private LanguageMap languageMap(String... fileNamesAndContents) throws IOException {
+        for (int i = 0; i < fileNamesAndContents.length; i += 2) {
+            Files.writeString(tempDir.resolve(fileNamesAndContents[i]), fileNamesAndContents[i + 1], StandardCharsets.UTF_8);
+        }
+        return new LanguageMap(tempDir);
+    }
+}


### PR DESCRIPTION
## 改了什么

修复光影包选项翻译在游戏内回退为英文的问题，重写 `LocaleIrisMixin` 的查找链：

- 新增 `ShaderPackTranslationLookup`（mixin 包外的纯函数实现类，符合 "mixin 只做注入" 约定，可直接单测）：统一将语言码小写后匹配 `LanguageMap` 键；vanilla 已解析的键原样让路，不被光影包同名键覆盖。
- `LocaleIrisMixin` 改为薄委托：语言查找顺序实时读取 `gameSettings.language`（当前语言优先，`en_us` 兜底，与 vanilla `Locale` 加载顺序一致）；清除静态语言快照缓存与失效的 normalize/兜底死代码（净 -70 行）。
- 新增 `ShaderPackTranslationLookupTest`（7 个用例）：游戏语言命中、英文兜底（BSL 类单语言包）、双语言包不被兜底抢先（photon 类）、大小写变体匹配、vanilla 键优先、未命中返回 null、空语言表返回 null。

## 为什么改

光影包选项的 `option.*` / `value.*` / `screen.*` / `profile.*` 键不在 vanilla 语言表中，由 `LocaleIrisMixin` 把光影包 `lang/` 目录接入 vanilla I18n 查找链。原有实现存在三个缺陷，叠加导致游戏内翻译链断裂：

1. **英文兜底是死代码**：`getTranslations("en_US")` 用大写变体查询，而 `LanguageMap` 将 lang 文件名整体小写化（key 为 `en_us`），永远查到 null（`LanguageMapTest` 已断言该行为）。
2. **语言码规范化方向反了**：`normalize` 产出 `zh_CN` 风格 key，同样永远无法命中小写 key。
3. **语言列表是资源重载时的静态快照**：游戏内快照缺失当前语言码，`zh_cn` 查不到后落到唯一的存活路径（en_us），表现为游戏外显示中文、游戏内显示英文；而"枚举选项值显示为数字"是该症状的衍生现象（`value.<名称>.<值>` 查不到时回退显示原始值）。

## 如何验证

- 自动化：`./gradlew :test --no-daemon` 全量通过（含新增 7 个用例与既有 `LanguageMapTest`）。
- dev 回归：游戏语言 zh_cn 下，photon v1.3b 游戏外（视频设置入口）与游戏内（按键入口）的光影包选项均正确显示中文翻译，与修复前"游戏外正常、游戏内英文"的行为对比一致；BSL v10.0（仅 en_US.lang）按预期回退英文。