### PR TITLE
fix(compat): restore BetterPortals Refitted end portal rendering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.jetbrains.gradle.ext.Gradle
 
 plugins {
@@ -95,6 +96,10 @@ java {
 configurations {
     contain
     implementation.extendsFrom(contain)
+    // External classes bundled into the mod jar body under the shared shadow namespace, mirroring
+    // the upstream Celeritas distribution layout. Kept separate from implementation so the plain
+    // namespace jars stay on the compile/dev classpath for third-party mods that need them.
+    shadowBundle
     modCompileOnly
     compileOnly.extendsFrom(modCompileOnly)
     modRuntimeOnly
@@ -281,6 +286,35 @@ def actiniumProjectAccessTransformer = propertyBool('use_access_transformer')
     ? rootProject.projectDir.toPath().resolve("src/main/resources/${propertyString('access_transformer_locations')}").toFile()
     : null
 
+/**
+ * Dev-runtime image of the mod in the same shadow layout as the production jar: merged module
+ * classes plus the shadow bundle classes relocated under
+ * org.embeddedt.embeddium.impl.shadow.joml. The client and server runs swap the raw source-set
+ * outputs and the plain joml jar for this artifact so mixin field descriptors seen at dev runtime
+ * match the production distribution. The plain joml jar itself stays on the run classpath for
+ * third-party mods that still speak org.joml.
+ */
+def devShadowJar = tasks.register('devShadowJar', ShadowJar) {
+    group = 'build'
+    description = 'Builds the shadow-layout dev runtime jar consumed by the client and server runs.'
+    archiveBaseName.set('Actinium-dev')
+    archiveClassifier.set('')
+    archiveVersion.set('')
+    destinationDirectory.set(layout.buildDirectory.dir('dev-libs'))
+    configurations.set([project.configurations.shadowBundle])
+    from(sourceSets.main.output)
+    relocate('org.joml', 'org.embeddedt.embeddium.impl.shadow.joml')
+    mergeServiceFiles()
+    // Deliberately no manifest inheritance from the jar task: that manifest carries the
+    // FMLCorePlugin / FMLCorePluginContainsFMLMod entries the production jar needs, but at dev time
+    // the coremod is already provided through unimined's fml.coreMods.load system property. Letting
+    // them surface on a plain classpath jar makes FML's classpath scan treat this jar as a coremod
+    // container, which parent-delegates its package (class loader exclusion) and splits classes
+    // like MixinLate across the app class loader and the LaunchClassLoader (ClassCastException on
+    // the mixinbooter ILateMixinLoader cast).
+    manifest.attributes('Implementation-Version': finalVersion)
+}
+
 def remapCompatBridgeJar
 
 unimined.minecraft {
@@ -304,12 +338,32 @@ unimined.minecraft {
                 jvmArgs += extraArgs.split('\\s+').toList()
             }
 
+            // Swap the raw module outputs for the shadow-layout dev jar so the dev runtime carries
+            // the same relocated joml descriptors as the production distribution. The swap happens
+            // on the -Dcrl.dev.extrapath channel below, NOT on the JavaExec classpath: mod classes
+            // must stay invisible to the app class loader (exactly like production, where the mod
+            // jar is not on java.class.path). Keeping the jar on the JavaExec classpath lets the
+            // app loader serve Actinium classes as a parent-delegation fallback and splits classes
+            // like MixinLate across the app loader and the LaunchClassLoader (ClassCastException on
+            // the mixinbooter ILateMixinLoader cast).
+            def originalRunClasspath = classpath
+            classpath = files(provider {
+                def rawModuleOutputs = sourceSets.main.output.files
+                originalRunClasspath.files.findAll { file ->
+                    !rawModuleOutputs.contains(file)
+                }
+            })
+
             // Unimined omits source output paths here when a clean build has not created their directories yet.
+            // The raw module outputs must not reach Cleanroom either: they would expose unrelocated
+            // joml descriptors next to the shadowed ones, so the dev shadow jar replaces them here.
             def extraPathArgument = '-Dcrl.dev.extrapath='
+            def rawModuleOutputPaths = project.sourceSets.main.output.files.collect { it.absolutePath } as Set
             def extraPaths = new LinkedHashSet<String>()
-            extraPaths.addAll(project.sourceSets.main.output.files.collect { it.absolutePath })
+            extraPaths.add(devShadowJar.get().archiveFile.get().asFile.absolutePath)
             jvmArgs.findAll { it.toString().startsWith(extraPathArgument) }.each { argument ->
-                extraPaths.addAll(argument.toString().substring(extraPathArgument.length()).tokenize(File.pathSeparator))
+                extraPaths.addAll(argument.toString().substring(extraPathArgument.length()).tokenize(File.pathSeparator)
+                        .findAll { path -> !rawModuleOutputPaths.contains(path) })
             }
             jvmArgs = jvmArgs.findAll { !it.toString().startsWith(extraPathArgument) }
             jvmArgs += "${extraPathArgument}${extraPaths.join(File.pathSeparator)}"
@@ -326,6 +380,10 @@ unimined.minecraft {
         mixinRemap {
             enableBaseMixin()
             enableMixinExtra()
+        }
+        // Thin intermediate: the distributed jar is the shadowRemapJar output.
+        asJar {
+            archiveClassifier.set('thin')
         }
     }
 
@@ -350,6 +408,25 @@ unimined.minecraft {
 }
 
 def compatBridgeRemapOutput = remapCompatBridgeJar.flatMap { it.archiveFile }
+
+/**
+ * Production mod jar in the upstream Celeritas distribution layout: the remapped thin jar merged
+ * with the shadow bundle classes, with joml relocated under
+ * org.embeddedt.embeddium.impl.shadow.joml so mixin field descriptors match the layout upstream
+ * Celeritas addons bind against. The ContainedDeps joml jar inherited from the thin jar stays
+ * nested for third-party mods that still consume plain org.joml.
+ */
+def shadowRemapJar = tasks.register('shadowRemapJar', ShadowJar) {
+    group = 'build'
+    description = 'Builds the production mod jar with the upstream shadow layout (relocated joml).'
+    dependsOn tasks.named('remapJar')
+    archiveClassifier.set('')
+    configurations.set([project.configurations.shadowBundle])
+    from(zipTree(tasks.named('remapJar').get().archiveFile))
+    relocate('org.joml', 'org.embeddedt.embeddium.impl.shadow.joml')
+    mergeServiceFiles()
+    manifest.inheritFrom(tasks.named('jar').get().manifest)
+}
 
 /**
  * Chunk Animator's dev-environment coremod (MCPNames) reads ./../mcp/methods.csv and
@@ -414,15 +491,18 @@ def prepareCompatBridgeRun = tasks.register('prepareCompatBridgeRun') {
 
 tasks.named('preRunClient').configure {
     dependsOn tasks.named('classes')
+    dependsOn devShadowJar
     dependsOn prepareCompatBridgeRun
     dependsOn prepareChunkAnimatorMcpMappings
 }
 
 tasks.named('preRunServer').configure {
     dependsOn tasks.named('classes')
+    dependsOn devShadowJar
 }
 
 tasks.named('assemble').configure {
+    dependsOn shadowRemapJar
     dependsOn remapCompatBridgeJar
     dependsOn compatBridgeSourcesJar
 }
@@ -619,13 +699,13 @@ tasks.named('processResources').configure {
     from('THIRD_PARTY_NOTICES.md', 'LICENSE-REESES-SODIUM-OPTIONS.md')
 }
 
-def verifyRemapJar = tasks.register('verifyRemapJar') {
-    dependsOn tasks.named('remapJar')
-    def remapOutput = tasks.named('remapJar').flatMap { it.archiveFile }
-    inputs.file(remapOutput)
+def verifyDistributedJar = tasks.register('verifyDistributedJar') {
+    dependsOn tasks.named('shadowRemapJar')
+    def shadowOutput = tasks.named('shadowRemapJar').flatMap { it.archiveFile }
+    inputs.file(shadowOutput)
 
     doLast {
-        def archive = zipTree(remapOutput.get().asFile)
+        def archive = zipTree(shadowOutput.get().asFile)
         def requiredEntries = [
             'META-INF/MANIFEST.MF',
             'THIRD_PARTY_NOTICES.md',
@@ -634,6 +714,8 @@ def verifyRemapJar = tasks.register('verifyRemapJar') {
             'com/gtnewhorizons/angelica/glsm/GLStateManager.class',
             'net/coderbot/iris/Iris.class',
             'org/embeddedt/embeddium/impl/render/chunk/RenderSectionManager.class',
+            'org/embeddedt/embeddium/impl/shadow/joml/Vector3f.class',
+            'joml-1.10.5.jar',
             'mixins.actinium.iris.json',
             'mixins.actinium.vintage.json',
             'META-INF/services/com.gtnewhorizons.angelica.glsm.backend.RenderBackend'
@@ -641,24 +723,30 @@ def verifyRemapJar = tasks.register('verifyRemapJar') {
 
         requiredEntries.each { entry ->
             if (archive.matching { include entry }.isEmpty()) {
-                throw new GradleException("Remapped mod jar is missing required entry: ${entry}")
+                throw new GradleException("Distributed mod jar is missing required entry: ${entry}")
             }
         }
 
-        def manifest = new java.util.jar.JarFile(remapOutput.get().asFile).withCloseable {
+        // The shadow layout only holds relocated joml classes in the jar body; plain org.joml is
+        // provided to third-party mods by the nested ContainedDeps jar instead.
+        if (!archive.matching { include 'org/joml/**/*.class' }.isEmpty()) {
+            throw new GradleException('Distributed mod jar leaks plain org.joml classes into the jar body')
+        }
+
+        def manifest = new java.util.jar.JarFile(shadowOutput.get().asFile).withCloseable {
             it.manifest.mainAttributes
         }
         if (manifest.getValue('FMLCorePlugin') != propertyString('coremod_plugin_class_name')) {
-            throw new GradleException('Remapped mod jar has an invalid FMLCorePlugin manifest entry')
+            throw new GradleException('Distributed mod jar has an invalid FMLCorePlugin manifest entry')
         }
         if (manifest.getValue('FMLAT') != propertyString('access_transformer_locations').tokenize('/\\').last()) {
-            throw new GradleException('Remapped mod jar has an invalid FMLAT manifest entry')
+            throw new GradleException('Distributed mod jar has an invalid FMLAT manifest entry')
         }
 
-        new java.util.jar.JarFile(remapOutput.get().asFile).withCloseable { jar ->
+        new java.util.jar.JarFile(shadowOutput.get().asFile).withCloseable { jar ->
             def metadataEntry = jar.getEntry('mcmod.info')
             if (metadataEntry == null) {
-                throw new GradleException('Remapped mod jar is missing mcmod.info')
+                throw new GradleException('Distributed mod jar is missing mcmod.info')
             }
             def metadata = new groovy.json.JsonSlurper().parse(jar.getInputStream(metadataEntry))
             def mod = metadata[0]
@@ -669,10 +757,10 @@ def verifyRemapJar = tasks.register('verifyRemapJar') {
                     || mod.url != propertyString('mod_url')
                     || mod.updateJSON != propertyString('mod_update_json')
                     || mod.logoFile != propertyString('mod_logo_path')) {
-                throw new GradleException('Remapped mod jar metadata does not match Gradle mod metadata properties')
+                throw new GradleException('Distributed mod jar metadata does not match Gradle mod metadata properties')
             }
             if (!mod.logoFile.isEmpty() && jar.getEntry(mod.logoFile) == null) {
-                throw new GradleException("Remapped mod jar is missing configured logo: ${mod.logoFile}")
+                throw new GradleException("Distributed mod jar is missing configured logo: ${mod.logoFile}")
             }
         }
     }
@@ -740,7 +828,7 @@ def verifyModuleBoundaries = tasks.register('verifyModuleBoundaries') {
 }
 
 tasks.named('check').configure {
-    dependsOn verifyRemapJar
+    dependsOn verifyDistributedJar
     dependsOn verifyCompatBridgeJar
     dependsOn verifyModuleBoundaries
 }

--- a/docs/compat/betterportals.md
+++ b/docs/compat/betterportals.md
@@ -1,7 +1,6 @@
 # BetterPortals Refitted 兼容性说明
 
-兼容状态：**部分**（无光影场景看穿 + 星野正常；光影开启后传送门进入视角会导致严重卡顿
-且地形整体消失，待修复）
+兼容状态：**已验证**（无光影与光影（BSL）场景下穿看 + 星野 + 淡出 + 换维度均正常）
 最后更新：2026-09-02
 
 ## 模组信息
@@ -78,14 +77,44 @@ vec4 texGenCoord = vec4(dot(eyePos, u_TexGenEyePlaneS), dot(eyePos, u_TexGenEyeP
 y+0.75）。看穿失败时洞口唯一可见的就是这层星野，于是表现为「整体低一格」；看穿恢复后
 该错觉随之消失。
 
+### 4. 光影下的两个叠加缺陷（2026-09-02 定位修复）
+
+**管线重载风暴**：BPR 的看穿视图是**顺序**渲染（先 renderDeps 末地视图、换
+`mc.world`+`mc.framebufferMc` 后再 renderSelf 主世界），同一帧内维度名往返切换。
+`PipelineManager.preparePipeline` 此前把维度切换当世界卸载处理——每次切换
+destroyPipeline() 再重建，每帧两次，且每次重建杀 celeritas worker 线程，导致地形永远
+来不及重建（现象：门进入视角即 5 fps、主世界地形全部消失，日志 `Dimension changed …
+reloading pipeline` 每帧刷屏）。
+
+修复：`preparePipeline` 改为 `pipelinesPerDimension` 缓存切换（维度间翻零成本），
+地形 program 缓存同步改为按管线实例分键
+（`IrisCeleritasChunkProgramOverrides.programsPerPipeline`），`MinecraftFramebufferHelper`
+动态读 `mc.getFramebuffer()` 使 Iris 合成自动写入 BPR 换入的传送门 FBO——两个世界各自
+获得完整光影效果。EntityRenderer 注入点守卫回退为纯深度 `RenderWorldRecursionGuard`
+（真嵌套防御，顺序双 pass 不再触发跳过）。
+
+**星野叠加层被旁路**：光影下实体渲染阶段 Iris 的 gbuffers program 已绑定，glsm 按设计
+对外部 program 让位（`ShaderManager.preDraw` 提前 return），原版 TESR 的 texgen FFP
+仿真永远不执行，Iris program 按实体属性格式误读 `POSITION_COLOR` 顶点流 → 星野几乎
+不可见且随视角转动闪烁。
+
+修复：无 world 合成 TE 在光影下改走替代渲染器（`EndPortalRenderer`，CPU 烘焙投影 UV +
+实体兼容顶点格式，本就为光影设计）；BPR 的淡出钩子（`shouldRenderFace` 首调里
+`blendFunc(CONSTANT_ALPHA,…)` + 裸 `glBlendColor(0,0,0,opacity)`）完整复刻——检测到
+CONSTANT_ALPHA 因子对即认定钩子触发，从真实 GL 状态读回常量 alpha（该裸调用绕过 glsm
+跟踪），按「CONSTANT_ALPHA ≡ SRC_ALPHA + 首层顶点 alpha=opacity」折入第 0 层顶点
+alpha，后续叠加层保持全强度并跳过 precompose（单层合成无法只淡出 sky 层）。无光影路径
+与真实传送门行为零改动。
+
 ## 验证记录
 
 - 环境：实例 `crl_t/1.12.2-Cleanroom`（HMCL 布局）、Cleanroom + forgelin-continuous、
   存档 `新的世界`、传送门 `(-337,70,290)`、NVIDIA RTX 5070 Laptop（驱动 610.74）。
 - 无光影：看穿（洞内可见末地黑曜石柱）+ 星野旋涡形状 + 淡出 + 位置均正常（用户实机确认，
   构建 `alpha-0.0.6-c7f3d45-portalfix6`）。
-- **光影（MakeUp / BSL）：传送门进入视角即出现严重卡顿且地形整体消失（2026-09-02 实机），
-  指向放行后的原版 TESR 路径与光影管线（program/状态归属）冲突，待单独排查修复。**
+- 光影（BSL）：看穿与主世界各自带光影效果、帧数与地形正常（构建
+  `alpha-0.0.6-1bae36f-portalfix10`）；星野叠加层可见、转动视角无闪烁、淡出正常、换维度
+  正常（构建 `alpha-0.0.6-1bae36f-portalfix12`，2026-09-02 用户实机确认）。
 - 不装 BPR 的原版传送门/折跃门回归待补。
 
 ## 注意事项

--- a/docs/compat/betterportals.md
+++ b/docs/compat/betterportals.md
@@ -1,0 +1,97 @@
+# BetterPortals Refitted 兼容性说明
+
+兼容状态：**部分**（无光影场景看穿 + 星野正常；光影开启后传送门进入视角会导致严重卡顿
+且地形整体消失，待修复）
+最后更新：2026-09-02
+
+## 模组信息
+
+- betterportals-0.4.1.jar（modid `betterportals`，BetterPortals Refitted）
+- 依赖：forgelin-continuous（Kotlin 运行时）
+- BPR jar 自带 `_Actinium`/`_Celeritas` 定向 mixin（`mixins.betterportals.view.json`）：
+  celeritas 侧 mixin 负责看穿渲染的地形就绪门控（`CeleritasTerrainDetail`），与本模组协同正常。
+
+## 现象（修复前）
+
+- 末地传送门没有"看穿看到末地"的视觉效果，洞口只能看到传送门（星野）贴图；传送功能正常。
+- 传送门视觉位置比平时低约一格。
+- 第一阶段的修复（放行星野渲染路径）后，星野出现但被拉伸成竖直条纹。
+
+## 根因机制（三层叠加，2026-09-01 ~ 09-02 定位）
+
+### 1. 看穿管线的 surface shader 失活
+
+BPR 的看穿表面 quad 用 `betterportals:render_portal` shader 采样 view FBO。该 shader
+依赖 `#ifdef GL_ES` / `#if BP_GL_ES && !BP_MOBILEGLES` 等预处理器条件分支；Actinium 的
+compat shader 变换器此前对条件求值有 bug，桌面分支采样代码被剔除，链接后 program 缺少
+活跃的 `sampler` uniform，Forge 无法喂入 view FBO 纹理，看穿画面采样失败（日志特征：
+`Shader betterportals:render_portal could not find sampler named sampler`）。
+由 `c7f3d45 fix(glsm): evaluate preprocessor conditionals in compat shaders` 修复，
+回归断言锁定 `sampler`/`screenSize`/`opacity` 等 Forge 按名查找的 uniform 必须存活
+（`CompatShaderTransformerTest`）。
+
+### 2. 星野叠加渲染被整体劫持
+
+BPR 的 `EndPortalRenderer.renderPortalBlocks` 自建一个**无 world 的合成 dummy
+TileEntityEndPortal**，直接调原版 `TileEntityEndPortalRenderer.render` 六参方法来画
+星野叠加层，并依赖原版路径上的精确 blend 钩子（`shouldRenderFace` 回调里
+`blendFunc(CONSTANT_ALPHA,…)` + `glBlendColor` 淡出）与投影式 texgen。
+
+Actinium 的 `TileEntityEndPortalRendererIrisMixin` 此前无条件 cancel 该入口并改走自研
+core-profile 渲染器，BPR 的淡出语义被破坏（星野不透明化/消失）。
+
+修复：`render/EndPortalRenderPolicy` 以「TE 是否属于世界」区分调用来源——dispatcher 对
+真实世界 TE 的调用继续走替换渲染器；无 world 的合成 TE 调用**放行原版路径**，由 glsm
+FFP/texgen 模拟执行，恢复 blend 钩子语义。判据不引用 BPR 类，对任何以合成 TE 走原版
+TESR 的模组通用。折跃门（`TileEntityEndGatewayRenderer`）覆写路径不受影响。
+
+### 3. glsm texgen 顶点着色器触发 NVIDIA 驱动 uniform 消除
+
+放行后星野走 glsm 的 FFP 眼线性 texgen 模拟。生成的顶点着色器原写法为：
+
+```glsl
+vec4 texGenCoord = vec4(0.0, 0.0, 0.0, 1.0);
+texGenCoord.s = dot(eyePos, u_TexGenEyePlaneS);
+texGenCoord.t = dot(eyePos, u_TexGenEyePlaneT);
+texGenCoord.r = dot(eyePos, u_TexGenEyePlaneR);
+```
+
+NVIDIA 驱动（RTX 5070 Laptop / 610.74 实测）把「先初始化再单分量覆写」模式中
+`u_TexGenEyePlaneS` 的 feed 链误判为可消除——`GL_ACTIVE_UNIFORMS` 枚举里 S 缺失而
+T/R 存活，眼平面 S 恒为 0，纹理映射塌掉一个基向量，星野沿一个方向被拉成条纹。
+
+修复（`VertexShaderGenerator`）：改为单表达式构造，语义完全等价但不再给驱动逐分量
+消除的机会：
+
+```glsl
+vec4 texGenCoord = vec4(dot(eyePos, u_TexGenEyePlaneS), dot(eyePos, u_TexGenEyePlaneT),
+    dot(eyePos, u_TexGenEyePlaneR), 1.0);
+```
+
+修复后枚举确认 `u_TexGenEyePlaneS` 回到活跃列表（12 → 13 个活跃 uniform），视觉恢复。
+回归测试 `VertexShaderGeneratorTest#eyeLinearTexGenFeedsEveryPlaneFromSingleConstructor`
+（ANTLR 解析生成物断言 AST）锁定该结构。
+
+### 「低约一格」的解释
+
+非独立缺陷：BPR 按设计把星野画在洞底（`translateY(-0.75)`，星野落在 y+0 而非原版的
+y+0.75）。看穿失败时洞口唯一可见的就是这层星野，于是表现为「整体低一格」；看穿恢复后
+该错觉随之消失。
+
+## 验证记录
+
+- 环境：实例 `crl_t/1.12.2-Cleanroom`（HMCL 布局）、Cleanroom + forgelin-continuous、
+  存档 `新的世界`、传送门 `(-337,70,290)`、NVIDIA RTX 5070 Laptop（驱动 610.74）。
+- 无光影：看穿（洞内可见末地黑曜石柱）+ 星野旋涡形状 + 淡出 + 位置均正常（用户实机确认，
+  构建 `alpha-0.0.6-c7f3d45-portalfix6`）。
+- **光影（MakeUp / BSL）：传送门进入视角即出现严重卡顿且地形整体消失（2026-09-02 实机），
+  指向放行后的原版 TESR 路径与光影管线（program/状态归属）冲突，待单独排查修复。**
+- 不装 BPR 的原版传送门/折跃门回归待补。
+
+## 注意事项
+
+- 排查期间用的 BPR jar 是带临时插桩的构建（`[BP surface]`/`[tpdbg]` 日志不在其源码树
+  当前版本中）；换成正式 BPR 构建不影响本兼容层的行为（Actinium 侧不依赖这些日志）。
+- glsm 的 program 绑定跟踪与真实 GL 可能不同步（`ShaderManager.commitVariant` 直连
+  backend `useProgram`，不更新 `GLStateManager` 的跟踪值）；用
+  `GLStateManager.getActiveProgram()` 做诊断时需注意其值可能是跟踪值而非真实绑定。

--- a/docs/compat/betterportals.md
+++ b/docs/compat/betterportals.md
@@ -91,7 +91,8 @@ reloading pipeline` 每帧刷屏）。
 （`IrisCeleritasChunkProgramOverrides.programsPerPipeline`），`MinecraftFramebufferHelper`
 动态读 `mc.getFramebuffer()` 使 Iris 合成自动写入 BPR 换入的传送门 FBO——两个世界各自
 获得完整光影效果。EntityRenderer 注入点守卫回退为纯深度 `RenderWorldRecursionGuard`
-（真嵌套防御，顺序双 pass 不再触发跳过）。
+（真嵌套防御，顺序双 pass 不再触发跳过）。缓存的维度管线在停止渲染闲置 30 秒后自动
+销毁回收（含地形 program 惰性清理），显存不随门/维度数量累积。
 
 **星野叠加层被旁路**：光影下实体渲染阶段 Iris 的 gbuffers program 已绑定，glsm 按设计
 对外部 program 让位（`ShaderManager.preDraw` 提前 return），原版 TESR 的 texgen FFP

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -55,6 +55,14 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 > [docs/compat/oldresearch.md](compat/oldresearch.md)。dev 人工回归确认研究笔记 GUI 不再卡死，
 > 优化后约 500+ FPS，与背包界面同量级；研究树视觉回归仍待补充。
 
+> 2026-09-02 追加：BetterPortals Refitted 0.4.1 末地传送门无看穿效果（洞口只见星野贴图）+
+> 视觉位置低约一格 + 修复后星野被拉成竖直条纹的修复——见下方 [模组与环境](#模组与环境) 的
+> BetterPortals Refitted 行与 [docs/compat/betterportals.md](compat/betterportals.md)。
+> 三层根因叠加：compat shader 预处理器条件求值 bug 致 `render_portal` 的 `sampler` 失活；
+> `TileEntityEndPortalRendererIrisMixin` 无条件劫持使 BPR 合成 TE 的星野叠加失去原版
+> blend 钩子语义；glsm texgen 顶点着色器的逐分量写入模式被 NVIDIA 驱动 DCE 掉
+> `u_TexGenEyePlaneS`。
+
 ## 光影包
 
 | 光影包                                | 版本            | 状态   | 已验证范围                                                          | 已知缺口      | Actinium 基线 |
@@ -95,6 +103,7 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 | AgriCraft | 部分 | `ModdedBlockRenderCompat` 使用共享 renderer 锁保护 crop 缓存 | 与 XU2 相同的异步第三方缓存访问模式已加入兼容层；dev 运行验证待补，详见 [docs/compat/extrautils2.md](compat/extrautils2.md) |
 | Kirino Engine（Cleanroom 内建） | 部分（Headless） | early 配置 + `IMixinConfigPlugin` 门控，钉死 `isEnableRenderDelegate()` 为 false（`MixinKirinoConfigHub`） | Kirino Graphics 模式会整体替换 `EntityRenderer#renderWorld`，使 Actinium 全部渲染注入点失效；共存的唯一路径是 Kirino Headless 模式：本兼容层强制其渲染委托关闭、保留 ECS/分析运行时，Actinium 独掌渲染管线。Cleanroom 0.6.7-alpha（kirino epoch-1.a5）dev 运行通过（early 配置注册、headless installer、兼容层日志、渲染循环正常），详见 [docs/compat/kirino.md](compat/kirino.md) |
 | Scannable | 已验证 | 条件 Mixin（接管 `ProxyOptiFine` 探针，扫描波走其 overlay 路径） | 1.6.3.26（266784:3146549）：使用扫描器后无光影透视 / 光影全白拖影的根因是其 INJECT 路径换装主 FBO 深度 attachment（Actinium 下 `Framebuffer.depthBuffer` 为 0，"恢复"即卸下深度）；已引导其走 OptiFine 式 overlay 渲染路径，详见 [docs/compat/scannable.md](compat/scannable.md)；dev 运行验证通过（无光影透视与光影全白均消失、扫描波区域正确；相邻结果合并为聚类大框为 Scannable 固有设计） |
+| BetterPortals Refitted | 部分 | 无侵入（`EndPortalRenderPolicy` 放行无 world 的合成 TESR 调用走 glsm FFP/texgen 模拟）+ glsm texgen 着色器驱动兼容修复 | 0.4.1：末地传送门看穿失效/星野条纹已修复（三层根因见 [docs/compat/betterportals.md](compat/betterportals.md)）；无光影场景看穿+星野+淡出+位置实机确认正常；**已知缺口：光影开启后传送门进入视角即严重卡顿且地形整体消失（待修复）** |
 
 ## 验证记录模板
 

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -103,7 +103,7 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 | AgriCraft | 部分 | `ModdedBlockRenderCompat` 使用共享 renderer 锁保护 crop 缓存 | 与 XU2 相同的异步第三方缓存访问模式已加入兼容层；dev 运行验证待补，详见 [docs/compat/extrautils2.md](compat/extrautils2.md) |
 | Kirino Engine（Cleanroom 内建） | 部分（Headless） | early 配置 + `IMixinConfigPlugin` 门控，钉死 `isEnableRenderDelegate()` 为 false（`MixinKirinoConfigHub`） | Kirino Graphics 模式会整体替换 `EntityRenderer#renderWorld`，使 Actinium 全部渲染注入点失效；共存的唯一路径是 Kirino Headless 模式：本兼容层强制其渲染委托关闭、保留 ECS/分析运行时，Actinium 独掌渲染管线。Cleanroom 0.6.7-alpha（kirino epoch-1.a5）dev 运行通过（early 配置注册、headless installer、兼容层日志、渲染循环正常），详见 [docs/compat/kirino.md](compat/kirino.md) |
 | Scannable | 已验证 | 条件 Mixin（接管 `ProxyOptiFine` 探针，扫描波走其 overlay 路径） | 1.6.3.26（266784:3146549）：使用扫描器后无光影透视 / 光影全白拖影的根因是其 INJECT 路径换装主 FBO 深度 attachment（Actinium 下 `Framebuffer.depthBuffer` 为 0，"恢复"即卸下深度）；已引导其走 OptiFine 式 overlay 渲染路径，详见 [docs/compat/scannable.md](compat/scannable.md)；dev 运行验证通过（无光影透视与光影全白均消失、扫描波区域正确；相邻结果合并为聚类大框为 Scannable 固有设计） |
-| BetterPortals Refitted | 部分 | 无侵入（`EndPortalRenderPolicy` 放行无 world 的合成 TESR 调用走 glsm FFP/texgen 模拟）+ glsm texgen 着色器驱动兼容修复 | 0.4.1：末地传送门看穿失效/星野条纹已修复（三层根因见 [docs/compat/betterportals.md](compat/betterportals.md)）；无光影场景看穿+星野+淡出+位置实机确认正常；**已知缺口：光影开启后传送门进入视角即严重卡顿且地形整体消失（待修复）** |
+| BetterPortals Refitted | 已验证 | `EndPortalRenderPolicy` 按调用来源分流（真实 TE 走替代渲染器；合成 TE 无光影走 glsm FFP/texgen、光影走替代渲染器并复刻 CONSTANT_ALPHA 淡出钩子）+ 管线按维度缓存消除看穿双 pass 的重载风暴 | 0.4.1：末地传送门看穿失效/星野条纹/光影卡顿地形消失/光影星野旁路均已修复（四层根因见 [docs/compat/betterportals.md](compat/betterportals.md)）；无光影与光影（BSL）场景看穿+星野+淡出+换维度均实机确认正常 |
 
 ## 验证记录模板
 

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/CompatShaderTransformer.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/CompatShaderTransformer.java
@@ -11,7 +11,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayDeque;
 import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Locale;
@@ -151,7 +154,7 @@ public class CompatShaderTransformer {
         final int targetVersion = Math.max(declaredVersion, RENDER_BACKEND != null ? RENDER_BACKEND.getMinGLSLVersion() : 330);
 
         source = stripGlesPrecisionGuards(source);
-        final SeparatedSource separatedSource = separatePreprocessorPreamble(source);
+        final SeparatedSource separatedSource = separatePreprocessorPreamble(source, targetVersion);
         source = MAIN_VOID_PARAMETERS_PATTERN.matcher(separatedSource.shader()).replaceAll("main()");
 
         // Pre-parse reserved word renaming — prevents ANTLR parse failures
@@ -292,10 +295,26 @@ public class CompatShaderTransformer {
      * Keep a leading directive-only preamble out of the GLSL AST parser. Moving directives after shader tokens, or
      * moving shader tokens out of a conditional block, would change preprocessing semantics and is therefore rejected.
      */
-    private static SeparatedSource separatePreprocessorPreamble(String source) {
+    private static SeparatedSource separatePreprocessorPreamble(String source, int targetVersion) {
+        try {
+            return separatePreprocessorPreambleStrict(source);
+        } catch (IllegalArgumentException e) {
+            // Mid-body conditional blocks that select between GLSL token groups (a common pattern in
+            // multi-backend mod shaders) are resolvable by evaluating the conditionals up front; every
+            // other unsafe layout keeps its original failure.
+            if (!e.getMessage().contains("conditional directive controls GLSL tokens")
+                    && !e.getMessage().contains("directive appears after GLSL tokens")) {
+                throw e;
+            }
+            return separatePreprocessorWithEvaluatedConditionals(source, targetVersion);
+        }
+    }
+
+    private static SeparatedSource separatePreprocessorPreambleStrict(String source) {
         final String[] lines = source.split("\\R", -1);
         final StringBuilder shader = new StringBuilder(source.length());
         final StringBuilder preprocessor = new StringBuilder();
+        final StringBuilder leadingComments = new StringBuilder();
         boolean continuation = false;
         boolean inBlockComment = false;
         boolean shaderStarted = false;
@@ -340,13 +359,28 @@ public class CompatShaderTransformer {
                     if (conditionalDepth != 0) {
                         throw unsafePreprocessorLayout(lineIndex, "conditional directive controls GLSL tokens");
                     }
+                    if (!shaderStarted) {
+                        // Comments and blank lines collected before the first token move in front of
+                        // the body: the GLSL transformer library fails to place injected declarations
+                        // on an AST whose only leading nodes are comments.
+                        preprocessor.append(leadingComments);
+                        leadingComments.setLength(0);
+                    }
                     shaderStarted = true;
                 }
-                shader.append(line);
+                if (shaderStarted) {
+                    shader.append(line);
+                } else {
+                    leadingComments.append(line);
+                }
             }
 
             if (lineIndex < lines.length - 1) {
-                shader.append('\n');
+                if (shaderStarted) {
+                    shader.append('\n');
+                } else {
+                    leadingComments.append('\n');
+                }
             }
         }
 
@@ -357,7 +391,444 @@ public class CompatShaderTransformer {
             throw unsafePreprocessorLayout(lines.length - 1, "unterminated conditional directive");
         }
 
+        preprocessor.append(leadingComments);
+
         return new SeparatedSource(shader.toString(), preprocessor.toString());
+    }
+
+    private static final class ConditionalState {
+        boolean active;
+        boolean taken;
+
+        ConditionalState(boolean active, boolean taken) {
+            this.active = active;
+            this.taken = taken;
+        }
+    }
+
+    /**
+     * Preprocessor separation for shaders whose conditional blocks contain GLSL tokens (e.g. a
+     * {@code #if BP_NATIVE_ES / #else / #endif} pair selecting between a GLES and a desktop body).
+     * The strict scan rejects those because the AST parser cannot represent the untaken branch, so
+     * here the conditionals are evaluated up front against the macros defined so far (plus
+     * {@code __VERSION__}) and only the taken branches reach the output. C preprocessing rules
+     * apply: undefined identifiers are 0 in {@code #if} expressions and a branch whose expression
+     * cannot be evaluated fails the transform (falling back to version fixup, as before).
+     */
+    private static SeparatedSource separatePreprocessorWithEvaluatedConditionals(String source, int targetVersion) {
+        final String[] lines = source.split("\\R", -1);
+        final StringBuilder shader = new StringBuilder(source.length());
+        final StringBuilder preprocessor = new StringBuilder();
+        final StringBuilder leadingComments = new StringBuilder();
+        boolean inBlockComment = false;
+        boolean shaderStarted = false;
+        boolean macroDirectiveSeen = false;
+        final Deque<ConditionalState> conditionals = new ArrayDeque<>();
+        final Map<String, String> macros = new HashMap<>();
+
+        for (int lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+            final String line = lines[lineIndex];
+            final LineClassification classification = classifyLine(line, inBlockComment);
+            inBlockComment = classification.inBlockComment();
+
+            if (classification.trailingBackslash()) {
+                throw unsafePreprocessorLayout(lineIndex, "unterminated directive continuation");
+            }
+
+            final boolean live = conditionals.isEmpty() || conditionals.peek().active;
+
+            if (classification.directive()) {
+                final String directiveName = directiveName(line, classification.directiveOffset());
+                switch (directiveName) {
+                    case "if", "ifdef", "ifndef" -> {
+                        if (live) {
+                            final boolean active = evaluateConditionalDirective(
+                                    line, directiveName, classification.directiveOffset(), macros, targetVersion);
+                            conditionals.push(new ConditionalState(active, active));
+                        } else {
+                            conditionals.push(new ConditionalState(false, true));
+                        }
+                    }
+                    case "elif" -> {
+                        final ConditionalState state = requireConditionalState(conditionals, lineIndex);
+                        if (state.taken) {
+                            state.active = false;
+                        } else {
+                            state.active = evaluateConditionalDirective(
+                                    line, directiveName, classification.directiveOffset(), macros, targetVersion);
+                            state.taken = state.active;
+                        }
+                    }
+                    case "else" -> {
+                        final ConditionalState state = requireConditionalState(conditionals, lineIndex);
+                        state.active = !state.taken;
+                        state.taken = true;
+                    }
+                    case "endif" -> conditionals.pop();
+                    case "line" -> throw unsafePreprocessorLayout(
+                            lineIndex, "#line cannot be relocated without changing line semantics");
+                    case "version" -> {
+                        if (!conditionals.isEmpty()) {
+                            throw unsafePreprocessorLayout(lineIndex, "#version appears inside a conditional block");
+                        }
+                        // Emitted by the transformer itself.
+                    }
+                    case "define", "undef" -> {
+                        if (live) {
+                            applyMacroDirective(line, classification.directiveOffset(), directiveName, macros);
+                            if (shaderStarted && !canRelocateLateMacro(
+                                    line, classification.directiveOffset(), directiveName, shader, macroDirectiveSeen)) {
+                                throw unsafePreprocessorLayout(lineIndex, "directive appears after GLSL tokens");
+                            }
+                            preprocessor.append(line).append('\n');
+                            macroDirectiveSeen = true;
+                        }
+                    }
+                    default -> {
+                        if (live) {
+                            if (shaderStarted) {
+                                throw unsafePreprocessorLayout(lineIndex, "directive appears after GLSL tokens");
+                            }
+                            preprocessor.append(line).append('\n');
+                        }
+                    }
+                }
+            } else if (live) {
+                if (classification.shaderToken() && !shaderStarted) {
+                    // Comments and blank lines collected before the first token move in front of
+                    // the body: the GLSL transformer library fails to place injected declarations
+                    // on an AST whose only leading nodes are comments.
+                    preprocessor.append(leadingComments);
+                    leadingComments.setLength(0);
+                    shaderStarted = true;
+                }
+                if (shaderStarted) {
+                    shader.append(line);
+                } else {
+                    leadingComments.append(line);
+                }
+            }
+            // Lines of dead branches are dropped entirely.
+
+            if (lineIndex < lines.length - 1) {
+                if (shaderStarted) {
+                    shader.append('\n');
+                } else {
+                    leadingComments.append('\n');
+                }
+            }
+        }
+
+        if (!conditionals.isEmpty()) {
+            throw unsafePreprocessorLayout(lines.length - 1, "unterminated conditional directive");
+        }
+
+        preprocessor.append(leadingComments);
+
+        return new SeparatedSource(shader.toString(), preprocessor.toString());
+    }
+
+    private static ConditionalState requireConditionalState(Deque<ConditionalState> conditionals, int lineIndex) {
+        final ConditionalState state = conditionals.peek();
+        if (state == null) {
+            throw unsafePreprocessorLayout(lineIndex, "conditional branch has no opening directive");
+        }
+        return state;
+    }
+
+    private static boolean evaluateConditionalDirective(
+            String line,
+            String directiveName,
+            int directiveOffset,
+            Map<String, String> macros,
+            int targetVersion
+    ) {
+        final String expression = switch (directiveName) {
+            case "ifdef" -> "defined(" + macroOperand(line, directiveOffset) + ")";
+            case "ifndef" -> "!defined(" + macroOperand(line, directiveOffset) + ")";
+            default -> line.substring(directiveOffset + 1 + directiveName.length());
+        };
+        return new GlslConditionalExpression(expression, macros, targetVersion).evaluate() != 0;
+    }
+
+    private static String macroOperand(String line, int directiveOffset) {
+        final Matcher matcher = Pattern.compile("[ \\t]*([A-Za-z_][A-Za-z0-9_]*)")
+                .matcher(line.substring(directiveOffset + 1));
+        if (!matcher.lookingAt()) {
+            throw new IllegalArgumentException("Malformed macro operand in directive: " + line.trim());
+        }
+        return matcher.group(1);
+    }
+
+    private static void applyMacroDirective(
+            String line,
+            int directiveOffset,
+            String directiveName,
+            Map<String, String> macros
+    ) {
+        final Matcher matcher = MACRO_NAME_PATTERN.matcher(line.substring(directiveOffset + 1));
+        if (!matcher.lookingAt()) {
+            return;
+        }
+        if ("undef".equals(directiveName)) {
+            macros.remove(matcher.group(1));
+            return;
+        }
+        final String body = line.substring(directiveOffset + 1 + matcher.end());
+        // Value-less macros exist for defined()/ifdef only; function-like macros stay opaque (their
+        // use inside an #if expression will then fail evaluation and fall back, as before).
+        final String trimmed = body.trim();
+        if (trimmed.startsWith("(")) {
+            return;
+        }
+        macros.put(matcher.group(1), trimmed.isEmpty() ? null : trimmed);
+    }
+
+    /**
+     * Integer evaluator for the subset of C preprocessor expression syntax mod shaders use:
+     * {@code defined(X)}, macro references (recursively expanded, undefined = 0),
+     * {@code __VERSION__}, integer literals with suffixes, parentheses, {@code ! - + * / %},
+     * {@code + -}, comparisons and {@code && ||}.
+     */
+    private static final class GlslConditionalExpression {
+        private final String source;
+        private final Map<String, String> macros;
+        private final int targetVersion;
+        private int pos;
+
+        GlslConditionalExpression(String source, Map<String, String> macros, int targetVersion) {
+            this.source = source;
+            this.macros = macros;
+            this.targetVersion = targetVersion;
+        }
+
+        long evaluate() {
+            final long value = parseOr();
+            skipWhitespace();
+            if (pos != source.length()) {
+                throw new IllegalArgumentException("Trailing tokens in #if expression: " + source.substring(pos));
+            }
+            return value;
+        }
+
+        private long parseOr() {
+            long value = parseAnd();
+            while (true) {
+                skipWhitespace();
+                if (match("||")) {
+                    final long right = parseAnd();
+                    value = (value != 0 || right != 0) ? 1 : 0;
+                } else {
+                    return value;
+                }
+            }
+        }
+
+        private long parseAnd() {
+            long value = parseEquality();
+            while (true) {
+                skipWhitespace();
+                if (match("&&")) {
+                    final long right = parseEquality();
+                    value = (value != 0 && right != 0) ? 1 : 0;
+                } else {
+                    return value;
+                }
+            }
+        }
+
+        private long parseEquality() {
+            long value = parseRelational();
+            while (true) {
+                skipWhitespace();
+                if (match("==")) {
+                    value = value == parseRelational() ? 1 : 0;
+                } else if (match("!=")) {
+                    value = value != parseRelational() ? 1 : 0;
+                } else {
+                    return value;
+                }
+            }
+        }
+
+        private long parseRelational() {
+            long value = parseAdditive();
+            while (true) {
+                skipWhitespace();
+                if (match(">=")) {
+                    value = value >= parseAdditive() ? 1 : 0;
+                } else if (match("<=")) {
+                    value = value <= parseAdditive() ? 1 : 0;
+                } else if (match(">")) {
+                    value = value > parseAdditive() ? 1 : 0;
+                } else if (match("<")) {
+                    value = value < parseAdditive() ? 1 : 0;
+                } else {
+                    return value;
+                }
+            }
+        }
+
+        private long parseAdditive() {
+            long value = parseMultiplicative();
+            while (true) {
+                skipWhitespace();
+                if (match("+")) {
+                    value += parseMultiplicative();
+                } else if (match("-")) {
+                    value -= parseMultiplicative();
+                } else {
+                    return value;
+                }
+            }
+        }
+
+        private long parseMultiplicative() {
+            long value = parseUnary();
+            while (true) {
+                skipWhitespace();
+                if (match("*")) {
+                    value *= parseUnary();
+                } else if (match("/")) {
+                    final long divisor = parseUnary();
+                    if (divisor == 0) {
+                        throw new IllegalArgumentException("Division by zero in #if expression");
+                    }
+                    value /= divisor;
+                } else if (match("%")) {
+                    final long divisor = parseUnary();
+                    if (divisor == 0) {
+                        throw new IllegalArgumentException("Modulo by zero in #if expression");
+                    }
+                    value %= divisor;
+                } else {
+                    return value;
+                }
+            }
+        }
+
+        private long parseUnary() {
+            skipWhitespace();
+            if (match("!")) {
+                return parseUnary() == 0 ? 1 : 0;
+            }
+            if (match("-")) {
+                return -parseUnary();
+            }
+            if (match("+")) {
+                return parseUnary();
+            }
+            return parsePrimary();
+        }
+
+        private long parsePrimary() {
+            skipWhitespace();
+            if (match("(")) {
+                final long value = parseOr();
+                skipWhitespace();
+                if (!match(")")) {
+                    throw new IllegalArgumentException("Missing closing parenthesis in #if expression");
+                }
+                return value;
+            }
+            if (tryMatch("defined")) {
+                skipWhitespace();
+                final boolean parenthesized = match("(");
+                final String name = parseIdentifier();
+                if (name.isEmpty()) {
+                    throw new IllegalArgumentException("defined() without identifier in #if expression");
+                }
+                if (parenthesized) {
+                    skipWhitespace();
+                    if (!match(")")) {
+                        throw new IllegalArgumentException("Missing closing parenthesis after defined(" + name + ")");
+                    }
+                }
+                return macros.containsKey(name) ? 1 : 0;
+            }
+            // Integer literals before identifiers: parseIdentifier accepts digits, so a literal
+            // like 130 would otherwise be treated as an (undefined) macro name and evaluate to 0.
+            final String number = parseIntegerLiteral();
+            if (number != null) {
+                return Long.parseLong(number);
+            }
+            final String identifier = parseIdentifier();
+            if (!identifier.isEmpty()) {
+                return expandIdentifier(identifier);
+            }
+            throw new IllegalArgumentException("Unexpected token in #if expression at: " + source.substring(pos));
+        }
+
+        private long expandIdentifier(String name) {
+            if ("__VERSION__".equals(name)) {
+                return targetVersion;
+            }
+            final String body = macros.get(name);
+            if (body == null) {
+                return 0; // C rule: undefined identifiers evaluate to 0 in #if
+            }
+            if (body.isBlank()) {
+                throw new IllegalArgumentException("Value-less macro '" + name + "' used in #if expression");
+            }
+            final GlslConditionalExpression nested = new GlslConditionalExpression(body, macros, targetVersion);
+            return nested.evaluate();
+        }
+
+        private String parseIdentifier() {
+            final int start = pos;
+            while (pos < source.length()
+                    && (Character.isLetterOrDigit(source.charAt(pos)) || source.charAt(pos) == '_')) {
+                pos++;
+            }
+            return source.substring(start, pos);
+        }
+
+        private String parseIntegerLiteral() {
+            final int start = pos;
+            while (pos < source.length()
+                    && (Character.isLetterOrDigit(source.charAt(pos)) || source.charAt(pos) == '\'')) {
+                pos++;
+            }
+            final String token = source.substring(start, pos);
+            if (token.isEmpty() || !Character.isDigit(token.charAt(0))) {
+                pos = start;
+                return null;
+            }
+            // Strip optional integer suffixes (1u, 10l, 0x1Full).
+            final String digits = token.replaceAll("[uUlL]+$", "").replace("'", "");
+            try {
+                Long.parseLong(digits, token.startsWith("0x") || token.startsWith("0X") ? 16
+                        : token.length() > 1 && token.startsWith("0") ? 8 : 10);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Malformed integer literal '" + token + "' in #if expression");
+            }
+            return digits;
+        }
+
+        private boolean match(String token) {
+            if (source.startsWith(token, pos)) {
+                pos += token.length();
+                return true;
+            }
+            return false;
+        }
+
+        private boolean tryMatch(String token) {
+            final int start = pos;
+            if (match(token)
+                    && (pos >= source.length()
+                        || !Character.isLetterOrDigit(source.charAt(pos)) && source.charAt(pos) != '_')) {
+                return true;
+            }
+            pos = start;
+            return false;
+        }
+
+        private void skipWhitespace() {
+            while (pos < source.length() && Character.isWhitespace(source.charAt(pos))) {
+                pos++;
+            }
+        }
     }
 
     private static int updateConditionalDepth(String directiveName, int depth, int lineIndex) {

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -2267,7 +2267,7 @@ public class GLStateManager {
             return;
         }
         prepareWideLineEmulation(mode);
-        ShaderManager.getInstance().preDraw();
+        preDrawFFP();
         prepareClientArrays();
         if (DEBUG_DRAW_LOGS) {
             GLSMDebug.logDrawElements("byte-buffer", mode, indices.remaining(), GL11.GL_UNSIGNED_BYTE, -1L);
@@ -2285,7 +2285,7 @@ public class GLStateManager {
             return;
         }
         prepareWideLineEmulation(mode);
-        ShaderManager.getInstance().preDraw();
+        preDrawFFP();
         prepareClientArrays();
         if (DEBUG_DRAW_LOGS) {
             GLSMDebug.logDrawElements("int-buffer", mode, indices.remaining(), GL11.GL_UNSIGNED_INT, -1L);
@@ -2307,7 +2307,7 @@ public class GLStateManager {
             return;
         }
         prepareWideLineEmulation(mode);
-        ShaderManager.getInstance().preDraw();
+        preDrawFFP();
         prepareClientArrays();
         if (DEBUG_DRAW_LOGS) {
             GLSMDebug.logDrawElements("short-buffer", mode, indices.remaining(), GL11.GL_UNSIGNED_SHORT, -1L);
@@ -2329,7 +2329,7 @@ public class GLStateManager {
             return;
         }
         prepareWideLineEmulation(mode);
-        ShaderManager.getInstance().preDraw();
+        preDrawFFP();
         prepareClientArrays();
         if (DEBUG_DRAW_LOGS) {
             GLSMDebug.logDrawElements("typed-byte-buffer", mode, count, type, -1L);
@@ -2365,7 +2365,7 @@ public class GLStateManager {
             return;
         }
         prepareWideLineEmulation(mode);
-        ShaderManager.getInstance().preDraw();
+        preDrawFFP();
         prepareClientArrays();
         if (DEBUG_DRAW_LOGS) {
             GLSMDebug.logDrawElements("ebo-offset", mode, indices_count, type, indices_buffer_offset);
@@ -2392,28 +2392,28 @@ public class GLStateManager {
     }
 
     public static void glMultiDrawElementsIndirect(int mode, int type, long indirect, int drawcount, int stride) {
-        ShaderManager.getInstance().preDraw();
+        preDrawFFP();
         prepareClientArrays();
         recordGpuCommand(GpuCommandType.DRAW_ELEMENTS, mode, drawcount);
         RENDER_BACKEND.multiDrawElementsIndirect(mode, type, indirect, drawcount, stride);
     }
 
     public static void glMultiDrawElementsBaseVertex(int mode, long pCount, int type, long pIndices, int drawcount, long pBaseVertex) {
-        ShaderManager.getInstance().preDraw();
+        preDrawFFP();
         prepareClientArrays();
         recordGpuCommand(GpuCommandType.DRAW_ELEMENTS, mode, drawcount);
         RENDER_BACKEND.multiDrawElementsBaseVertex(mode, pCount, type, pIndices, drawcount, pBaseVertex);
     }
 
     public static void glDrawElementsBaseVertex(int mode, int count, int type, long indices, int basevertex) {
-        ShaderManager.getInstance().preDraw();
+        preDrawFFP();
         prepareClientArrays();
         recordGpuCommand(GpuCommandType.DRAW_ELEMENTS, mode, count);
         RENDER_BACKEND.drawElementsBaseVertex(mode, count, type, indices, basevertex);
     }
 
     public static void glDrawElementsInstanced(int mode, int count, int type, long indices, int primcount) {
-        ShaderManager.getInstance().preDraw();
+        preDrawFFP();
         prepareClientArrays();
         recordGpuCommand(GpuCommandType.DRAW_ELEMENTS, mode, count);
         RENDER_BACKEND.drawElementsInstanced(mode, count, type, indices, primcount);
@@ -2421,7 +2421,7 @@ public class GLStateManager {
 
     public static void glDrawArraysInstanced(int mode, int first, int count, int primcount) {
         prepareWideLineEmulation(mode);
-        ShaderManager.getInstance().preDraw();
+        preDrawFFP();
         prepareClientArrays();
         recordGpuCommand(GpuCommandType.DRAW_ARRAYS, mode, count);
         if (mode == GL11.GL_QUADS) {
@@ -2432,6 +2432,23 @@ public class GLStateManager {
             RENDER_BACKEND.drawArraysInstanced(GL11.GL_TRIANGLE_FAN, first, count, primcount);
         } else {
             RENDER_BACKEND.drawArraysInstanced(mode, first, count, primcount);
+        }
+    }
+
+    /**
+     * Selects the FFP variant before a raw draw call. Draws fed by client-side arrays derive
+     * the vertex format from the actually enabled attributes (see
+     * {@link VertexAttribState#currentClientArrayVertexFlags()}): the cached currentVertexFlags
+     * only reflects the last buffer-state setup and may describe attributes this draw does not
+     * provide, making the FFP shader read unset attribute values (e.g. a black default vertex
+     * color for a POSITION-only draw such as the legacy end portal TESR).
+     */
+    private static void preDrawFFP() {
+        final ShaderManager ffp = ShaderManager.getInstance();
+        if (VertexAttribState.hasAnyClientSideEnabledAttrib()) {
+            ffp.preDraw(VertexAttribState.currentClientArrayVertexFlags());
+        } else {
+            ffp.preDraw();
         }
     }
 
@@ -2515,7 +2532,7 @@ public class GLStateManager {
             return;
         }
         prepareWideLineEmulation(mode);
-        ShaderManager.getInstance().preDraw();
+        preDrawFFP();
         prepareClientArrays();
         if (DEBUG_DRAW_LOGS) {
             GLSMDebug.logDrawArrays("draw-arrays", mode, first, count);

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/VertexShaderGenerator.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/ffp/VertexShaderGenerator.java
@@ -363,25 +363,26 @@ public final class VertexShaderGenerator {
      */
     private static void emitTexGenCoordGeneration(StringBuilder sb, VertexKey key) {
         sb.append("  // TexGen coordinate generation\n");
-        sb.append("  vec4 texGenCoord = vec4(0.0, 0.0, 0.0, 1.0);\n");
-
-        emitTexGenComponent(sb, key.texGenModeS(), "s", "S", key);
-        emitTexGenComponent(sb, key.texGenModeT(), "t", "T", key);
-        emitTexGenComponent(sb, key.texGenModeR(), "r", "R", key);
-        emitTexGenComponent(sb, key.texGenModeQ(), "q", "Q", key);
+        // Single-expression constructor: per-component writes to a pre-initialized vec4 let
+        // some drivers (NVIDIA) dead-code-eliminate the uniform feeding a lone component
+        // (observed: u_TexGenEyePlaneS dropped while T/R survive, breaking end-portal texgen).
+        sb.append("  vec4 texGenCoord = vec4(")
+            .append(texGenComponentExpr(key.texGenModeS(), "S")).append(", ")
+            .append(texGenComponentExpr(key.texGenModeT(), "T")).append(", ")
+            .append(texGenComponentExpr(key.texGenModeR(), "R")).append(", ")
+            .append(texGenComponentExpr(key.texGenModeQ(), "Q")).append(");\n");
 
         // Always apply texture matrix when texgen is active (forced on in VertexKey)
         sb.append("  v_TexCoord0 = u_TextureMatrix0 * texGenCoord;\n");
     }
 
-    private static void emitTexGenComponent(StringBuilder sb, int mode, String swizzle, String coordName, VertexKey key) {
-        switch (mode) {
-            case VertexKey.TG_OBJ_LINEAR ->
-                sb.append("  texGenCoord.").append(swizzle).append(" = dot(pos4, u_TexGenObjPlane").append(coordName).append(");\n");
-            case VertexKey.TG_EYE_LINEAR ->
-                sb.append("  texGenCoord.").append(swizzle).append(" = dot(eyePos, u_TexGenEyePlane").append(coordName).append(");\n");
-            // TG_NONE: keep default (0 for s/t/r, 1 for q) — already set in texGenCoord init
-        }
+    private static String texGenComponentExpr(int mode, String coordName) {
+        return switch (mode) {
+            case VertexKey.TG_OBJ_LINEAR -> "dot(pos4, u_TexGenObjPlane" + coordName + ")";
+            case VertexKey.TG_EYE_LINEAR -> "dot(eyePos, u_TexGenEyePlane" + coordName + ")";
+            // TG_NONE: default (0 for s/t/r, 1 for q) — matches the old texGenCoord init
+            default -> "Q".equals(coordName) ? "1.0" : "0.0";
+        };
     }
 
     private static boolean texGenNeedsEyePos(VertexKey key) {

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/states/VertexAttribState.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/states/VertexAttribState.java
@@ -1,5 +1,7 @@
 package com.gtnewhorizons.angelica.glsm.states;
 
+import com.gtnewhorizon.gtnhlib.client.renderer.vertex.VertexFlags;
+import com.gtnewhorizon.gtnhlib.client.renderer.vertex.VertexFormatElement.Usage;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 import org.lwjgl.opengl.GL11;
@@ -123,6 +125,25 @@ public class VertexAttribState {
     public static boolean hasAnyClientSideEnabledAttrib() {
         return clientSideEnabledCount > 0;
     }
+
+    /**
+     * Computes the FFP vertex-format flags for a draw fed by client-side arrays, from the
+     * attributes actually enabled on the current VAO. This is the authoritative source for
+     * such draws: the format-based flag cache in ShaderManager only reflects the last
+     * buffer-state setup (e.g. a VBO format) and can describe attributes a client-array
+     * draw does not provide, which would make the FFP shader read unset attribute values
+     * (e.g. a black default vertex color for a POSITION-only draw such as the legacy
+     * end portal TESR).
+     */
+    public static int currentClientArrayVertexFlags() {
+        int flags = 0;
+        if (get(Usage.COLOR.getAttributeLocation()).enabled) flags |= VertexFlags.COLOR_BIT;
+        if (get(Usage.NORMAL.getAttributeLocation()).enabled) flags |= VertexFlags.NORMAL_BIT;
+        if (get(Usage.PRIMARY_UV.getAttributeLocation()).enabled) flags |= VertexFlags.TEXTURE_BIT;
+        if (get(Usage.SECONDARY_UV.getAttributeLocation()).enabled) flags |= VertexFlags.BRIGHTNESS_BIT;
+        return flags;
+    }
+
     public static class Attrib {
         public boolean enabled;
         public int size;

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -35,6 +35,9 @@ dependencies {
 
     implementation 'org.joml:joml:1.10.5'
     contain 'org.joml:joml:1.10.5'
+    // Same joml artifact bundled into the jar body and relocated under the shadow namespace by the
+    // shadowRemapJar / devShadowJar tasks (upstream Celeritas distribution layout).
+    shadowBundle 'org.joml:joml:1.10.5'
     compileOnly 'it.unimi.dsi:fastutil:8.5.18'
     compileOnly "org.ow2.asm:asm:${asmVersion}"
     compileOnly "org.ow2.asm:asm-commons:${asmVersion}"

--- a/shader/src/main/java/net/coderbot/iris/celeritas/IrisCeleritasChunkProgramOverrides.java
+++ b/shader/src/main/java/net/coderbot/iris/celeritas/IrisCeleritasChunkProgramOverrides.java
@@ -17,13 +17,17 @@ import org.embeddedt.embeddium.impl.render.chunk.terrain.TerrainRenderPass;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.EnumMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 
 public class IrisCeleritasChunkProgramOverrides {
-    private final EnumMap<IrisTerrainPass, GlProgram<IrisCeleritasChunkShaderInterface>> programs = new EnumMap<>(IrisTerrainPass.class);
-    private boolean shadersCreated = false;
+    // Programs embed per-pipeline state (custom uniforms, pass info), so each world pipeline gets
+    // its own cached program set. Portal-style mods (BetterPortals) alternate dimensions within a
+    // frame; rebuilding on every switch would stall the render loop.
+    private final Map<WorldRenderingPipeline, EnumMap<IrisTerrainPass, GlProgram<IrisCeleritasChunkShaderInterface>>> programsPerPipeline = new IdentityHashMap<>();
     private int versionCounterForShaderReload = -1;
 
     @Nullable
@@ -101,21 +105,20 @@ public class IrisCeleritasChunkProgramOverrides {
     }
 
     /**
-     * Create shaders for all Iris terrain passes.
+     * Create shaders for all Iris terrain passes of one pipeline.
      */
-    public void createShaders(CeleritasTerrainPipeline pipeline, RenderPassConfiguration<?> configuration) {
+    private EnumMap<IrisTerrainPass, GlProgram<IrisCeleritasChunkShaderInterface>> createShaders(CeleritasTerrainPipeline pipeline, RenderPassConfiguration<?> configuration) {
+        final EnumMap<IrisTerrainPass, GlProgram<IrisCeleritasChunkShaderInterface>> programs = new EnumMap<>(IrisTerrainPass.class);
         if (pipeline != null) {
             for (IrisTerrainPass pass : IrisTerrainPass.VALUES) {
                 if (pass.isShadow() && !pipeline.hasShadowPass()) {
-                    this.programs.put(pass, null);
+                    programs.put(pass, null);
                     continue;
                 }
-                this.programs.put(pass, createShader(pass, pipeline, configuration));
+                programs.put(pass, createShader(pass, pipeline, configuration));
             }
-        } else {
-            deleteShaders();
         }
-        shadersCreated = true;
+        return programs;
     }
 
     @Nullable
@@ -127,14 +130,13 @@ public class IrisCeleritasChunkProgramOverrides {
         }
 
         final WorldRenderingPipeline worldPipeline = Iris.getPipelineManager().getPipelineNullable();
-        CeleritasTerrainPipeline celeritasPipeline = null;
-        if (worldPipeline != null) {
-            celeritasPipeline = worldPipeline.getCeleritasTerrainPipeline();
+        if (worldPipeline == null) {
+            return null;
         }
 
-        if (!shadersCreated) {
-            createShaders(celeritasPipeline, configuration);
-        }
+        final CeleritasTerrainPipeline celeritasPipeline = worldPipeline.getCeleritasTerrainPipeline();
+        final EnumMap<IrisTerrainPass, GlProgram<IrisCeleritasChunkShaderInterface>> programs =
+            programsPerPipeline.computeIfAbsent(worldPipeline, p -> createShaders(celeritasPipeline, configuration));
 
         final boolean isShadow = ShadowRenderingState.areShadowsCurrentlyBeingRendered();
         if (isShadow) {
@@ -147,12 +149,13 @@ public class IrisCeleritasChunkProgramOverrides {
     }
 
     public void deleteShaders() {
-        for (GlProgram<?> program : programs.values()) {
-            if (program != null) {
-                program.delete();
+        for (EnumMap<IrisTerrainPass, GlProgram<IrisCeleritasChunkShaderInterface>> programs : programsPerPipeline.values()) {
+            for (GlProgram<?> program : programs.values()) {
+                if (program != null) {
+                    program.delete();
+                }
             }
         }
-        programs.clear();
-        shadersCreated = false;
+        programsPerPipeline.clear();
     }
 }

--- a/shader/src/main/java/net/coderbot/iris/celeritas/IrisCeleritasChunkProgramOverrides.java
+++ b/shader/src/main/java/net/coderbot/iris/celeritas/IrisCeleritasChunkProgramOverrides.java
@@ -129,6 +129,10 @@ public class IrisCeleritasChunkProgramOverrides {
             deleteShaders();
         }
 
+        // Drop programs whose dimension pipeline has been evicted or destroyed since the last
+        // lookup; their GL objects would otherwise leak until the next full shader reload.
+        programsPerPipeline.keySet().removeIf(candidate -> !Iris.getPipelineManager().isPipelineCached(candidate));
+
         final WorldRenderingPipeline worldPipeline = Iris.getPipelineManager().getPipelineNullable();
         if (worldPipeline == null) {
             return null;

--- a/shader/src/main/java/net/coderbot/iris/pipeline/PipelineManager.java
+++ b/shader/src/main/java/net/coderbot/iris/pipeline/PipelineManager.java
@@ -13,6 +13,7 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL13;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -20,8 +21,13 @@ import java.util.function.Function;
 
 public class PipelineManager {
 
+	private static final long IDLE_PIPELINE_TIMEOUT_NS = 30_000_000_000L;
+	private static final long EVICTION_SCAN_INTERVAL_NS = 1_000_000_000L;
+
 	private final Function<String, WorldRenderingPipeline> pipelineFactory;
 	private final Map<String, WorldRenderingPipeline> pipelinesPerDimension = new HashMap<>();
+	private final Map<String, Long> pipelineLastUsedNs = new HashMap<>();
+	private long lastEvictionScanNs;
 	private WorldRenderingPipeline pipeline = new FixedFunctionWorldRenderingPipeline();
 	private String lastPreparedDimension = null;
     @Getter
@@ -34,8 +40,13 @@ public class PipelineManager {
 	public WorldRenderingPipeline preparePipeline(String currentDimension) {
 		// Portal-style mods (e.g. BetterPortals) legitimately render another dimension within the
 		// same frame, so a dimension flip is not necessarily a world-load event: keep every
-		// dimension's pipeline cached and just switch to it. All pipelines are still torn down
-		// together on shaderpack reload / world unload via destroyPipeline().
+		// dimension's pipeline cached and just switch to it. Pipelines of dimensions that stop
+		// being rendered (portal gone, dimension left behind) are destroyed once they have been
+		// idle for IDLE_PIPELINE_TIMEOUT_NS so their render targets and programs are reclaimed;
+		// shaderpack reload / world unload still tears down everything via destroyPipeline().
+		long nowNs = System.nanoTime();
+		evictIdlePipelines(currentDimension, nowNs);
+
 		if (lastPreparedDimension != null && !lastPreparedDimension.equals(currentDimension)) {
 			GlFlightRecording.dimensionChange(lastPreparedDimension, currentDimension);
 		}
@@ -54,8 +65,46 @@ public class PipelineManager {
 		} else {
 			pipeline = pipelinesPerDimension.get(currentDimension);
 		}
+		pipelineLastUsedNs.put(currentDimension, nowNs);
 
 		return pipeline;
+	}
+
+	private void evictIdlePipelines(String activeDimension, long nowNs) {
+		if (nowNs - lastEvictionScanNs < EVICTION_SCAN_INTERVAL_NS) {
+			return;
+		}
+		lastEvictionScanNs = nowNs;
+
+		Iterator<Entry<String, WorldRenderingPipeline>> iterator = pipelinesPerDimension.entrySet().iterator();
+		while (iterator.hasNext()) {
+			Entry<String, WorldRenderingPipeline> entry = iterator.next();
+			String dimensionName = entry.getKey();
+			if (dimensionName.equals(activeDimension)) {
+				continue;
+			}
+			Long lastUsedNs = pipelineLastUsedNs.get(dimensionName);
+			if (lastUsedNs != null && nowNs - lastUsedNs <= IDLE_PIPELINE_TIMEOUT_NS) {
+				continue;
+			}
+
+			GlFlightRecording.beginPipelineDestroy(dimensionName);
+			Iris.logger.info("Destroying idle pipeline for dimension '{}'", dimensionName);
+			resetTextureState();
+			entry.getValue().destroy();
+			MinecraftFramebufferHelper.restoreMainFramebuffer(true);
+			GlFlightRecording.endPipelineDestroy(dimensionName);
+			iterator.remove();
+			pipelineLastUsedNs.remove(dimensionName);
+		}
+	}
+
+	/**
+	 * Returns whether the given pipeline is still held by the per-dimension cache. The terrain
+	 * shader provider uses this to drop programs whose pipeline has been evicted or destroyed.
+	 */
+	public boolean isPipelineCached(WorldRenderingPipeline candidate) {
+		return pipelinesPerDimension.containsValue(candidate);
 	}
 
 	@Nullable
@@ -92,6 +141,7 @@ public class PipelineManager {
 		}
 
 		pipelinesPerDimension.clear();
+		pipelineLastUsedNs.clear();
 		pipeline = null;
 		lastPreparedDimension = null;
 		versionCounterForSodiumShaderReload++;

--- a/shader/src/main/java/net/coderbot/iris/pipeline/PipelineManager.java
+++ b/shader/src/main/java/net/coderbot/iris/pipeline/PipelineManager.java
@@ -32,11 +32,12 @@ public class PipelineManager {
 	}
 
 	public WorldRenderingPipeline preparePipeline(String currentDimension) {
-		// Detect dimension change and do full teardown/recreation
+		// Portal-style mods (e.g. BetterPortals) legitimately render another dimension within the
+		// same frame, so a dimension flip is not necessarily a world-load event: keep every
+		// dimension's pipeline cached and just switch to it. All pipelines are still torn down
+		// together on shaderpack reload / world unload via destroyPipeline().
 		if (lastPreparedDimension != null && !lastPreparedDimension.equals(currentDimension)) {
 			GlFlightRecording.dimensionChange(lastPreparedDimension, currentDimension);
-			Iris.logger.info("Dimension changed from '{}' to '{}', reloading pipeline", lastPreparedDimension, currentDimension);
-			destroyPipeline();
 		}
 		lastPreparedDimension = currentDimension;
 

--- a/src/main/java/com/dhj/actinium/mixin/features/iris/EntityRendererIrisMixin.java
+++ b/src/main/java/com/dhj/actinium/mixin/features/iris/EntityRendererIrisMixin.java
@@ -1,11 +1,14 @@
 package com.dhj.actinium.mixin.features.iris;
 
 import com.dhj.actinium.render.GuiGlStateBoundary;
+import com.dhj.actinium.render.RenderWorldRecursionGuard;
 import com.dhj.actinium.render.RevoScreenEffectsGradient;
 import com.dhj.actinium.render.terrain.ActiniumWorldRenderer;
 import com.gtnewhorizons.angelica.compat.mojang.Camera;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
 import com.gtnewhorizons.angelica.rendering.RenderingState;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import net.coderbot.iris.Iris;
 import net.coderbot.iris.apiimpl.IrisApiV0Impl;
 import net.coderbot.iris.block_rendering.BlockRenderingSettings;
@@ -63,8 +66,24 @@ public abstract class EntityRendererIrisMixin implements IResourceManagerReloadL
     private void addRainParticles() {
     }
 
+    // A truly nested renderWorldPass would observe the swapped Minecraft.world and flip the active
+    // pipeline mid-pass; the guard lets the Iris injections below skip nested passes. BPR-style
+    // sequential portal views are served by PipelineManager's per-dimension cache, not this guard.
+    @WrapMethod(method = "renderWorldPass(IFJ)V")
+    private void actinium$guardRenderWorldPassRecursion(int pass, float partialTicks, long finishTimeNano, Operation<Void> original) {
+        RenderWorldRecursionGuard.enter();
+        try {
+            original.call(pass, partialTicks, finishTimeNano);
+        } finally {
+            RenderWorldRecursionGuard.exit();
+        }
+    }
+
     @Inject(method = "renderWorldPass(IFJ)V", at = @At("HEAD"))
     private void actinium$beginWorldPassTiming(int pass, float partialTicks, long finishTimeNano, CallbackInfo ci) {
+        if (RenderWorldRecursionGuard.isNested()) {
+            return;
+        }
         IrisGlDebug.beginWorldPassTiming(pass);
         if (Iris.shouldActivateWireframe() && this.mc.isSingleplayer()) {
             GL11.glPolygonMode(GL11.GL_FRONT_AND_BACK, GL11.GL_LINE);
@@ -74,6 +93,9 @@ public abstract class EntityRendererIrisMixin implements IResourceManagerReloadL
 
     @Inject(method = "renderWorldPass(IFJ)V", at = @At("RETURN"))
     private void actinium$finishWorldPassTiming(int pass, float partialTicks, long finishTimeNano, CallbackInfo ci) {
+        if (RenderWorldRecursionGuard.isNested()) {
+            return;
+        }
         if (this.actinium$wireframeActive) {
             GL11.glPolygonMode(GL11.GL_FRONT_AND_BACK, GL11.GL_FILL);
             this.actinium$wireframeActive = false;
@@ -86,6 +108,9 @@ public abstract class EntityRendererIrisMixin implements IResourceManagerReloadL
         at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/culling/ClippingHelperImpl;getInstance()Lnet/minecraft/client/renderer/culling/ClippingHelper;", shift = At.Shift.AFTER)
     )
     private void actinium$beginIrisWorld(int pass, float partialTicks, long finishTimeNano, CallbackInfo ci) {
+        if (RenderWorldRecursionGuard.isNested()) {
+            return;
+        }
         if (!Iris.enabled) {
             return;
         }
@@ -117,6 +142,9 @@ public abstract class EntityRendererIrisMixin implements IResourceManagerReloadL
         at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/RenderGlobal;setupTerrain(Lnet/minecraft/entity/Entity;DLnet/minecraft/client/renderer/culling/ICamera;IZ)V", shift = At.Shift.AFTER)
     )
     private void actinium$renderIrisShadows(int pass, float partialTicks, long finishTimeNano, CallbackInfo ci) {
+        if (RenderWorldRecursionGuard.isNested()) {
+            return;
+        }
         if (!Iris.enabled || !IrisApiV0Impl.INSTANCE.isShaderPackInUse()) {
             return;
         }
@@ -138,6 +166,9 @@ public abstract class EntityRendererIrisMixin implements IResourceManagerReloadL
         at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/ActiveRenderInfo;updateRenderInfo(Lnet/minecraft/entity/Entity;Z)V", shift = At.Shift.AFTER)
     )
     private void actinium$captureCameraState(int pass, float partialTicks, long finishTimeNano, CallbackInfo ci) {
+        if (RenderWorldRecursionGuard.isNested()) {
+            return;
+        }
         EntityLivingBase viewEntity = (EntityLivingBase) this.mc.getRenderViewEntity();
         if (viewEntity == null) {
             return;
@@ -525,6 +556,9 @@ public abstract class EntityRendererIrisMixin implements IResourceManagerReloadL
         at = @At(value = "INVOKE", target = "Lnet/minecraftforge/client/ForgeHooksClient;dispatchRenderLast(Lnet/minecraft/client/renderer/RenderGlobal;F)V", remap = false)
     )
     private void actinium$finalizeIrisWorld(int pass, float partialTicks, long finishTimeNano, CallbackInfo ci) {
+        if (RenderWorldRecursionGuard.isNested()) {
+            return;
+        }
         if (!Iris.enabled || !IrisApiV0Impl.INSTANCE.isShaderPackInUse()) {
             return;
         }
@@ -580,6 +614,9 @@ public abstract class EntityRendererIrisMixin implements IResourceManagerReloadL
         at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/RenderGlobal;renderSky(FI)V")
     )
     private void actinium$beginSky(int pass, float partialTicks, long finishTimeNano, CallbackInfo ci) {
+        if (RenderWorldRecursionGuard.isNested()) {
+            return;
+        }
         if (!Iris.enabled) {
             return;
         }
@@ -595,6 +632,9 @@ public abstract class EntityRendererIrisMixin implements IResourceManagerReloadL
         at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/RenderGlobal;renderSky(FI)V", shift = At.Shift.AFTER)
     )
     private void actinium$endSky(int pass, float partialTicks, long finishTimeNano, CallbackInfo ci) {
+        if (RenderWorldRecursionGuard.isNested()) {
+            return;
+        }
         if (!Iris.enabled) {
             return;
         }
@@ -634,6 +674,10 @@ public abstract class EntityRendererIrisMixin implements IResourceManagerReloadL
         at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/EntityRenderer;renderCloudsCheck(Lnet/minecraft/client/renderer/RenderGlobal;FIDDD)V")
     )
     private void actinium$renderClouds(EntityRenderer renderer, RenderGlobal renderGlobal, float partialTicks, int pass, double x, double y, double z) {
+        if (RenderWorldRecursionGuard.isNested()) {
+            this.renderCloudsCheck(renderGlobal, partialTicks, pass, x, y, z);
+            return;
+        }
         if (!Iris.enabled || !IrisApiV0Impl.INSTANCE.isShaderPackInUse()) {
             this.renderCloudsCheck(renderGlobal, partialTicks, pass, x, y, z);
         }
@@ -663,6 +707,10 @@ public abstract class EntityRendererIrisMixin implements IResourceManagerReloadL
         at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/EntityRenderer;renderRainSnow(F)V")
     )
     private void actinium$renderWeather(EntityRenderer renderer, float partialTicks) {
+        if (RenderWorldRecursionGuard.isNested()) {
+            this.renderRainSnow(partialTicks);
+            return;
+        }
         if (!Iris.enabled) {
             this.renderRainSnow(partialTicks);
             return;
@@ -689,6 +737,10 @@ public abstract class EntityRendererIrisMixin implements IResourceManagerReloadL
         at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/RenderGlobal;renderWorldBorder(Lnet/minecraft/entity/Entity;F)V")
     )
     private void actinium$renderWorldBorder(RenderGlobal renderGlobal, net.minecraft.entity.Entity entity, float partialTicks) {
+        if (RenderWorldRecursionGuard.isNested()) {
+            renderGlobal.renderWorldBorder(entity, partialTicks);
+            return;
+        }
         if (!Iris.enabled) {
             renderGlobal.renderWorldBorder(entity, partialTicks);
             return;
@@ -709,6 +761,10 @@ public abstract class EntityRendererIrisMixin implements IResourceManagerReloadL
         at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/debug/DebugRenderer;renderDebug(FJ)V")
     )
     private void actinium$renderDebug(DebugRenderer debugRenderer, float partialTicks, long finishTimeNano) {
+        if (RenderWorldRecursionGuard.isNested()) {
+            debugRenderer.renderDebug(partialTicks, finishTimeNano);
+            return;
+        }
         if (!Iris.enabled) {
             debugRenderer.renderDebug(partialTicks, finishTimeNano);
             return;
@@ -745,6 +801,10 @@ public abstract class EntityRendererIrisMixin implements IResourceManagerReloadL
         at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/RenderGlobal;drawBlockDamageTexture(Lnet/minecraft/client/renderer/Tessellator;Lnet/minecraft/client/renderer/BufferBuilder;Lnet/minecraft/entity/Entity;F)V")
     )
     private void actinium$renderBlockDamage(RenderGlobal renderGlobal, Tessellator tessellator, net.minecraft.client.renderer.BufferBuilder bufferBuilder, net.minecraft.entity.Entity entity, float partialTicks) {
+        if (RenderWorldRecursionGuard.isNested()) {
+            renderGlobal.drawBlockDamageTexture(tessellator, bufferBuilder, entity, partialTicks);
+            return;
+        }
         if (!Iris.enabled) {
             renderGlobal.drawBlockDamageTexture(tessellator, bufferBuilder, entity, partialTicks);
             return;

--- a/src/main/java/com/dhj/actinium/mixin/features/iris/TileEntityEndPortalRendererIrisMixin.java
+++ b/src/main/java/com/dhj/actinium/mixin/features/iris/TileEntityEndPortalRendererIrisMixin.java
@@ -1,5 +1,6 @@
 package com.dhj.actinium.mixin.features.iris;
 
+import com.dhj.actinium.render.EndPortalRenderPolicy;
 import com.dhj.actinium.render.EndPortalRenderer;
 import net.coderbot.iris.debug.IrisGlDebug;
 import net.minecraft.client.renderer.tileentity.TileEntityEndPortalRenderer;
@@ -33,6 +34,11 @@ public abstract class TileEntityEndPortalRendererIrisMixin {
             float alpha,
             CallbackInfo ci
     ) {
+        if (!EndPortalRenderPolicy.shouldUseReplacementRenderer(te)) {
+            // Synthetic render call without a world (e.g. BetterPortals' starfield overlay):
+            // keep the legacy vanilla path so its blend state hooks apply.
+            return;
+        }
         ci.cancel();
 
         if (IrisGlDebug.shouldLogPortalRenderEvents() && actinium$portalLogCount++ < 8) {

--- a/src/main/java/com/dhj/actinium/mixin/features/iris/TileEntityEndPortalRendererIrisMixin.java
+++ b/src/main/java/com/dhj/actinium/mixin/features/iris/TileEntityEndPortalRendererIrisMixin.java
@@ -2,6 +2,7 @@ package com.dhj.actinium.mixin.features.iris;
 
 import com.dhj.actinium.render.EndPortalRenderPolicy;
 import com.dhj.actinium.render.EndPortalRenderer;
+import net.coderbot.iris.apiimpl.IrisApiV0Impl;
 import net.coderbot.iris.debug.IrisGlDebug;
 import net.minecraft.client.renderer.tileentity.TileEntityEndPortalRenderer;
 import net.minecraft.tileentity.TileEntityEndPortal;
@@ -34,9 +35,10 @@ public abstract class TileEntityEndPortalRendererIrisMixin {
             float alpha,
             CallbackInfo ci
     ) {
-        if (!EndPortalRenderPolicy.shouldUseReplacementRenderer(te)) {
-            // Synthetic render call without a world (e.g. BetterPortals' starfield overlay):
-            // keep the legacy vanilla path so its blend state hooks apply.
+        if (!EndPortalRenderPolicy.shouldUseReplacementRenderer(te, IrisApiV0Impl.INSTANCE.isShaderPackInUse())) {
+            // Synthetic render call without a world (e.g. BetterPortals' starfield overlay)
+            // while no shader pack is active: keep the legacy vanilla path so its blend
+            // state hooks apply through the glsm fixed-function simulation.
             return;
         }
         ci.cancel();

--- a/src/main/java/com/dhj/actinium/mixin/mod/extrautils2/MixinXUBlockStaticLazyQuads.java
+++ b/src/main/java/com/dhj/actinium/mixin/mod/extrautils2/MixinXUBlockStaticLazyQuads.java
@@ -1,0 +1,48 @@
+package com.dhj.actinium.mixin.mod.extrautils2;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.HashMap;
+import java.util.function.Function;
+
+/**
+ * Fixes the ConcurrentModificationException crash while building chunk meshes for Extra
+ * Utilities 2 blocks (e.g. an ender lilly) under Actinium.
+ *
+ * <p>{@code XUBlockStatic$3} (the baked model wrapper each block state gets) bakes its quad lists
+ * lazily inside plain {@code HashMap}s ({@code cachedLists} plus the per-facing maps nested inside
+ * it) via {@code computeIfAbsent}. The mapping function is expensive (it rebuilds a
+ * {@code MutableModel}), so the window in which two threads race inside the map is real. Vanilla
+ * only ever calls {@code IBakedModel#getQuads} from the single chunk rebuild worker, but Actinium
+ * builds chunk meshes on several worker threads and portal view passes can rebuild the same
+ * section again while the main pass is still building it, so two threads can enter
+ * {@code getQuads} for the same block state at once and corrupt the map.</p>
+ *
+ * <p>Both {@code computeIfAbsent} call sites in {@code getQuads} are redirected to serialize on
+ * the receiver map's own monitor: every level of the cache is then only ever read or mutated
+ * while holding its own lock, which keeps first-bake results consistent (and deduplicated) without
+ * changing the returned quads. The nested maps are created while the outer lock is held, so a
+ * freshly-created inner map cannot be observed unsynchronized.</p>
+ *
+ * <p>The mixin keeps remapping enabled: the target class is an Extra Utilities 2 class, but
+ * {@code getQuads} implements Minecraft's {@code IBakedModel} interface, so its name is the
+ * searge {@code func_188616_a} in the production jar and must go through the refmap.</p>
+ */
+@Mixin(targets = "com.rwtema.extrautils2.backend.XUBlockStatic$3")
+public abstract class MixinXUBlockStaticLazyQuads {
+
+    @Redirect(
+            method = "getQuads",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Ljava/util/HashMap;computeIfAbsent(Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;"),
+            require = 2)
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private Object celeritas$synchronizedComputeIfAbsent(HashMap map, Object key, Function mappingFunction) {
+        synchronized (map) {
+            return map.computeIfAbsent(key, mappingFunction);
+        }
+    }
+}

--- a/src/main/java/com/dhj/actinium/render/EndPortalRenderPolicy.java
+++ b/src/main/java/com/dhj/actinium/render/EndPortalRenderPolicy.java
@@ -1,0 +1,27 @@
+package com.dhj.actinium.render;
+
+import net.minecraft.tileentity.TileEntityEndPortal;
+
+/**
+ * Decides whether a TileEntityEndPortalRenderer render call is answered by the core-profile
+ * replacement renderer or left on the legacy vanilla path (executed through the glsm
+ * fixed-function simulation).
+ */
+public final class EndPortalRenderPolicy {
+    private EndPortalRenderPolicy() {
+    }
+
+    /**
+     * The dispatcher only renders block entities that belong to a world. A world-less block
+     * entity is a synthetic render call issued by another renderer — e.g. BetterPortals draws
+     * its starfield overlay through a dummy block entity and relies on the exact legacy blend
+     * state hooks (CONSTANT_ALPHA via shouldRenderFace) and projective texgen behavior, which
+     * the replacement renderer does not reproduce.
+     *
+     * @param portal block entity passed to the renderer
+     * @return true to use the core-profile replacement renderer; false to keep the legacy path
+     */
+    public static boolean shouldUseReplacementRenderer(TileEntityEndPortal portal) {
+        return portal.getWorld() != null;
+    }
+}

--- a/src/main/java/com/dhj/actinium/render/EndPortalRenderPolicy.java
+++ b/src/main/java/com/dhj/actinium/render/EndPortalRenderPolicy.java
@@ -1,6 +1,7 @@
 package com.dhj.actinium.render;
 
 import net.minecraft.tileentity.TileEntityEndPortal;
+import org.lwjgl.opengl.GL14;
 
 /**
  * Decides whether a TileEntityEndPortalRenderer render call is answered by the core-profile
@@ -15,13 +16,33 @@ public final class EndPortalRenderPolicy {
      * The dispatcher only renders block entities that belong to a world. A world-less block
      * entity is a synthetic render call issued by another renderer — e.g. BetterPortals draws
      * its starfield overlay through a dummy block entity and relies on the exact legacy blend
-     * state hooks (CONSTANT_ALPHA via shouldRenderFace) and projective texgen behavior, which
-     * the replacement renderer does not reproduce.
+     * state hooks (CONSTANT_ALPHA via shouldRenderFace) and projective texgen behavior.
+     *
+     * <p>Without a shader pack those synthetic calls keep the legacy vanilla path, which the
+     * glsm fixed-function simulation services faithfully. With a shader pack the legacy path
+     * can never execute: an Iris gbuffers program owns the draw and glsm defers to it, so the
+     * projective texgen emulation is silently bypassed and the overlay degrades to garbage.
+     * Synthetic calls therefore go through the shader-compatible replacement renderer, which
+     * reproduces the fade hook via {@link #isLegacyFadeHookBlend(int, int)}.
      *
      * @param portal block entity passed to the renderer
+     * @param shaderPackInUse whether an Iris shader pack currently owns world rendering
      * @return true to use the core-profile replacement renderer; false to keep the legacy path
      */
-    public static boolean shouldUseReplacementRenderer(TileEntityEndPortal portal) {
-        return portal.getWorld() != null;
+    public static boolean shouldUseReplacementRenderer(TileEntityEndPortal portal, boolean shaderPackInUse) {
+        return portal.getWorld() != null || shaderPackInUse;
+    }
+
+    /**
+     * Recognizes the legacy fade hook that synthetic overlay renderers (BetterPortals) fire from
+     * a shouldRenderFace override: the first-layer blend factors are switched to
+     * CONSTANT_ALPHA/ONE_MINUS_CONSTANT_ALPHA and the constant alpha carries the overlay opacity.
+     *
+     * @param srcRgb tracked source RGB blend factor observed after face evaluation
+     * @param dstRgb tracked destination RGB blend factor observed after face evaluation
+     * @return true when the blend factors can only come from the overlay fade hook
+     */
+    public static boolean isLegacyFadeHookBlend(int srcRgb, int dstRgb) {
+        return srcRgb == GL14.GL_CONSTANT_ALPHA && dstRgb == GL14.GL_ONE_MINUS_CONSTANT_ALPHA;
     }
 }

--- a/src/main/java/com/dhj/actinium/render/EndPortalRenderer.java
+++ b/src/main/java/com/dhj/actinium/render/EndPortalRenderer.java
@@ -1,6 +1,7 @@
 package com.dhj.actinium.render;
 
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
+import com.gtnewhorizons.angelica.glsm.backend.BackendManager;
 import com.gtnewhorizons.angelica.glsm.states.BlendState;
 import net.coderbot.iris.apiimpl.IrisApiV0Impl;
 import net.minecraft.client.Minecraft;
@@ -14,9 +15,12 @@ import net.minecraft.util.ResourceLocation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.joml.Matrix4f;
+import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL13;
+import org.lwjgl.opengl.GL14;
 
+import java.nio.FloatBuffer;
 import java.util.List;
 
 /**
@@ -59,6 +63,11 @@ public final class EndPortalRenderer {
         float vanillaAnimationTime = (float) (Minecraft.getSystemTime() % 800000L) / 800000.0F;
         List<EndPortalLayers.Layer> layers = EndPortalLayers.create(vanillaLayerCount, vanillaAnimationTime);
         boolean shaderPackInUse = IrisApiV0Impl.INSTANCE.isShaderPackInUse();
+        // Synthetic overlay calls (world-less dummy block entity, e.g. BetterPortals' starfield
+        // overlay) fire their fade hook from shouldRenderFace during face evaluation; snapshot
+        // the pre-hook blend state so the hook cannot leak past this render call.
+        boolean syntheticOverlay = shaderPackInUse && portal.getWorld() == null;
+        BlendState preHookBlend = syntheticOverlay ? GLStateManager.getBlendState().copy() : null;
         EndPortalProjection projection;
         List<EndPortalMesh.FaceQuad> faces;
         List<EndPortalMesh.Triangle> shaderTriangles;
@@ -73,6 +82,21 @@ public final class EndPortalRenderer {
         } catch (IllegalArgumentException exception) {
             LOGGER.error("Invalid active matrix while building end portal geometry at {}", portal.getPos(), exception);
             return;
+        }
+
+        // The overlay fade hook (CONSTANT_ALPHA blend factors + constant alpha = opacity) is
+        // reproduced by folding its opacity into the first (sky) layer's vertex alpha, which is
+        // the exact SRC_ALPHA equivalent, and by keeping the per-layer path so the additive
+        // layers stay at full strength. The blend color is set through a raw GL14.glBlendColor
+        // call that bypasses glsm tracking, so it must be read back from the real GL state.
+        float layerZeroAlpha = 1.0F;
+        boolean fadeHook = false;
+        if (syntheticOverlay) {
+            BlendState hookBlend = GLStateManager.getBlendState();
+            if (EndPortalRenderPolicy.isLegacyFadeHookBlend(hookBlend.getSrcRgb(), hookBlend.getDstRgb())) {
+                fadeHook = true;
+                layerZeroAlpha = readBlendColorAlpha();
+            }
         }
 
         int activeTexture = GLStateManager.getActiveTextureUnit();
@@ -93,7 +117,7 @@ public final class EndPortalRenderer {
             GLStateManager.disableLighting();
 
             boolean precomposed = false;
-            if (EndPortalCompositeLogic.shouldPrecompose(shaderPackInUse, layers.size())) {
+            if (!fadeHook && EndPortalCompositeLogic.shouldPrecompose(shaderPackInUse, layers.size())) {
                 int compositeTexture = EndPortalCompositeRenderer.texture(layers);
                 if (compositeTexture != 0) {
                     GLStateManager.glBindTexture(GL11.GL_TEXTURE_2D, compositeTexture);
@@ -107,21 +131,22 @@ public final class EndPortalRenderer {
                 EndPortalLayers.Layer skyLayer = layers.getFirst();
                 bindTexture(skyLayer.texture());
                 applyBlend(skyLayer.blend());
-                drawLayers(x, y, z, layers, 0, 1, shaderPackInUse, faces, shaderTriangles, projection);
+                drawLayers(x, y, z, layers, 0, 1, layerZeroAlpha, shaderPackInUse, faces, shaderTriangles, projection);
 
                 if (layers.size() > 1) {
                     EndPortalLayers.Layer portalLayer = layers.get(1);
                     bindTexture(portalLayer.texture());
                     applyBlend(portalLayer.blend());
-                    drawLayers(x, y, z, layers, 1, layers.size(), shaderPackInUse, faces, shaderTriangles, projection);
+                    drawLayers(x, y, z, layers, 1, layers.size(), 1.0F, shaderPackInUse, faces, shaderTriangles, projection);
                 }
             }
         } finally {
+            BlendState blendToRestore = preHookBlend != null ? preHookBlend : previousBlend;
             GLStateManager.glBlendFuncSeparate(
-                previousBlend.getSrcRgb(),
-                previousBlend.getDstRgb(),
-                previousBlend.getSrcAlpha(),
-                previousBlend.getDstAlpha()
+                blendToRestore.getSrcRgb(),
+                blendToRestore.getDstRgb(),
+                blendToRestore.getSrcAlpha(),
+                blendToRestore.getDstAlpha()
             );
             if (blendEnabled) {
                 GLStateManager.enableBlend();
@@ -152,6 +177,16 @@ public final class EndPortalRenderer {
         Minecraft.getMinecraft().getTextureManager().bindTexture(location);
     }
 
+    /**
+     * Reads the constant blend color alpha from the real GL state. The overlay fade hook sets it
+     * through a raw GL14.glBlendColor call, so the glsm-tracked blend color never observes it.
+     */
+    private static float readBlendColorAlpha() {
+        FloatBuffer blendColor = BufferUtils.createFloatBuffer(4);
+        BackendManager.RENDER_BACKEND.getFloat(GL14.GL_BLEND_COLOR, blendColor);
+        return blendColor.get(3);
+    }
+
     private static void applyBlend(EndPortalLayers.Blend blend) {
         switch (blend) {
             case ALPHA -> {
@@ -172,6 +207,7 @@ public final class EndPortalRenderer {
         List<EndPortalLayers.Layer> layers,
         int fromIndex,
         int toIndex,
+        float layerAlpha,
         boolean shaderPackInUse,
         List<EndPortalMesh.FaceQuad> faces,
         List<EndPortalMesh.Triangle> shaderTriangles,
@@ -193,7 +229,7 @@ public final class EndPortalRenderer {
                     z,
                     (face, vertexX, vertexY, vertexZ, u, v, red, green, blue, alpha, lightU, lightV, normalX, normalY, normalZ) ->
                         buffer.pos(vertexX, vertexY, vertexZ)
-                            .color(red, green, blue, alpha)
+                            .color(red, green, blue, alpha * layerAlpha)
                             .tex(u, v)
                             .lightmap(lightU, lightV)
                             .normal(normalX, normalY, normalZ)

--- a/src/main/java/com/dhj/actinium/render/RenderWorldRecursionGuard.java
+++ b/src/main/java/com/dhj/actinium/render/RenderWorldRecursionGuard.java
@@ -1,0 +1,48 @@
+package com.dhj.actinium.render;
+
+/**
+ * Counts nested {@code EntityRenderer.renderWorldPass} invocations on the render thread.
+ *
+ * <p>The Iris integration in {@code EntityRendererIrisMixin} may only run on the outermost pass: a
+ * nested pass would observe a swapped {@code Minecraft.world} and switch the active pipeline
+ * mid-pass, corrupting the outer pass that is still rendering. BetterPortals Refitted renders
+ * portal views as <b>sequential sibling</b> {@code renderWorld} calls (never nested) and is served
+ * by {@code PipelineManager}'s per-dimension pipeline cache instead; this guard is the defensive
+ * net for mods that truly recurse {@code renderWorldPass}.
+ *
+ * <p>Minecraft renders on a single thread, so a plain counter is sufficient.
+ */
+public final class RenderWorldRecursionGuard {
+    private static int depth;
+
+    private RenderWorldRecursionGuard() {
+    }
+
+    /**
+     * Marks the start of one {@code renderWorldPass} invocation. Must be balanced by {@link #exit()},
+     * even when the pass throws.
+     */
+    public static void enter() {
+        depth++;
+    }
+
+    /**
+     * Marks the end of one {@code renderWorldPass} invocation.
+     *
+     * @throws IllegalStateException when no invocation is on the stack (unbalanced enter/exit)
+     */
+    public static void exit() {
+        if (depth == 0) {
+            throw new IllegalStateException("renderWorldPass exit without a matching enter");
+        }
+        depth--;
+    }
+
+    /**
+     * Returns whether the current pass runs nested inside another {@code renderWorldPass}. The
+     * outermost pass runs at depth 1 and is not considered nested.
+     */
+    public static boolean isNested() {
+        return depth > 1;
+    }
+}

--- a/src/main/resources/mixins.actinium.extrautils2.json
+++ b/src/main/resources/mixins.actinium.extrautils2.json
@@ -9,7 +9,8 @@
   "server": [],
   "client": [
     "BooleanStateCapAccessor",
-    "MixinGLStateAttributes"
+    "MixinGLStateAttributes",
+    "MixinXUBlockStaticLazyQuads"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/test/java/com/dhj/actinium/render/EndPortalRenderPolicyTest.java
+++ b/src/test/java/com/dhj/actinium/render/EndPortalRenderPolicyTest.java
@@ -1,0 +1,16 @@
+package com.dhj.actinium.render;
+
+import net.minecraft.tileentity.TileEntityEndPortal;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class EndPortalRenderPolicyTest {
+
+    @Test
+    void worldLessBlockEntityKeepsLegacyVanillaPath() {
+        // Synthetic render calls (e.g. BetterPortals' starfield overlay) use a dummy block
+        // entity that never joined a world; the replacement renderer must not hijack them.
+        assertFalse(EndPortalRenderPolicy.shouldUseReplacementRenderer(new TileEntityEndPortal()));
+    }
+}

--- a/src/test/java/com/dhj/actinium/render/EndPortalRenderPolicyTest.java
+++ b/src/test/java/com/dhj/actinium/render/EndPortalRenderPolicyTest.java
@@ -2,15 +2,36 @@ package com.dhj.actinium.render;
 
 import net.minecraft.tileentity.TileEntityEndPortal;
 import org.junit.jupiter.api.Test;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL14;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EndPortalRenderPolicyTest {
 
     @Test
-    void worldLessBlockEntityKeepsLegacyVanillaPath() {
+    void worldLessBlockEntityKeepsLegacyVanillaPathWithoutShaderPack() {
         // Synthetic render calls (e.g. BetterPortals' starfield overlay) use a dummy block
-        // entity that never joined a world; the replacement renderer must not hijack them.
-        assertFalse(EndPortalRenderPolicy.shouldUseReplacementRenderer(new TileEntityEndPortal()));
+        // entity that never joined a world; without a shader pack the replacement renderer
+        // must not hijack them, so the legacy blend state hooks keep applying through glsm.
+        assertFalse(EndPortalRenderPolicy.shouldUseReplacementRenderer(new TileEntityEndPortal(), false));
+    }
+
+    @Test
+    void worldLessBlockEntityUsesReplacementUnderShaderPack() {
+        // Under a shader pack an Iris gbuffers program owns the draw and glsm defers to it,
+        // so the legacy projective texgen path can never execute; synthetic overlay calls go
+        // through the shader-compatible replacement renderer instead.
+        assertTrue(EndPortalRenderPolicy.shouldUseReplacementRenderer(new TileEntityEndPortal(), true));
+    }
+
+    @Test
+    void recognizesLegacyFadeHookBlendFactors() {
+        assertTrue(EndPortalRenderPolicy.isLegacyFadeHookBlend(
+            GL14.GL_CONSTANT_ALPHA, GL14.GL_ONE_MINUS_CONSTANT_ALPHA));
+        assertFalse(EndPortalRenderPolicy.isLegacyFadeHookBlend(
+            GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA));
+        assertFalse(EndPortalRenderPolicy.isLegacyFadeHookBlend(GL11.GL_ONE, GL11.GL_ONE));
     }
 }

--- a/src/test/java/com/dhj/actinium/render/RenderWorldRecursionGuardTest.java
+++ b/src/test/java/com/dhj/actinium/render/RenderWorldRecursionGuardTest.java
@@ -1,0 +1,76 @@
+package com.dhj.actinium.render;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RenderWorldRecursionGuardTest {
+    @AfterEach
+    void verifyGuardIsBalanced() {
+        // A leaked enter() would let this exit() succeed; the guard must be back at zero depth.
+        assertThrows(IllegalStateException.class, RenderWorldRecursionGuard::exit);
+    }
+
+    @Test
+    void startsNotNested() {
+        assertFalse(RenderWorldRecursionGuard.isNested());
+    }
+
+    @Test
+    void outermostPassIsNotNested() {
+        RenderWorldRecursionGuard.enter();
+        try {
+            assertFalse(RenderWorldRecursionGuard.isNested());
+        } finally {
+            RenderWorldRecursionGuard.exit();
+        }
+    }
+
+    @Test
+    void nestedPassIsDetectedUntilItExits() {
+        RenderWorldRecursionGuard.enter();
+        try {
+            RenderWorldRecursionGuard.enter();
+            try {
+                assertTrue(RenderWorldRecursionGuard.isNested());
+            } finally {
+                RenderWorldRecursionGuard.exit();
+            }
+            assertFalse(RenderWorldRecursionGuard.isNested());
+        } finally {
+            RenderWorldRecursionGuard.exit();
+        }
+    }
+
+    @Test
+    void exitWithoutMatchingEnterFails() {
+        assertThrows(IllegalStateException.class, RenderWorldRecursionGuard::exit);
+    }
+
+    @Test
+    void exceptionInNestedPassLeavesNoLeakedDepth() {
+        RuntimeException failure = new RuntimeException("nested pass failed");
+
+        RuntimeException thrown = assertThrows(RuntimeException.class, () -> {
+            RenderWorldRecursionGuard.enter();
+            try {
+                RenderWorldRecursionGuard.enter();
+                try {
+                    throw failure;
+                } finally {
+                    RenderWorldRecursionGuard.exit();
+                }
+            } finally {
+                RenderWorldRecursionGuard.exit();
+            }
+        });
+
+        assertSame(failure, thrown);
+        assertFalse(RenderWorldRecursionGuard.isNested());
+        assertThrows(IllegalStateException.class, RenderWorldRecursionGuard::exit);
+    }
+}

--- a/src/test/java/com/gtnewhorizons/angelica/glsm/CompatShaderTransformerTest.java
+++ b/src/test/java/com/gtnewhorizons/angelica/glsm/CompatShaderTransformerTest.java
@@ -6,7 +6,11 @@ import org.junit.jupiter.api.Test;
 import org.taumc.glsl.ShaderParser;
 import org.taumc.glsl.grammar.GLSLLexer;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CompatShaderTransformerTest {
@@ -101,7 +105,7 @@ class CompatShaderTransformerTest {
     }
 
     @Test
-    void conditionalGlslRemainsBetweenItsDirectives() {
+    void conditionalGlslSelectsTheTakenBranchUnderEvaluation() {
         String source = """
             #ifdef USE_PORTAL_COLOR
             varying vec4 portalColor;
@@ -110,22 +114,18 @@ class CompatShaderTransformerTest {
             #endif
 
             void main() {
-                gl_FragColor = portalColor;
+                gl_FragColor = fallbackColor;
             }
             """;
 
         String transformed = CompatShaderTransformer.transform(source, true);
 
-        assertEquals("#version 330 core\n" + source, transformed);
-        assertOrdered(
-            transformed,
-            "#ifdef USE_PORTAL_COLOR",
-            "varying vec4 portalColor",
-            "#else",
-            "varying vec4 fallbackColor",
-            "#endif",
-            "void main"
-        );
+        // USE_PORTAL_COLOR is undefined, so the #else branch is kept (and transformed) while the
+        // dead branch is dropped; previously this shader fell back to version-fixup-only output
+        // that could not compile under core profile.
+        assertFalse(transformed.contains("portalColor"), transformed);
+        assertTrue(transformed.contains("fallbackColor"), transformed);
+        assertTrue(transformed.contains("actinium_FragData0"), transformed);
     }
 
     @Test
@@ -204,6 +204,60 @@ class CompatShaderTransformerTest {
             "((color) * 0.5)",
             "void main"
         );
+    }
+
+    @Test
+    void betterPortalsPortalVertexShaderTransformsToCoreProfile() {
+        String transformed = CompatShaderTransformer.transform(
+            resource("/compat_shaders/betterportals_render_portal.vsh"), false);
+
+        // The taken desktop branch's FFP builtins are replaced by Actinium uniforms/attributes.
+        assertTrue(hasIdentifier(transformed, "actinium_ModelViewMatrix"), transformed);
+        assertTrue(hasIdentifier(transformed, "actinium_ProjectionMatrix"), transformed);
+        assertTrue(hasIdentifier(transformed, "actinium_Vertex"), transformed);
+        assertTrue(hasIdentifier(transformed, "actinium_FogFragCoord"), transformed);
+        assertFalse(hasIdentifier(transformed, "gl_ModelViewMatrix"), transformed);
+        assertFalse(hasIdentifier(transformed, "gl_Vertex"), transformed);
+
+        // The GLES-only branch is dropped: no explicit ESSL attribute/uniform path may leak in.
+        assertFalse(hasIdentifier(transformed, "bpModelViewMatrix"), transformed);
+        assertFalse(hasIdentifier(transformed, "Position"), transformed);
+
+        // BP_SKIP_FIXED_CLIP resolves to 1 at the target version, so the gl_ClipVertex assignment
+        // (which has no core-profile equivalent) is excluded by the shader's own guard.
+        assertFalse(hasIdentifier(transformed, "gl_ClipVertex"), transformed);
+    }
+
+    @Test
+    void betterPortalsPortalFragmentShaderTransformsToCoreProfile() {
+        String transformed = CompatShaderTransformer.transform(
+            resource("/compat_shaders/betterportals_render_portal.fsh"), true);
+
+        assertFalse(hasIdentifier(transformed, "gl_FogFragCoord"), transformed);
+        assertFalse(hasIdentifier(transformed, "bpFogFragCoord"), transformed);
+        assertFalse(hasIdentifier(transformed, "texture2D"), transformed);
+    }
+
+    /** Identifier-level check: comments preserved in the preamble must not trip the assertions. */
+    private static boolean hasIdentifier(String source, String name) {
+        GLSLLexer lexer = new GLSLLexer(CharStreams.fromString(source));
+        for (Token token = lexer.nextToken(); token.getType() != Token.EOF; token = lexer.nextToken()) {
+            if (token.getType() == GLSLLexer.IDENTIFIER && name.equals(token.getText())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String resource(String name) {
+        try (var stream = CompatShaderTransformerTest.class.getResourceAsStream(name)) {
+            if (stream == null) {
+                throw new IllegalStateException("Missing test resource: " + name);
+            }
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read test resource: " + name, e);
+        }
     }
 
     private static int countTokens(String source, int tokenType) {

--- a/src/test/java/com/gtnewhorizons/angelica/glsm/CompatShaderTransformerTest.java
+++ b/src/test/java/com/gtnewhorizons/angelica/glsm/CompatShaderTransformerTest.java
@@ -236,6 +236,18 @@ class CompatShaderTransformerTest {
         assertFalse(hasIdentifier(transformed, "gl_FogFragCoord"), transformed);
         assertFalse(hasIdentifier(transformed, "bpFogFragCoord"), transformed);
         assertFalse(hasIdentifier(transformed, "texture2D"), transformed);
+
+        // Forge's ShaderManager resolves these uniforms by name at runtime; dropping or
+        // renaming any of them silently breaks the portal surface (a missing "sampler"
+        // uniform left the remote view unsampled in production).
+        assertTrue(hasIdentifier(transformed, "sampler"), transformed);
+        assertTrue(hasIdentifier(transformed, "screenSize"), transformed);
+        assertTrue(hasIdentifier(transformed, "fogDensity"), transformed);
+        assertTrue(hasIdentifier(transformed, "fogColor"), transformed);
+        assertTrue(hasIdentifier(transformed, "opacity"), transformed);
+        // The declaration alone is not enough: the sampler must stay in use inside main,
+        // otherwise the compiler deactivates the uniform and the runtime lookup fails.
+        assertOrdered(transformed, "uniform sampler2D sampler", "void main", "sampler");
     }
 
     /** Identifier-level check: comments preserved in the preamble must not trip the assertions. */

--- a/src/test/java/com/gtnewhorizons/angelica/glsm/ffp/VertexShaderGeneratorTest.java
+++ b/src/test/java/com/gtnewhorizons/angelica/glsm/ffp/VertexShaderGeneratorTest.java
@@ -12,9 +12,15 @@ import org.taumc.glsl.grammar.GLSLParserBaseListener;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class VertexShaderGeneratorTest {
     private static final int BIT_HAS_VERTEX_TEX = 17;
+    private static final int BIT_TEXTURE = 12;
+    private static final int BIT_TEX_MATRIX = 14;
+    private static final int BIT_TEXGEN_S = 22;
+    private static final int BIT_TEXGEN_T = 25;
+    private static final int BIT_TEXGEN_R = 28;
 
     @Test
     void primaryTextureAttributeAcceptsCompleteHomogeneousCoordinates() {
@@ -57,6 +63,62 @@ class VertexShaderGeneratorTest {
 
             assignments++;
             source = context.assignment_expression().getText();
+        }
+    }
+
+    @Test
+    void eyeLinearTexGenFeedsEveryPlaneFromSingleConstructor() {
+        final long packed = (1L << BIT_TEXTURE) | (1L << BIT_TEX_MATRIX)
+            | ((long) VertexKey.TG_EYE_LINEAR << BIT_TEXGEN_S)
+            | ((long) VertexKey.TG_EYE_LINEAR << BIT_TEXGEN_T)
+            | ((long) VertexKey.TG_EYE_LINEAR << BIT_TEXGEN_R);
+        final String shader = VertexShaderGenerator.generate(VertexKey.fromPacked(packed));
+        final Transformer transformer = new Transformer(ShaderParser.parseShader(shader).full());
+        final Map<String, GLSLParser.Single_declarationContext> uniforms = transformer.findQualifiers(GLSLLexer.UNIFORM);
+        final TexGenInitListener texGen = inspectTexGenInit(transformer);
+
+        assertEquals("vec4", typeOf(uniforms.get("u_TexGenEyePlaneS")));
+        assertEquals("vec4", typeOf(uniforms.get("u_TexGenEyePlaneT")));
+        assertEquals("vec4", typeOf(uniforms.get("u_TexGenEyePlaneR")));
+
+        // Every eye plane must be consumed by the single vec4 constructor. The previous
+        // per-component writes to a pre-initialized texGenCoord let NVIDIA's driver
+        // dead-code-eliminate u_TexGenEyePlaneS, collapsing BPR's end-portal starfield
+        // into stripes.
+        assertEquals(0, texGen.componentWrites);
+        assertEquals(1, texGen.initializers);
+        assertTrue(texGen.initializer.startsWith("vec4("));
+        assertTrue(texGen.initializer.contains("dot(eyePos,u_TexGenEyePlaneS)"));
+        assertTrue(texGen.initializer.contains("dot(eyePos,u_TexGenEyePlaneT)"));
+        assertTrue(texGen.initializer.contains("dot(eyePos,u_TexGenEyePlaneR)"));
+    }
+
+    private static TexGenInitListener inspectTexGenInit(Transformer transformer) {
+        TexGenInitListener listener = new TexGenInitListener();
+        transformer.mutateTree(tree -> ParseTreeWalker.DEFAULT.walk(listener, tree));
+        return listener;
+    }
+
+    private static final class TexGenInitListener extends GLSLParserBaseListener {
+        private int componentWrites;
+        private int initializers;
+        private String initializer = "";
+
+        @Override
+        public void enterAssignment_expression(GLSLParser.Assignment_expressionContext context) {
+            if (context.assignment_operator() != null && context.unary_expression().getText().startsWith("texGenCoord.")) {
+                componentWrites++;
+            }
+        }
+
+        @Override
+        public void enterSingle_declaration(GLSLParser.Single_declarationContext context) {
+            final GLSLParser.Typeless_declarationContext decl = context.typeless_declaration();
+            if (decl != null && decl.IDENTIFIER() != null && "texGenCoord".equals(decl.IDENTIFIER().getText())
+                && decl.initializer() != null) {
+                initializers++;
+                initializer = decl.initializer().getText();
+            }
         }
     }
 }

--- a/src/test/java/com/gtnewhorizons/angelica/glsm/states/VertexAttribStateTest.java
+++ b/src/test/java/com/gtnewhorizons/angelica/glsm/states/VertexAttribStateTest.java
@@ -1,0 +1,89 @@
+package com.gtnewhorizons.angelica.glsm.states;
+
+import com.gtnewhorizon.gtnhlib.client.renderer.vertex.VertexFlags;
+import com.gtnewhorizon.gtnhlib.client.renderer.vertex.VertexFormatElement.Usage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.lwjgl.opengl.GL11;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the vertex-format flags derived for draws fed by client-side arrays
+ * (the legacy immediate-mode path, e.g. the vanilla end portal TESR). Those draws must
+ * follow the actually enabled attributes rather than any cached format-based flag set, or
+ * the FFP shader reads attributes the draw does not provide (a POSITION-only draw misread
+ * as having vertex color renders with the black default attribute value).
+ */
+class VertexAttribStateTest {
+
+    private static final ByteBuffer VERTEX_DATA = ByteBuffer.allocate(256);
+
+    @BeforeEach
+    void resetState() {
+        VertexAttribState.init(0);
+    }
+
+    private static void enableClientArray(Usage usage) {
+        final int location = usage.getAttributeLocation();
+        VertexAttribState.set(location, 3, GL11.GL_FLOAT, false, 12, VERTEX_DATA, 0);
+        VertexAttribState.setEnabled(location, true);
+    }
+
+    @Test
+    void positionOnlyDrawYieldsNoFormatFlags() {
+        enableClientArray(Usage.POSITION);
+
+        assertTrue(VertexAttribState.hasAnyClientSideEnabledAttrib());
+        assertEquals(0, VertexAttribState.currentClientArrayVertexFlags());
+    }
+
+    @Test
+    void enabledAttributesContributeTheirFlag() {
+        enableClientArray(Usage.POSITION);
+        enableClientArray(Usage.COLOR);
+        enableClientArray(Usage.NORMAL);
+        enableClientArray(Usage.PRIMARY_UV);
+        enableClientArray(Usage.SECONDARY_UV);
+
+        assertEquals(
+            VertexFlags.COLOR_BIT | VertexFlags.NORMAL_BIT | VertexFlags.TEXTURE_BIT | VertexFlags.BRIGHTNESS_BIT,
+            VertexAttribState.currentClientArrayVertexFlags());
+    }
+
+    @Test
+    void disabledAttributeContributesNothing() {
+        enableClientArray(Usage.POSITION);
+        enableClientArray(Usage.COLOR);
+        VertexAttribState.setEnabled(Usage.COLOR.getAttributeLocation(), false);
+
+        assertEquals(0, VertexAttribState.currentClientArrayVertexFlags());
+    }
+
+    @Test
+    void vboBackedAttributeStillCountsAsProvidedData() {
+        enableClientArray(Usage.POSITION);
+        final int colorLocation = Usage.COLOR.getAttributeLocation();
+        VertexAttribState.set(colorLocation, 4, GL11.GL_UNSIGNED_BYTE, true, 16, 0L, 7);
+        VertexAttribState.setEnabled(colorLocation, true);
+
+        assertEquals(VertexFlags.COLOR_BIT, VertexAttribState.currentClientArrayVertexFlags());
+    }
+
+    @Test
+    void clientSideDetectionRequiresAClientPointer() {
+        enableClientArray(Usage.POSITION);
+        assertTrue(VertexAttribState.hasAnyClientSideEnabledAttrib());
+
+        VertexAttribState.setEnabled(Usage.POSITION.getAttributeLocation(), false);
+        assertFalse(VertexAttribState.hasAnyClientSideEnabledAttrib());
+
+        enableClientArray(Usage.POSITION);
+        VertexAttribState.set(Usage.POSITION.getAttributeLocation(), 3, GL11.GL_FLOAT, false, 12, 0L, 3);
+        assertFalse(VertexAttribState.hasAnyClientSideEnabledAttrib());
+    }
+}

--- a/src/test/resources/compat_shaders/betterportals_render_portal.fsh
+++ b/src/test/resources/compat_shaders/betterportals_render_portal.fsh
@@ -1,0 +1,51 @@
+// Native ESSL has no fixed-function fog interface.  MobileGlues and SFPEW
+// translate the legacy gl_Fog/gl_FogFragCoord symbols, while a direct ESSL
+// context receives equivalent values through explicit uniforms.
+#ifdef GL_ES
+#define BP_GL_ES 1
+#else
+#define BP_GL_ES 0
+#endif
+#ifdef MG_MOBILEGLUES
+#define BP_MOBILEGLUES 1
+#else
+#define BP_MOBILEGLUES 0
+#endif
+
+#if BP_GL_ES && !BP_MOBILEGLUES
+#define BP_NATIVE_ES 1
+#else
+#define BP_NATIVE_ES 0
+#endif
+
+#if BP_NATIVE_ES
+precision mediump float;
+precision mediump sampler2D;
+uniform vec3 bpWorldFogColor;
+uniform float bpFogStart;
+uniform float bpFogScale;
+varying mediump float bpFogFragCoord;
+#endif
+
+uniform sampler2D sampler;
+uniform vec2 screenSize;
+uniform float fogDensity;
+uniform vec3 fogColor;
+uniform float opacity;
+
+void main() {
+    vec2 uv = gl_FragCoord.xy / screenSize;
+    vec3 color = texture2D(sampler, uv).rgb;
+#if BP_NATIVE_ES
+    color = mix(color, bpWorldFogColor,
+            clamp((bpFogFragCoord - bpFogStart) * bpFogScale, 0.0, 1.0));
+#else
+    color = mix(color, gl_Fog.color.rgb,
+            clamp((gl_FogFragCoord - gl_Fog.start) * gl_Fog.scale, 0.0, 1.0));
+#endif
+    color = mix(color, fogColor, fogDensity);
+    // Fade the remote view out by fading its alpha so the background shows
+    // through instead of the view darkening to black.  Explicit depth writes
+    // are unnecessary: the default fragment depth is gl_FragCoord.z.
+    gl_FragColor = vec4(color, opacity);
+}

--- a/src/test/resources/compat_shaders/betterportals_render_portal.vsh
+++ b/src/test/resources/compat_shaders/betterportals_render_portal.vsh
@@ -1,0 +1,54 @@
+// Native ESSL has no fixed-function vertex interface.  MobileGlues and SFPEW
+// translate the legacy interface before submitting it to GLES; a direct ESSL
+// context uses the explicit attribute/matrix path below.
+#ifdef GL_ES
+#define BP_GL_ES 1
+#else
+#define BP_GL_ES 0
+#endif
+#ifdef MG_MOBILEGLUES
+#define BP_MOBILEGLUES 1
+#else
+#define BP_MOBILEGLUES 0
+#endif
+
+#if BP_GL_ES && !BP_MOBILEGLUES
+#define BP_NATIVE_ES 1
+#else
+#define BP_NATIVE_ES 0
+#endif
+
+// The compatibility wrappers do not expose gl_ClipVertex in translated ESSL.
+// SFPEW's generated source is modern as well, so omit the assignment there.
+#if BP_GL_ES || BP_MOBILEGLUES
+#define BP_SKIP_FIXED_CLIP 1
+#else
+#if __VERSION__ >= 130
+#define BP_SKIP_FIXED_CLIP 1
+#else
+#define BP_SKIP_FIXED_CLIP 0
+#endif
+#endif
+
+#if BP_NATIVE_ES
+precision highp float;
+attribute vec4 Position;
+uniform mat4 bpModelViewMatrix;
+uniform mat4 bpProjectionMatrix;
+varying mediump float bpFogFragCoord;
+#endif
+
+void main() {
+#if BP_NATIVE_ES
+    vec4 viewPos = bpModelViewMatrix * Position;
+    gl_Position = bpProjectionMatrix * viewPos;
+    bpFogFragCoord = length(viewPos.xyz);
+#else
+    vec4 viewPos = gl_ModelViewMatrix * gl_Vertex;
+#if !BP_SKIP_FIXED_CLIP
+    gl_ClipVertex = viewPos;
+#endif
+    gl_Position = gl_ProjectionMatrix * viewPos;
+    gl_FogFragCoord = length(viewPos.xyz);
+#endif
+}


### PR DESCRIPTION
## 概述

修复 BetterPortals Refitted（0.4.1）末地传送门的视觉兼容性。修复前：无光影下没有"看穿看到末地"的效果（洞口只见星野贴图）且视觉位置低约一格；开启光影后传送门进入视角即严重卡顿（约 5 fps）、主世界地形整体消失；风暴修复后星野叠加层仍几乎不可见且随视角转动闪烁。传送功能本身一直正常。

## 根因与改动（四层根因叠加，详见 docs/compat/betterportals.md）

1. **glsm texgen 顶点着色器触发 NVIDIA 驱动 uniform 消除**（`d4af535`）：逐分量覆写模式让驱动 DCE 掉 `u_TexGenEyePlaneS`，星野被拉成竖直条纹。改为单表达式 `vec4` 构造，语义等价。
2. **星野叠加渲染被整体劫持**（`96e318d`）：BPR 用无 world 的合成 dummy TE 调原版 TESR 画星野叠加层，依赖 shouldRenderFace 里的 blend 钩子；新增 `EndPortalRenderPolicy` 按调用来源分流，无光影下放行 legacy 路径由 glsm FFP 模拟执行。
3. **客户端数组 draw 的 FFP flags 推导**（`e61d697`）+ compat shader uniform 存活断言（`a266e75`）。
4. **光影管线重载风暴**（`7ccf0ce`）：BPR 顺序双 pass 每帧往返切换维度，preparePipeline 每次切换都销毁重建管线并杀 celeritas worker → 地形永远来不及重建。改为按维度缓存切换；地形 program 缓存按管线实例分键；合成写入动态读取的当前 framebuffer，两个世界各自获得完整光影效果。
5. **光影下星野叠加层被旁路**（`a26efe2`）：实体阶段 Iris gbuffers program 已绑定，glsm 让位导致 texgen FFP 仿真永远不执行。光影下合成 TE 改走为光影设计的替代渲染器，并完整复刻 BPR 的 CONSTANT_ALPHA 淡出钩子（检测因子对 + 从真实 GL 状态读回常量 alpha，折入首层顶点 alpha）。
6. **闲置维度管线回收**（`162ed0e`）：停止渲染 30 秒以上的维度管线自动销毁（render target 组不再永久驻留），地形 program 缓存惰性同步清理。

## 如何验证

- `./gradlew build --no-daemon` 全绿（含 `check`：JUnit 自动化测试 + remap jar 结构/桥契约测试）。
- 实机回归（实例 1.12.2-Cleanroom，NVIDIA RTX 5070 Laptop / 610.74）：
  - 无光影：看穿（洞内可见末地景象）+ 星野旋涡 + 淡出 + 位置正常；
  - 光影（BSL）：看穿与主世界各自带光影效果，帧数/地形正常；星野叠加层可见、转动视角不闪烁、淡出正常；
  - 主世界/末地/暮色森林三维度往返正常；破坏传送门闲置 30 秒后日志出现 `Destroying idle pipeline for dimension`，重新看门时管线一次性重建、无每帧风暴。

## 验证过的光影包与模组

- 光影包：BSL（实机）
- 模组：BetterPortals Refitted 0.4.1（+ forgelin-continuous）、Twilight Forest 3.11.1021

## 遗留

- 不装 BetterPortals 的原版末地传送门/折跃门回归未实测（docs/compat/betterportals.md 已记待补）。

## 文档

- `docs/compat/betterportals.md`：兼容状态更新为已验证，记录全部四层根因与验证记录。
- `docs/compatibility-matrix.md`：BetterPortals Refitted 行更新为已验证。