### PR TITLE
fix(terrain): terrain invisible at high altitude and chunk loading holes

### DIFF
--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/RenderSectionManager.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/RenderSectionManager.java
@@ -4,6 +4,8 @@ import it.unimi.dsi.fastutil.longs.Long2ReferenceMap;
 import it.unimi.dsi.fastutil.longs.Long2ReferenceOpenHashMap;
 import it.unimi.dsi.fastutil.objects.*;
 import lombok.Getter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.embeddedt.embeddium.impl.common.util.TimeUtil;
 import org.embeddedt.embeddium.impl.gl.device.CommandList;
 import org.embeddedt.embeddium.impl.gl.device.RenderDevice;
@@ -64,6 +66,8 @@ public abstract class RenderSectionManager {
      */
     protected static final boolean CONTINUOUSLY_REMESH_WORLD = false;
 
+    private static final Logger LOGGER = LogManager.getLogger(RenderSectionManager.class);
+
     private final ChunkBuilder builder;
 
     private final Thread renderThread = Thread.currentThread();
@@ -96,6 +100,10 @@ public abstract class RenderSectionManager {
 
     @Nullable
     protected final RenderListManager shadowRenderListManager;
+
+    // Normalizes the two external frame counters (terrain pass and shadow pass) into one strictly
+    // increasing sequence; every frame number archived or compared by this manager comes from it.
+    private final SectionFrameClock frameClock = new SectionFrameClock();
 
     // Set by the shadow pass, which precedes the terrain pass in a frame and submits both searches. The terrain
     // pass of the same frame then skips re-running the search.
@@ -198,6 +206,10 @@ public abstract class RenderSectionManager {
      * per-frame camera bookkeeping.
      */
     public void update(Viewport positionedViewport, int frame, boolean spectator) {
+        // The terrain and shadow passes hand in independent frame counters (the shadow counter
+        // restarts on pipeline rebuild); normalize to one monotonic sequence before any use.
+        frame = this.frameClock.next(frame);
+
         // HBM-CE compatibility seam. MixinRenderSectionManager (hbm.mod.mixin.json) applies
         // @Redirect injections on this exact method body that rewrite the CameraTransform
         // x/y/z getfields below to its unsafe accessors (CeleritasCameraTransformAccess).
@@ -229,6 +241,9 @@ public abstract class RenderSectionManager {
         if (this.shadowRenderListManager == null) {
             throw new IllegalStateException("No shadow pass configured");
         }
+
+        // Same normalization as update(): both passes share the monotonic frame sequence.
+        frame = this.frameClock.next(frame);
 
         this.updateCameraPosition(playerViewport);
         this.shadowPassRanThisFrame = true;
@@ -615,17 +630,22 @@ public abstract class RenderSectionManager {
                 this.updateTranslucencyInfo(result.render, buildResult.meshes);
             }
 
-            var job = result.render.getBuildCancellationToken();
-
-            // Only clear the token if this result belongs to the most recently submitted build.
-            // A stale result from an earlier submission must not clear the token for a newer
-            // in-flight job, which is identified by a higher lastSubmittedFrame.
-            if (job != null && result.buildTime >= result.render.getLastSubmittedFrame()) {
-                result.render.setBuildCancellationToken(null);
-            }
+            releaseBuildCancellationToken(result);
 
             result.render.setLastBuiltFrame(result.buildTime);
             this.sectionMetricsTracker.updateSectionBuildDuration(result.render, holder.executionTimeNanos());
+        }
+    }
+
+    /**
+     * Releases the section's build cancellation token when {@code output} belongs to the latest
+     * submission. A stale result from an earlier submission must not clear the token of a newer
+     * in-flight job, which is identified by a higher {@code lastSubmittedFrame}.
+     */
+    private static void releaseBuildCancellationToken(ChunkTaskOutput output) {
+        var job = output.render.getBuildCancellationToken();
+        if (job != null && output.buildTime >= output.render.getLastSubmittedFrame()) {
+            output.render.setBuildCancellationToken(null);
         }
     }
 
@@ -666,10 +686,20 @@ public abstract class RenderSectionManager {
 
         for (var holder : outputs) {
             var output = holder.output();
-            if (output.render.isDisposed()
-                    || output.render.getLastBuiltFrame() > output.buildTime
+            if (output.render.isDisposed()) {
+                releaseBuildCancellationToken(output);
+                continue;
+            }
+            if (output.render.getLastBuiltFrame() > output.buildTime
                     || (output instanceof ChunkBuildOutput buildOutput
                         && output.render.getLastSubmittedBuildFrame() > buildOutput.buildTime)) {
+                // Dropped results never reach processChunkBuildResults, so the token release has to
+                // happen here; skipping it pinned the section's buildInFlight bit and made the graph
+                // search skip the section permanently.
+                LOGGER.warn("Discarding stale chunk build result for section [{}, {}, {}]: buildTime={}, lastBuiltFrame={}, lastSubmittedFrame={}",
+                        output.render.getChunkX(), output.render.getChunkY(), output.render.getChunkZ(),
+                        output.buildTime, output.render.getLastBuiltFrame(), output.render.getLastSubmittedFrame());
+                releaseBuildCancellationToken(output);
                 continue;
             }
 

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/SectionFrameClock.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/SectionFrameClock.java
@@ -1,0 +1,41 @@
+package org.embeddedt.embeddium.impl.render.chunk;
+
+/**
+ * Normalizes the external frame numbers handed to {@link RenderSectionManager} into one
+ * strictly increasing sequence.
+ *
+ * <p>The terrain pass and the shadow pass are driven by two independent external counters: the
+ * vanilla frame counter, and the shadow renderer's own counter which restarts from zero whenever
+ * the shader pipeline is rebuilt. The manager archives and compares frame numbers in several
+ * places — lattice visit stamps, {@code lastUpdatedFrame}, build times and the per-section
+ * submission/build frames — and every comparison assumes a single monotonic sequence. A counter
+ * that jumps backwards poisons those comparisons: searches skip cells carrying a stamp from the
+ * "future", and finished build results are discarded as stale without releasing their
+ * cancellation token.</p>
+ *
+ * <p>Feeding every external frame through this clock keeps the internal sequence monotonic while
+ * preserving caller order within a game frame: the first caller takes the next number and later
+ * callers of the same frame take higher numbers. Not thread-safe; the section manager only calls
+ * it from the render thread.</p>
+ */
+final class SectionFrameClock {
+    private boolean initialized;
+    private int last;
+
+    /**
+     * Returns the internal frame number for {@code external}. The first observed value is
+     * accepted as-is; afterwards the result is {@code max(external, previous + 1)}, so repeated,
+     * out-of-order or restarted external counters still yield a strictly advancing sequence.
+     * Saturates at {@link Integer#MAX_VALUE} rather than overflowing into negative frames.
+     */
+    int next(int external) {
+        if (!this.initialized) {
+            this.initialized = true;
+        } else {
+            int successor = this.last == Integer.MAX_VALUE ? Integer.MAX_VALUE : this.last + 1;
+            external = Math.max(external, successor);
+        }
+        this.last = external;
+        return external;
+    }
+}

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/map/ChunkTracker.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/map/ChunkTracker.java
@@ -112,6 +112,64 @@ public class ChunkTracker implements ClientChunkEventListener {
         this.updateNeighbors(x, z);
     }
 
+    /**
+     * Reconciles the tracked state with the chunks actually loaded by the world.
+     *
+     * The normal load/unload event stream can miss transitions (e.g. chunk data written to a
+     * chunk the tracker never saw load, or mods mutating the world's chunk map directly),
+     * which leaves the tracker permanently out of sync with no way to recover: affected chunks
+     * never satisfy the neighbor-readiness gate and are never published to subscribers. This
+     * method diffs the tracked set against the world's authoritative loaded set and replays
+     * the difference through the regular event methods, so neighbor-readiness gating and
+     * subscription notifications behave exactly as if the events had arrived normally.
+     *
+     * @param actuallyLoadedChunkKeys packed coordinates of the chunks currently loaded in the
+     *                                world; not modified by this method
+     */
+    public synchronized void reconcile(LongSet actuallyLoadedChunkKeys) {
+        int unknown = this.chunkStatus.defaultReturnValue();
+
+        // Collect the diff first: replaying the events mutates chunkStatus, which must not
+        // happen while either set is being iterated.
+        LongList missingFromTracker = null;
+        var loadedIterator = actuallyLoadedChunkKeys.iterator();
+        while (loadedIterator.hasNext()) {
+            long key = loadedIterator.nextLong();
+            if (this.chunkStatus.get(key) == unknown) {
+                if (missingFromTracker == null) {
+                    missingFromTracker = new LongArrayList();
+                }
+                missingFromTracker.add(key);
+            }
+        }
+
+        LongList missingFromWorld = null;
+        var trackedIterator = this.chunkStatus.keySet().iterator();
+        while (trackedIterator.hasNext()) {
+            long key = trackedIterator.nextLong();
+            if (!actuallyLoadedChunkKeys.contains(key)) {
+                if (missingFromWorld == null) {
+                    missingFromWorld = new LongArrayList();
+                }
+                missingFromWorld.add(key);
+            }
+        }
+
+        if (missingFromTracker != null) {
+            for (int i = 0; i < missingFromTracker.size(); i++) {
+                long key = missingFromTracker.getLong(i);
+                this.onChunkStatusAdded(PositionUtil.unpackChunkX(key), PositionUtil.unpackChunkZ(key), ChunkStatus.FLAG_ALL);
+            }
+        }
+
+        if (missingFromWorld != null) {
+            for (int i = 0; i < missingFromWorld.size(); i++) {
+                long key = missingFromWorld.getLong(i);
+                this.onChunkStatusRemoved(PositionUtil.unpackChunkX(key), PositionUtil.unpackChunkZ(key), ChunkStatus.FLAG_ALL);
+            }
+        }
+    }
+
     private void updateNeighbors(int x, int z) {
         int r = this.requiredNeighborRadius;
         for (int ox = -r; ox <= r; ox++) {

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/occlusion/OcclusionCuller.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/occlusion/OcclusionCuller.java
@@ -427,23 +427,23 @@ public class OcclusionCuller {
 
     /**
      * Test the search's render-distance shape against a section bounding box.
-     * Horizontal distance is circular in X/Z, while vertical distance is
-     * tested independently so tall searches do not use a spherical cutoff.
+     * The distance is a horizontal circle in X/Z only; the vertical axis is
+     * not distance-culled at all, matching vanilla 1.12 behaviour. Mods such
+     * as Depths Update can extend the world height, so a fixed vertical
+     * cutoff would wrongly drop in-bounds terrain below or above the camera.
      */
     static boolean isWithinRenderDistance(CameraTransform camera, int chunkX, int chunkY, int chunkZ, float maxDistance) {
         // Origin point of the chunk's bounding box in view space.
         int ox = (chunkX << 4) - camera.intX;
-        int oy = (chunkY << 4) - camera.intY;
         int oz = (chunkZ << 4) - camera.intZ;
 
         // Closest point within the bounding box to the camera at (0, 0, 0).
         // Testing the closest point avoids rejecting a section whose near face
         // is within range even when its origin is farther away.
         float dx = nearestToZero(ox, ox + 16) - camera.fracX;
-        float dy = nearestToZero(oy, oy + 16) - camera.fracY;
         float dz = nearestToZero(oz, oz + 16) - camera.fracZ;
 
-        return ((((dx * dx) + (dz * dz)) < (maxDistance * maxDistance)) && (Math.abs(dy) < maxDistance));
+        return ((dx * dx) + (dz * dz)) < (maxDistance * maxDistance);
     }
 
     @SuppressWarnings("ManualMinMaxCalculation")

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/occlusion/RegionCullCache.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/occlusion/RegionCullCache.java
@@ -70,7 +70,7 @@ final class RegionCullCache {
      * subsequent classifications.
      *
      * @param viewport current camera and frustum
-     * @param searchDistance maximum horizontal/vertical render distance
+     * @param searchDistance maximum horizontal render distance
      * @param numRegions exclusive upper bound of the dense region ids that
      *                    may be passed to {@link #classify}
      */
@@ -132,6 +132,12 @@ final class RegionCullCache {
      * Compute conservative region bounds. Distance is rejected first when the
      * nearest possible section point is too far away; otherwise the padded
      * region box is classified against the camera frustum.
+     *
+     * <p>The distance test is a horizontal circle in X/Z only, matching
+     * {@link OcclusionCuller#isWithinRenderDistance(CameraTransform, int, int, int, float)}:
+     * there is no vertical cutoff, so regions far below or above the camera
+     * stay in range (vanilla 1.12 behaviour; the world height may be extended
+     * by mods such as Depths Update).
      */
     private int compute(int regionOriginX, int regionOriginY, int regionOriginZ) {
         final CameraTransform t = this.camera;
@@ -142,29 +148,26 @@ final class RegionCullCache {
         final int az = regionOriginZ - t.intZ, bz = az + REGION_BLOCK_LENGTH;
 
         // Signed range of the nearest-point distance component for all member
-        // section boxes along each axis.
+        // section boxes along each horizontal axis.
         final float loX = nearestToZero(ax, ax + 16) - t.fracX;
         final float hiX = nearestToZero(bx - 16, bx) - t.fracX;
-        final float loY = nearestToZero(ay, ay + 16) - t.fracY;
-        final float hiY = nearestToZero(by - 16, by) - t.fracY;
         final float loZ = nearestToZero(az, az + 16) - t.fracZ;
         final float hiZ = nearestToZero(bz - 16, bz) - t.fracZ;
 
         // Upper bound on every member's absolute distance component.
         final float farX = maxAbs(loX, hiX) + DISTANCE_EPSILON;
-        final float farY = maxAbs(loY, hiY) + DISTANCE_EPSILON;
         final float farZ = maxAbs(loZ, hiZ) + DISTANCE_EPSILON;
 
         // Lower bound on every member's absolute distance component.
         final float nearX = Math.max(0.0f, minAbs(loX, hiX) - DISTANCE_EPSILON);
-        final float nearY = Math.max(0.0f, minAbs(loY, hiY) - DISTANCE_EPSILON);
         final float nearZ = Math.max(0.0f, minAbs(loZ, hiZ) - DISTANCE_EPSILON);
 
         final float maxDistanceSq = maxDistance * maxDistance;
 
-        // If even the nearest possible point fails the distance test, every
-        // section is out of range and the frustum need not be queried.
-        boolean distanceOut = ((nearX * nearX) + (nearZ * nearZ)) >= maxDistanceSq || nearY >= maxDistance;
+        // If even the nearest possible point fails the horizontal distance
+        // test, every section is out of range and the frustum need not be
+        // queried.
+        boolean distanceOut = ((nearX * nearX) + (nearZ * nearZ)) >= maxDistanceSq;
 
         if (distanceOut) {
             return OUTSIDE;
@@ -172,7 +175,7 @@ final class RegionCullCache {
 
         // Only claim a conclusive pass when the farthest possible point is
         // still strictly inside the distance bounds.
-        boolean distanceIn = ((farX * farX) + (farZ * farZ)) < maxDistanceSq && farY < maxDistance;
+        boolean distanceIn = ((farX * farX) + (farZ * farZ)) < maxDistanceSq;
 
         int result = this.viewport.intersectCameraRelativeBox(
                 (ax - t.fracX) - FRUSTUM_PAD,

--- a/src/main/java/com/dhj/actinium/mixin/vintage/core/terrain/MixinClientChunkManager.java
+++ b/src/main/java/com/dhj/actinium/mixin/vintage/core/terrain/MixinClientChunkManager.java
@@ -1,5 +1,6 @@
 package com.dhj.actinium.mixin.vintage.core.terrain;
 
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import net.minecraft.client.multiplayer.ChunkProviderClient;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
@@ -19,6 +20,10 @@ public abstract class MixinClientChunkManager {
     @Final
     private World world;
 
+    @Shadow
+    @Final
+    private Long2ObjectMap<Chunk> loadedChunks;
+
     @Inject(method = "loadChunk", at = @At("RETURN"))
     private void afterLoadChunkFromPacket(int x, int z, CallbackInfoReturnable<Chunk> cir) {
         ChunkTrackerHolder.get(this.world).onChunkStatusAdded(x, z, ChunkStatus.FLAG_ALL);
@@ -27,6 +32,15 @@ public abstract class MixinClientChunkManager {
     @Inject(method = "unloadChunk", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/chunk/Chunk;onUnload()V", shift = At.Shift.AFTER))
     private void afterUnloadChunk(int x, int z, CallbackInfo ci) {
         ChunkTrackerHolder.get(this.world).onChunkStatusRemoved(x, z, ChunkStatus.FLAG_ALL);
+    }
+
+    /**
+     * Repairs any drift between the chunk tracker and the authoritative loaded set once per
+     * client tick; in steady state the diff is empty and no events fire.
+     */
+    @Inject(method = "tick", at = @At("RETURN"))
+    private void reconcileTrackerWithLoadedChunks(CallbackInfoReturnable<Boolean> cir) {
+        ChunkTrackerHolder.get(this.world).reconcile(this.loadedChunks.keySet());
     }
 }
 

--- a/src/test/java/org/embeddedt/embeddium/impl/render/chunk/SectionFrameClockTest.java
+++ b/src/test/java/org/embeddedt/embeddium/impl/render/chunk/SectionFrameClockTest.java
@@ -1,0 +1,94 @@
+package org.embeddedt.embeddium.impl.render.chunk;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the monotonic frame normalization that shields {@link RenderSectionManager} from
+ * out-of-order external frame counters.
+ *
+ * <p>The terrain pass is driven by the vanilla frame counter while the shadow pass hands in its
+ * own counter, which restarts from zero on every shader-pipeline rebuild. Every frame comparison
+ * inside the manager (lattice visit stamps, build times, submission frames) assumes one monotonic
+ * sequence, so the clock must never move backwards regardless of input order.</p>
+ */
+class SectionFrameClockTest {
+    /**
+     * Motivation: the first observed value anchors the sequence; requiring a specific starting
+     * point would break worlds joined at an arbitrary vanilla frame count.
+     */
+    @Test
+    void acceptsFirstValueAsIs() {
+        assertEquals(0, new SectionFrameClock().next(0));
+        assertEquals(42, new SectionFrameClock().next(42));
+    }
+
+    /**
+     * Motivation: a steadily advancing counter passes through untouched, preserving the exact
+     * frame numbers the surrounding code already reasons about.
+     */
+    @Test
+    void followsSteadilyAdvancingInput() {
+        var clock = new SectionFrameClock();
+        for (int frame = 7; frame < 20; frame++) {
+            assertEquals(frame, clock.next(frame));
+        }
+    }
+
+    /**
+     * Motivation: the shadow counter restarting at zero after a pipeline rebuild must not pull
+     * the internal sequence backwards; a backwards jump is what poisons the lattice visit
+     * stamps and the stale-build filter.
+     */
+    @Test
+    void neverRegressesWhenInputJumpsBackward() {
+        var clock = new SectionFrameClock();
+        assertEquals(5000, clock.next(5000));
+        assertEquals(5001, clock.next(12));
+        assertEquals(5002, clock.next(13));
+    }
+
+    /**
+     * Motivation: the shadow pass and the terrain pass of one game frame hand in the same
+     * external number; each caller must still get its own, later frame so "visited this frame"
+     * gates cannot confuse the two passes.
+     */
+    @Test
+    void advancesOnRepeatedInput() {
+        var clock = new SectionFrameClock();
+        assertEquals(10, clock.next(10));
+        assertEquals(11, clock.next(10));
+        assertEquals(12, clock.next(10));
+    }
+
+    /**
+     * Motivation: the two production counters interleave per game frame; the output must stay
+     * strictly increasing no matter how far the lagging counter trails.
+     */
+    @Test
+    void staysMonotonicAcrossInterleavedCounters() {
+        var clock = new SectionFrameClock();
+        int previous = clock.next(100);
+        for (int i = 0; i < 50; i++) {
+            int terrain = clock.next(100 + i);
+            int shadow = clock.next(i);
+            assertTrue(terrain > previous);
+            assertTrue(shadow > terrain);
+            previous = shadow;
+        }
+    }
+
+    /**
+     * Motivation: {@code last + 1} overflows at {@link Integer#MAX_VALUE}; the clock must
+     * saturate there instead of emitting a negative frame that would regress the sequence.
+     */
+    @Test
+    void saturatesAtMaxValueInsteadOfOverflowing() {
+        var clock = new SectionFrameClock();
+        assertEquals(Integer.MAX_VALUE, clock.next(Integer.MAX_VALUE));
+        assertEquals(Integer.MAX_VALUE, clock.next(Integer.MAX_VALUE));
+        assertEquals(Integer.MAX_VALUE, clock.next(0));
+    }
+}

--- a/src/test/java/org/embeddedt/embeddium/impl/render/chunk/map/ChunkTrackerReconcileTest.java
+++ b/src/test/java/org/embeddedt/embeddium/impl/render/chunk/map/ChunkTrackerReconcileTest.java
@@ -1,0 +1,114 @@
+package org.embeddedt.embeddium.impl.render.chunk.map;
+
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
+import org.embeddedt.embeddium.impl.util.PositionUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ChunkTrackerReconcileTest {
+    @Test
+    void worldChunksUnknownToTrackerBecomeReadyOnceNeighborsSatisfyRadius() {
+        ChunkTracker tracker = new ChunkTracker(1);
+        ChunkTracker.Subscription subscription = tracker.subscribe();
+
+        tracker.reconcile(loadedArea(10, 20));
+
+        assertEquals(9, tracker.getReadyChunks().size());
+        assertEquals(readyEvents("load:", 10, 20), sortedDrain(subscription));
+    }
+
+    @Test
+    void trackerChunksMissingFromWorldAreRemoved() {
+        ChunkTracker tracker = new ChunkTracker(1);
+        ChunkTracker.Subscription subscription = tracker.subscribe();
+
+        tracker.reconcile(loadedArea(10, 20));
+        drain(subscription);
+        assertEquals(9, tracker.getReadyChunks().size());
+
+        tracker.reconcile(new LongOpenHashSet());
+
+        assertTrue(tracker.getReadyChunks().isEmpty());
+        assertEquals(readyEvents("unload:", 10, 20), sortedDrain(subscription));
+    }
+
+    @Test
+    void reconcileIsIdempotent() {
+        ChunkTracker tracker = new ChunkTracker(1);
+        ChunkTracker.Subscription subscription = tracker.subscribe();
+
+        LongSet loaded = loadedArea(10, 20);
+        tracker.reconcile(loaded);
+        assertEquals(9, drain(subscription).size());
+
+        tracker.reconcile(loaded);
+        tracker.reconcile(loaded);
+
+        assertEquals(List.of(), drain(subscription));
+        assertEquals(9, tracker.getReadyChunks().size());
+    }
+
+    @Test
+    void isolatedChunkDoesNotBecomeReadyWithoutNeighbors() {
+        ChunkTracker tracker = new ChunkTracker(1);
+        ChunkTracker.Subscription subscription = tracker.subscribe();
+
+        LongSet isolated = new LongOpenHashSet();
+        isolated.add(PositionUtil.packChunk(10, 20));
+        tracker.reconcile(isolated);
+
+        assertTrue(tracker.getReadyChunks().isEmpty());
+        assertEquals(List.of(), drain(subscription));
+
+        // The isolated chunk was still registered: once its neighbors appear, readiness resolves normally.
+        tracker.reconcile(loadedArea(10, 20));
+        assertEquals(9, tracker.getReadyChunks().size());
+        assertEquals(9, drain(subscription).size());
+    }
+
+    /**
+     * A 5x5 square of loaded chunks around the center; with neighbor radius 1 exactly the
+     * inner 3x3 chunks satisfy the readiness gate.
+     */
+    private static LongSet loadedArea(int centerX, int centerZ) {
+        LongSet keys = new LongOpenHashSet();
+        for (int x = centerX - 2; x <= centerX + 2; x++) {
+            for (int z = centerZ - 2; z <= centerZ + 2; z++) {
+                keys.add(PositionUtil.packChunk(x, z));
+            }
+        }
+        return keys;
+    }
+
+    private static List<String> readyEvents(String prefix, int centerX, int centerZ) {
+        List<String> events = new ArrayList<>();
+        for (int x = centerX - 1; x <= centerX + 1; x++) {
+            for (int z = centerZ - 1; z <= centerZ + 1; z++) {
+                events.add(prefix + x + "," + z);
+            }
+        }
+        events.sort(null);
+        return events;
+    }
+
+    private static List<String> sortedDrain(ChunkTracker.Subscription subscription) {
+        List<String> events = drain(subscription);
+        events.sort(null);
+        return events;
+    }
+
+    private static List<String> drain(ChunkTracker.Subscription subscription) {
+        List<String> events = new ArrayList<>();
+        subscription.forEachEvent(
+            (x, z) -> events.add("load:" + x + "," + z),
+            (x, z) -> events.add("unload:" + x + "," + z)
+        );
+        return events;
+    }
+}

--- a/src/test/java/org/embeddedt/embeddium/impl/render/chunk/occlusion/OcclusionCullerRenderDistanceTest.java
+++ b/src/test/java/org/embeddedt/embeddium/impl/render/chunk/occlusion/OcclusionCullerRenderDistanceTest.java
@@ -1,0 +1,92 @@
+package org.embeddedt.embeddium.impl.render.chunk.occlusion;
+
+import org.embeddedt.embeddium.impl.render.viewport.CameraTransform;
+import org.embeddedt.embeddium.impl.render.viewport.Viewport;
+import org.joml.Vector3d;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The chunk search must be bounded by horizontal distance only: vanilla 1.12
+ * has no vertical cutoff, and mods such as Depths Update can extend the world
+ * height, so a fixed vertical truncation would wrongly drop in-bounds terrain
+ * directly below or above the camera.
+ */
+class OcclusionCullerRenderDistanceTest {
+    // 12-chunk render distance, in blocks.
+    private static final float MAX_DISTANCE = 12 * 16.0f;
+
+    @Test
+    void sectionFarBelowCameraIsWithinRenderDistance() {
+        // Camera at Y=1024 with a section directly underneath at the bottom of the world.
+        CameraTransform camera = new CameraTransform(8.0, 1024.0, 8.0);
+
+        assertTrue(OcclusionCuller.isWithinRenderDistance(camera, 0, 0, 0, MAX_DISTANCE));
+    }
+
+    @Test
+    void sectionFarAboveCameraIsWithinRenderDistance() {
+        CameraTransform camera = new CameraTransform(8.0, 64.0, 8.0);
+
+        assertTrue(OcclusionCuller.isWithinRenderDistance(camera, 0, 64, 0, MAX_DISTANCE));
+    }
+
+    @Test
+    void sectionBelowZeroInExtendedHeightWorldIsWithinRenderDistance() {
+        // Depths Update style extended height: sections exist below Y=0.
+        CameraTransform camera = new CameraTransform(8.0, 64.0, 8.0);
+
+        assertTrue(OcclusionCuller.isWithinRenderDistance(camera, 0, -32, 0, MAX_DISTANCE));
+    }
+
+    @Test
+    void sectionJustPastFormerVerticalCutoffIsWithinRenderDistance() {
+        // The section's nearest point sits exactly one maxDistance above the
+        // camera; the horizontal test alone must keep it in range.
+        CameraTransform camera = new CameraTransform(8.0, 64.0, 8.0);
+
+        assertTrue(OcclusionCuller.isWithinRenderDistance(camera, 0, 16, 0, MAX_DISTANCE));
+    }
+
+    @Test
+    void horizontallyOutOfRangeSectionIsRejected() {
+        CameraTransform camera = new CameraTransform(8.0, 64.0, 8.0);
+
+        assertFalse(OcclusionCuller.isWithinRenderDistance(camera, 20, 4, 0, MAX_DISTANCE));
+    }
+
+    @Test
+    void regionFarBelowCameraPassesDistanceTest() {
+        // Region directly underneath a high camera; only the horizontal
+        // distance may reject it.
+        RegionCullCache cache = beginCache(8.0, 1024.0, 8.0);
+
+        assertEquals(RegionCullCache.PARTIAL_DISTANCE_IN, cache.classify(0, 0, 0, 0));
+    }
+
+    @Test
+    void regionBelowZeroInExtendedHeightWorldPassesDistanceTest() {
+        RegionCullCache cache = beginCache(8.0, 64.0, 8.0);
+
+        assertEquals(RegionCullCache.PARTIAL_DISTANCE_IN, cache.classify(0, 0, -512, 0));
+    }
+
+    @Test
+    void horizontallyDistantRegionIsOutside() {
+        RegionCullCache cache = beginCache(8.0, 64.0, 8.0);
+
+        assertEquals(RegionCullCache.OUTSIDE, cache.classify(0, 1024, 0, 0));
+    }
+
+    // A frustum that reports everything visible keeps the region
+    // classification focused on the distance test alone.
+    private static RegionCullCache beginCache(double x, double y, double z) {
+        Viewport viewport = new Viewport((minX, minY, minZ, maxX, maxY, maxZ) -> true, new Vector3d(x, y, z));
+        RegionCullCache cache = new RegionCullCache();
+        cache.begin(viewport, MAX_DISTANCE, 1);
+        return cache;
+    }
+}


### PR DESCRIPTION
## 改了什么

三个独立提交，修复两类区块渲染/加载缺陷：

1. **fix(terrain): drop vertical render-distance cutoff** — 区块遮挡搜索移除了沿自 Sodium 的圆柱体视距中的垂直截断项（section 级 `OcclusionCuller.isWithinRenderDistance` 与 region 级 `RegionCullCache.compute`），只保留水平圆形距离判定，与 vanilla 1.12.2 行为对齐。
2. **fix(terrain): unify section frame clock and release tokens of discarded builds** — `RenderSectionManager` 两个入口（`update`/`updateForShadowPass`）的外部帧号统一经新增的 `SectionFrameClock` 归一化为严格递增序列；`filterChunkBuildResults` 丢弃「过期」结果时补放 `buildCancellationToken` 并输出 WARN 日志。
3. **fix(terrain): reconcile chunk tracker with loaded chunks** — `ChunkTracker.reconcile()` 每 client tick 与 `ChunkProviderClient.loadedChunks` 对账，经原有事件通道重放差异（稳态下 diff 为空、零事件）。

## 为什么改

- **高空地形不渲染（稳定复现）**：开光影飞高后地形完全不渲染、靠近地面恢复。根因是垂直截断：相机高出地面超过 `renderDistance × 16` 格后正下方地形被整片裁掉，渲染列表清空且 INITIAL_BUILD 停止收集。vanilla 1.12.2 无垂直视距裁剪；且 Depths Update 等模组可扩展世界高度（本仓库已有 `DepthsUpdateCompat`），任何固定垂直截断在扩展高度世界同样错误。
- **跑图整片区块不加载、靠近不触发、重进恢复（不稳定复现）**：帧时钟混用（主 pass 的 vanilla `frameCount` vs 阴影 pass 自建且管线重建即归零的 `celeritasShadowFrame`）导致 lattice 访问戳毒化（搜索永久跳过 cell）与构建结果误丢后 token 泄漏（`buildInFlight` 卡死、section 永不再被收集）。另对 `ChunkTracker` 与世界加载集可能脱节（非 full-chunk 包、模组绕过 `loadChunk` 直写）增加了对账自愈。

## 如何验证

- `./gradlew check --no-daemon` 与 `./gradlew build --no-daemon` 全绿（含 remap jar 结构校验、compatBridge 契约测试、模块边界校验）。
- 新增 3 个测试类共 18 个用例（TDD 先行）：`OcclusionCullerRenderDistanceTest`（高空/负高度/水平超界）、`SectionFrameClockTest`（单调性/回退/饱和）、`ChunkTrackerReconcileTest`（补缺失/清多余/幂等/孤立不就绪）。
- dev 实机回归（维护者验证）：开光影高空飞行地形持续渲染；同高度无光影对照正常；光影开关/重载与常规跑图无回归。

## 兼容性

- HBM-CE（NTM-CE）mixin 注入面已反编译 dev 依赖 jar 复核：`OcclusionCuller` legacy object-node API 与 `RenderSectionManager.update()` 的 CameraTransform getfield 内联均原样保留，`HbmCameraRedirectContractTest` 通过。
- compatBridge 未改动，`CeleritasCompatBridgeJarTest` 通过。
- 无光影包特定改动；fog occlusion 的水平距离收缩行为不变。

## 相关 issue

- #43（Caves Not Cliffs 高度扩展模组渲染错误）可能与本修复同源，未实机确认，暂不关联关闭。