### PR TITLE
fix(terrain): restore translucent depth-mask semantics for pass-1 TESR fluids

### DIFF
--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -43,6 +43,15 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 > 无条件强制 `glDepthMask(true)`，translucent 层里的罐体玻璃窗因此写出深度，遮挡了其后绘制的
 > TESR 液体；修复后 translucent terrain pass 在主 pass 不再写深度（与 vanilla 语义一致），
 > 阴影图 pass 与不透明 pass 保持写深度。
+>
+> 2026-09-02 追加：上述修复曾被 #85（`da83c59`）回潮——该提交把 translucent terrain pass
+> 翻转为写深度，依据的"vanilla 半透明阶段保持写深度"前提不实：vanilla 1.12.2 将整个
+> translucent 阶段（半透明地形 + pass-1 方块实体重绘）包在 `depthMask(false)` 内
+> （`EntityRenderer` 约 1539/1564 行），储罐玻璃先写深度便遮挡了其后渲染的流体 TESR，
+> 有无光影均不显示。修复为 translucent pass 恢复不写深度
+> （`VintageRenderPassConfigurationBuilder`），水 pass 保持写深度；光影路径由
+> Iris celeritas 接口对 translucent 语义 pass 统一不写深度兜底。无光影/光影双路径、
+> 水与玻璃叠层、mipmap 切换均回归通过。
 > 
 > 2026-08-18 追加：Snow! Real Magic! 0.7.4（issue #35）带雪栅栏不渲染的修复——见下方
 > [模组与环境](#模组与环境) 的 Snow! Real Magic! 行。根因是 SRM 把被雪覆盖的方块替换为携带
@@ -94,7 +103,7 @@ Windows 10、NVIDIA GeForce RTX 5070 Laptop GPU（驱动 610.74）。
 | VoxelMap         | 部分 | 条件 Mixin（CPU 纹理路径 + 线性过滤 + scissor 重路由 + HudCaching alpha 保护） | 1.9.25 小地图黑屏/黑块已修复（dev 验证圆内正常显示地图内容、HUD 不被缓存隐藏，见 [docs/compat/voxelmap.md](compat/voxelmap.md)）；已知缺口：与 StellarCore `HudCaching` 组合时小地图圆周仍可能残留黑块（VoxelMap 全屏清 alpha + DST_ALPHA 混合与 HUD 缓存 FBO 的第三方冲突，`HudCaching=false` 即消失，非本模组缺陷）；验证 VoxelMap 需停用 JourneyMap（二者频道冲突） |
 | ModernUI         | 代码支持 | GUI scale hook                     | 尚缺当前运行时验证记录      |
 | Depths Update    | 已验证 | 兼容门控（`compat/depthsupdate`：公开 API 推导 section 范围 + storage 索引映射） | 1.0.0-a10：扩展世界高度（默认 -64..320）下 Y<0 与 Y>255 的方块不再缺失（渲染器原先硬编码 0-255）；dev 实测正常；无 Depths 时回退 vanilla 行为 |
-| EnderIO CEu / EnderCore CEu | 已验证 | 无（核心渲染语义修复，非模组接入） | 5.4.2 + EnderCore 0.5.81：光影开启时流体罐内液体被罐体玻璃窗深度遮挡的问题已修复（`cb4feaa5`，translucent terrain pass 不再写深度）；MakeUp Ultra Fast 9.4c + Cleanroom 0.5.17-alpha 实测通过 |
+| EnderIO CEu / EnderCore CEu | 已验证 | 无（核心渲染语义修复，非模组接入） | 5.4.2 + EnderCore 0.5.81：光影开启时流体罐内液体被罐体玻璃窗深度遮挡的问题已修复（`cb4feaa5`，translucent terrain pass 不再写深度）；MakeUp Ultra Fast 9.4c + Cleanroom 0.5.17-alpha 实测通过；2026-09-02 修复 #85（`da83c59`）引入的回潮——translucent pass 被错误翻转为写深度导致有无光影流体均被玻璃遮挡，已恢复 vanilla 深度语义，双路径实测通过 |
 | Snow! Real Magic! | 已验证 | 兼容门控（SRM 的 snow_layer 块退回 vanilla dispatcher 路径） | 0.7.4：带雪栅栏不渲染已修复（SRM 把被覆盖方块替换为带 SnowTile 的雪层、仅在 `BlockRendererDispatcher.renderBlock` 内重绘，快速区块路径已绕过）；`6aee395`，dev 运行验证通过（MakeUp Ultra Fast 下无光影 + 光影各验一次） |
 | TC4 Research Port: Reborn | 部分 | 条件 Mixin（Old Research Tessellator 转发到 streaming drawer） | 1.0.1-release（1632015:8642028）：已修复 splash 结束后 repack capacity 为 0 导致的 GUI Client thread 无限循环；dev 人工回归确认研究笔记 GUI 不再卡死，优化后约 500+ FPS，与背包界面同量级；研究树视觉回归待补，详见 [docs/compat/oldresearch.md](compat/oldresearch.md) |
 | Modern Splash    | 部分 | 无侵入（替换类与 mixin 注入天然兼容）+ splash 字体 color=0 修复 | 1.5.3（629058:8487408）dev 运行通过（coremod 加载、mixin 注入保留、字体颜色按配置生效）；光影场景回归待做，详见 [docs/compat/modern-splash.md](compat/modern-splash.md) |

--- a/shader/src/main/java/net/coderbot/iris/celeritas/IrisCeleritasChunkShaderInterface.java
+++ b/shader/src/main/java/net/coderbot/iris/celeritas/IrisCeleritasChunkShaderInterface.java
@@ -159,7 +159,13 @@ public class IrisCeleritasChunkShaderInterface implements ChunkShaderInterface {
     }
 
     public static boolean shouldWriteDepth(TerrainRenderPass pass, boolean shadowPass) {
-        return shadowPass || pass.writesDepth();
+        // The main translucent pass must never write depth: under shaders, block entities render
+        // after translucent terrain, so glass windows (EnderIO fluid tanks, issue #58) writing
+        // depth would occlude the TESR fluid behind them. The pass's writesDepth flag carries the
+        // shaderless (fixed-function) policy, where vanilla keeps the mask on and TESRs draw first;
+        // the Iris path therefore applies the per-semantic override itself instead of deferring to
+        // the flag. Water keeps writing depth so stacked water sorts correctly (#79).
+        return shadowPass || (pass.writesDepth() && pass.semantic() != TerrainRenderPass.Semantic.TRANSLUCENT);
     }
 
     @Override

--- a/src/main/java/com/dhj/actinium/render/terrain/VintageRenderPassConfigurationBuilder.java
+++ b/src/main/java/com/dhj/actinium/render/terrain/VintageRenderPassConfigurationBuilder.java
@@ -87,7 +87,14 @@ public class VintageRenderPassConfigurationBuilder {
                 .fragmentDiscard(false)
                 .useReverseOrder(true)
                 .semantic(TerrainRenderPass.Semantic.TRANSLUCENT)
-                .writesDepth(true)
+                // Vanilla 1.12.2 wraps the whole translucent stage (terrain plus the pass-1
+                // tile-entity re-render such as EnderIO tank fluid) in depthMask(false), see
+                // EntityRenderer around lines 1539/1564. Writing depth here makes translucent
+                // terrain (e.g. the tank glass) occlude pass-1 TESR geometry drawn afterwards,
+                // which hid EnderIO tank fluid on both the fixed-function and shader paths (#58).
+                // The earlier flip to true (64b9c32/da83c59) rested on the incorrect premise
+                // that vanilla keeps the depth mask on for translucent terrain.
+                .writesDepth(false)
                 .useTranslucencySorting(ActiniumRuntime.options().performance.useTranslucentFaceSorting)
                 .build();
 

--- a/src/test/java/org/embeddedt/embeddium/impl/render/chunk/terrain/TerrainRenderPassTest.java
+++ b/src/test/java/org/embeddedt/embeddium/impl/render/chunk/terrain/TerrainRenderPassTest.java
@@ -142,19 +142,30 @@ class TerrainRenderPassTest {
         );
     }
 
-    @ParameterizedTest(name = "{0} shadow={1} writes depth={2}")
+    @ParameterizedTest(name = "{0} shadow={3} writes depth={4}")
     @MethodSource("depthWritePolicies")
-    void appliesDepthWritePolicy(String name, boolean shadowPass, boolean expected) {
-        TerrainRenderPass pass = pass(name, expected, shadowPass, false);
+    void appliesDepthWritePolicy(
+            String name,
+            TerrainRenderPass.Semantic semantic,
+            boolean reverseOrder,
+            boolean writesDepth,
+            boolean shadowPass,
+            boolean expected
+    ) {
+        TerrainRenderPass pass = pass(name, writesDepth, reverseOrder, false, semantic);
 
         assertEquals(expected, IrisCeleritasChunkShaderInterface.shouldWriteDepth(pass, shadowPass));
     }
 
     private static Stream<Arguments> depthWritePolicies() {
         return Stream.of(
-                Arguments.of("translucent", false, false),
-                Arguments.of("water", false, true),
-                Arguments.of("shadow translucent", true, true)
+                // Mirror VintageRenderPassConfigurationBuilder: the translucent pass carries the
+                // fixed-function depth policy (writesDepth=true), and the Iris main pass must still
+                // suppress depth writes so TESR fluids behind glass stay visible (#58).
+                Arguments.of("translucent", TerrainRenderPass.Semantic.TRANSLUCENT, true, true, false, false),
+                Arguments.of("water", TerrainRenderPass.Semantic.WATER, true, true, false, true),
+                Arguments.of("solid", TerrainRenderPass.Semantic.SOLID, false, true, false, true),
+                Arguments.of("shadow translucent", TerrainRenderPass.Semantic.TRANSLUCENT, true, true, true, true)
         );
     }
 


### PR DESCRIPTION
## 概述

修复 EnderIO 储罐流体显示回归：#85 的修复（`da83c59`）之后，储罐内流体在**无光影和光影下均不渲染**（容器功能正常，仅视觉缺失）。此前 #58 的光影路径修复（`cb4feaa5`）被该提交回潮。

## 根因

`da83c59`（#85）把 translucent terrain pass 从 `writesDepth(false)` 翻转为 `true`，依据的前提是"vanilla 1.12.2 半透明地形阶段保持写深度"——该前提不实。vanilla 将整个 translucent 阶段包在 `depthMask(false)` 内（`EntityRenderer` 约 1539/1564 行），且 pass-1 方块实体（EIO 储罐流体 TESR）在半透明地形**之后**、同一深度掩码窗口内重绘。translucent pass 主动写深度后，储罐玻璃先写深度，把其后渲染的流体 TESR 遮挡掉：

- 无光影路径：pass 的 `startDrawing()` 主动 `glDepthMask(writesDepth)`，覆盖外层的 `depthMask(false)`；
- 光影路径：Iris celeritas 地形接口按 pass 的 writesDepth 决定深度掩码，同样中招。

排查链：二分锁定 7c339d2（08-22）正常、`da83c59`（08-24）起坏；A/B 实验确认 `da83c59` 单点回退该标志流体即恢复显示。

## 改动

- `VintageRenderPassConfigurationBuilder`：translucent pass 恢复 `writesDepth(false)` 并附注释记录 vanilla 语义；水 pass（WATER 语义）保持 `writesDepth(true)` 不动（#79 语义）。
- `IrisCeleritasChunkShaderInterface#shouldWriteDepth`：translucent 语义 pass 在主 pass 不写深度，阴影图 pass 与不透明语义不变（双路径兜底）。
- `TerrainRenderPassTest`：深度策略测试重写为镜像真实 builder 配置（translucent 语义 + writesDepth(true) → 主 pass 期望 false）。

## 如何验证

- `./gradlew build --no-daemon` 全绿（含 `check`：JUnit 自动化测试 + remap jar 结构/桥契约测试）。
- 实机回归（实例 1.12.2-Cleanroom，NVIDIA RTX 5070 Laptop）：
  - 无光影：EIO 储罐流体恢复显示；
  - 光影：储罐流体正常（未破坏既有光影路径修复）；
  - BetterPortals 末地传送门回归：看穿 + 星野正常、无卡顿；
  - #85 防回潮：水/玻璃叠层正常，切换 mipmap 等级触发重载后方块不消失。

## 验证过的光影包与模组

- 光影包：MakeUp Ultra Fast 9.4c（实机）
- 模组：EnderIO CEu 5.4.2 + EnderCore CEu 0.5.81、BetterPortals Refitted 0.4.1

## 关联

- Refs #58（原修复）、#85（回潮来源）

## 文档

- `docs/compatibility-matrix.md`：EnderIO 行更新 + 2026-09-02 回潮根因追加段。