### PR TITLE
fix(shader): strip leading zeros from ACTINIUM_VERSION macro value

### DIFF
--- a/shader/src/main/java/net/coderbot/iris/gl/shader/StandardMacros.java
+++ b/shader/src/main/java/net/coderbot/iris/gl/shader/StandardMacros.java
@@ -45,10 +45,19 @@ public class StandardMacros {
 
     private static String makeActiniumVersion()
     {
+        return formatActiniumVersion(Tags.VERSION);
+    }
+
+    /**
+     * Encodes a version string (e.g. "alpha-0.0.5-da83c59") into a numeric macro value.
+     * Package-visible for testing.
+     */
+    static String formatActiniumVersion(String version)
+    {
         // The version may carry a non-numeric prefix (e.g. "alpha-0.0.1-2dc019e") and the
         // build appends a git sha, so locate the first dotted numeric triplet instead of
         // assuming the string starts with digits.
-        String[] parts = Tags.VERSION.split("[.-]");
+        String[] parts = version.split("[.-]");
         int numericStart = -1;
         for (int i = 0; i < parts.length; i++) {
             if (!parts[i].isEmpty() && parts[i].chars().allMatch(Character::isDigit)) {
@@ -76,7 +85,13 @@ public class StandardMacros {
                     sub = Integer.parseInt(num);
             }
         }
-        return String.format("%d%02d%02d%03d", major, minor, patch, sub);
+        String encoded = String.format("%d%02d%02d%03d", major, minor, patch, sub);
+        // jcpp lexes macro values as C constants: a multi-digit value starting with '0' is
+        // treated as octal, and an 8/9 digit then raises a LexerException that fails the whole
+        // shader pack load (production: alpha-0.0.5-da83c59 -> "000058359"). Strip the leading
+        // zeros; the numeric value is unchanged.
+        String stripped = encoded.replaceFirst("^0+", "");
+        return stripped.isEmpty() ? "0" : stripped;
     }
 
 	public static Iterable<StringPair> createStandardEnvironmentDefines() {

--- a/shader/src/main/java/net/coderbot/iris/shaderpack/preprocessor/PropertiesPreprocessor.java
+++ b/shader/src/main/java/net/coderbot/iris/shaderpack/preprocessor/PropertiesPreprocessor.java
@@ -30,26 +30,29 @@ public class PropertiesPreprocessor {
 		final Map<String, String> stringValues = getStringValues(shaderPackOptions);
 
 		try (Preprocessor pp = new Preprocessor()) {
-			// Install a listener before adding macros: jcpp throws LexerException for lexer warnings
-			// (e.g. "Decimal constant starts with 0, but not octal") only when no listener is set.
-			// Shader packs such as Complementary Unbound r5.8.1 trigger such warnings in macro values,
-			// and Iris treats a LexerException here as a fatal pack load failure, breaking shader
-			// toggling. With a listener installed the warning is logged and processing continues.
-			pp.setListener(new PropertiesCommentListener());
-
+			// jcpp lexes macro values inside addMacro through an internal lexer source that has
+			// no listener attached, so lexer warnings (e.g. "Decimal constant starts with 0, but
+			// not octal") throw LexerException from addMacro itself; the preprocessor listener is
+			// never consulted there. A single bad define must not fail the whole pack load
+			// (production: ACTINIUM_VERSION=000058359 from version alpha-0.0.5-da83c59), so the
+			// offending macro is skipped with a warning and processing continues.
 			for (String value : booleanValues) {
 				pp.addMacro(value);
 			}
 
 			for (StringPair envDefine : environmentDefines) {
-				pp.addMacro(envDefine.getKey(), envDefine.getValue());
+				try {
+					pp.addMacro(envDefine.getKey(), envDefine.getValue());
+				} catch (LexerException e) {
+					Iris.logger.warn("Skipping environment define {}={}: {}", envDefine.getKey(), envDefine.getValue(), e.getMessage());
+				}
 			}
 
 			stringValues.forEach((name, value) -> {
 				try {
 					pp.addMacro(name, value);
 				} catch (LexerException e) {
-					e.printStackTrace();
+					Iris.logger.warn("Skipping string option macro {}={}: {}", name, value, e.getMessage());
 				}
 			});
 
@@ -67,16 +70,15 @@ public class PropertiesPreprocessor {
 		}
 
 		final Preprocessor preprocessor = new Preprocessor();
-		// See the comment in the other preprocessSource overload: without a listener, jcpp turns lexer
-		// warnings into LexerExceptions, which must not be fatal for shader pack properties.
-		preprocessor.setListener(new PropertiesCommentListener());
 
-		try {
-			for (StringPair envDefine : environmentDefines) {
+		// See the comment in the other preprocessSource overload: addMacro throws on lexer
+		// warnings regardless of any listener, so skip the offending macro instead of failing.
+		for (StringPair envDefine : environmentDefines) {
+			try {
 				preprocessor.addMacro(envDefine.getKey(), envDefine.getValue());
+			} catch (LexerException e) {
+				Iris.logger.warn("Skipping environment define {}={}: {}", envDefine.getKey(), envDefine.getValue(), e.getMessage());
 			}
-		} catch (LexerException e) {
-			e.printStackTrace();
 		}
 
 		return process(preprocessor, source);

--- a/src/test/java/net/coderbot/iris/gl/shader/StandardMacrosVersionTest.java
+++ b/src/test/java/net/coderbot/iris/gl/shader/StandardMacrosVersionTest.java
@@ -1,0 +1,37 @@
+package net.coderbot.iris.gl.shader;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * The ACTINIUM_VERSION define is lexed by jcpp as a C constant. A multi-digit value starting
+ * with '0' is treated as an octal constant, and any '8'/'9' digit then raises a LexerException
+ * that fails the whole shader pack load (production: alpha-0.0.5-da83c59 -&gt; 000058359).
+ */
+class StandardMacrosVersionTest {
+
+    @Test
+    void letterPrefixedGitShaDoesNotProduceLeadingZeroValue() {
+        // alpha-0.0.5-da83c59 -> major=0, minor=0, patch=5, sub=8359; previously encoded as
+        // "000058359", which jcpp parses as octal and rejects on the 8/9 digits.
+        assertEquals("58359", StandardMacros.formatActiniumVersion("alpha-0.0.5-da83c59"));
+    }
+
+    @Test
+    void releaseVersionKeepsEstablishedEncoding() {
+        assertEquals("10203000", StandardMacros.formatActiniumVersion("1.2.3"));
+    }
+
+    @Test
+    void versionWithoutNumericTripletFallsBackToZero() {
+        assertEquals("0", StandardMacros.formatActiniumVersion("unknown"));
+    }
+
+    @Test
+    void numericShaSegmentIsNotTreatedAsPrerelease() {
+        // A trailing git sha that starts with digits (e.g. "00e287f") must not become sub.
+        assertEquals("5000", StandardMacros.formatActiniumVersion("0.0.5-00e287f"));
+    }
+}

--- a/src/test/java/net/coderbot/iris/shaderpack/preprocessor/PropertiesPreprocessorTest.java
+++ b/src/test/java/net/coderbot/iris/shaderpack/preprocessor/PropertiesPreprocessorTest.java
@@ -1,29 +1,64 @@
 package net.coderbot.iris.shaderpack.preprocessor;
 
+import com.google.common.collect.ImmutableList;
 import net.coderbot.iris.shaderpack.StringPair;
+import net.coderbot.iris.shaderpack.include.AbsolutePackPath;
+import net.coderbot.iris.shaderpack.include.IncludeGraph;
+import net.coderbot.iris.shaderpack.option.ShaderPackOptions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Verifies that lexer warnings during property macro preprocessing are not fatal.
+ * Verifies that lexer warnings while adding property macros are not fatal.
  *
- * <p>jcpp throws a {@code LexerException} for warnings (e.g. "Decimal constant starts with 0, but
- * not octal") only while no listener is installed. Iris installs its listeners inside
- * {@code process()}, so macro values added before that point could fail the whole pack load.
- * Complementary Unbound r5.8.1 triggers exactly this warning, which broke shader toggling
- * (issue #31).</p>
+ * <p>jcpp lexes macro values inside {@code addMacro} through an internal lexer source that has
+ * no listener attached, so warnings (e.g. "Decimal constant starts with 0, but not octal") throw
+ * {@code LexerException} from {@code addMacro} itself — the preprocessor listener installed for
+ * {@code process()} is never consulted there. Such an exception used to fail the whole shader
+ * pack load: Complementary Unbound r5.8.1 defines zero-prefixed decimals in string option values
+ * (issue #31), and the ACTINIUM_VERSION environment define hit the same crash whenever the
+ * encoded mod version started with 0 and contained an 8/9 digit (production:
+ * alpha-0.0.5-da83c59 -&gt; "000058359").</p>
  */
 class PropertiesPreprocessorTest {
+    @TempDir
+    Path tempDir;
+
     @Test
     void zeroPrefixedDecimalInEnvironmentDefineValueIsNotFatal() {
-        // The macro value is lexed while the preprocessor has no listener installed (issue #31).
+        // The macro value is lexed inside addMacro, which throws on warnings (issue #31).
         assertDoesNotThrow(() -> PropertiesPreprocessor.preprocessSource(
             "someKey = someValue\n",
             List.of(new StringPair("COMPLEMENTARY", "00002178"))
+        ));
+    }
+
+    @Test
+    void zeroPrefixedDecimalInEnvironmentDefineValueIsNotFatalWithPackOptions() throws IOException {
+        // The three-arg overload feeds ACTINIUM_VERSION (e.g. "000058359" from version
+        // alpha-0.0.5-da83c59) into addMacro; jcpp rejects it as a malformed octal constant
+        // and the exception used to abort the whole shader pack load.
+        Path entry = tempDir.resolve("entry.glsl");
+        Files.writeString(entry, "void main() {}\n");
+        IncludeGraph graph = new IncludeGraph(
+            tempDir,
+            ImmutableList.of(AbsolutePackPath.fromAbsolutePath("/entry.glsl"))
+        );
+        ShaderPackOptions options = new ShaderPackOptions(graph, Map.of());
+
+        assertDoesNotThrow(() -> PropertiesPreprocessor.preprocessSource(
+            "someKey = someValue\n",
+            options,
+            List.of(new StringPair("ACTINIUM_VERSION", "000058359"))
         ));
     }
 


### PR DESCRIPTION
## 问题

生产环境偶发：进世界后任何光影包都无法载入，切换光影包时提示「已使用光影包：(off)！」，换任何光影包均无效（触发类似重载，但始终回退到原版渲染）。

## 根因

生产日志堆栈：

```
RuntimeException: Unexpected LexerException processing macros
    at PropertiesPreprocessor.preprocessSource(PropertiesPreprocessor.java:45)
    at ShaderProperties.<init>(ShaderProperties.java:132)
    at ShaderPack.<init>(ShaderPack.java:232)
    at Iris.loadExternalShaderpack(Iris.java:574)
Caused by: org.anarres.cpp.LexerException: Warning at 1:8: Decimal constant starts with 0, but not octal: 000058359
    at org.anarres.cpp.Preprocessor.addMacro(Preprocessor.java:380)
```

证据链：

- `StandardMacros.makeActiniumVersion()` 把版本 `alpha-0.0.5-da83c59` 编码为 `ACTINIUM_VERSION=000058359`：sha 段 `da83c59` 以字母开头被当作 prerelease 抽出数字 `8359`，而 major=0 时编码值恒以 0 开头。
- jcpp 的 `addMacro(name, value)` 在内部新建**无 listener 关联**的 lexer 解析宏值：多字符、0 开头、含 8/9 的数字被当作非法八进制常量，直接抛 `LexerException`。
- 三参 `preprocessSource` 的 environmentDefines 循环没有容错，异常一路抛到 `ShaderPack.<init>`。environment define 与具体包无关，因此**所有**光影包都加载失败，表现为「换包无效」。
- 是否触发取决于构建版本号 sha 段是否被解析出含 8/9 的数字 → 偶发；dev 环境 `Tags.VERSION` 无数字三元组，恒返回 `"0"` → dev 无法复现。
- #61（e07dd15）安装的 `pp.setListener(...)` 对该路径**无效**——`addMacro` 内部 lexer 不关联 Preprocessor 的 listener（生产代码在行 38 装了 listener、行 45 仍抛异常，行号完全吻合）。真正起保护作用的是 catch，本 PR 一并修正注释并移除无效调用。

## 改动

- `StandardMacros`：编码值去前导零（`000058359` → `58359`），数值语义不变，从根源消除非法八进制常量。
- `PropertiesPreprocessor`：两个 overload 中宏值解析失败时跳过该宏并 `logger.warn`（含宏名/值），不再让整个光影包加载失败；两参 overload 的 catch 移入循环内（原来首个坏宏会导致后续宏全部丢失）；`printStackTrace()` 统一换成 `logger.warn`。
- 测试：新增 `StandardMacrosVersionTest`（版本编码回归 4 例）；`PropertiesPreprocessorTest` 补充三参 overload 用例（复现生产崩溃路径）。

## 验证

- TDD：修复前 3 个用例按预期失败（三参用例抛出与生产同型的 `RuntimeException ← LexerException` 链），修复后 7 个用例全绿。
- `./gradlew build --no-daemon` 全绿。