### PR TITLE
fix(glsm): answer enable-cap glGet queries from tracked state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ gradle-app.setting
 
 # Mesa EGL/GLES DLLs for the (deferred) JMH GL benchmark harness; not committed.
 celeritas-common/jmh-natives/
+/.tools/

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -924,6 +924,38 @@ public class GLStateManager {
         };
     }
 
+    /**
+     * Whether the pname is an enable capability tracked by {@link #glIsEnabled}. Compatibility
+     * GL allows querying enable caps through glGetInteger/glGetFloat, but the core-profile
+     * backend rejects them; legacy mods (e.g. OreLib OpenGlState, issue #41) query caps this
+     * way, so the glGet* variants answer from tracked state instead of forwarding.
+     */
+    private static boolean isEnableCap(int pname) {
+        return switch (pname) {
+            case GL11.GL_ALPHA_TEST, GL11.GL_AUTO_NORMAL, GL11.GL_BLEND, GL11.GL_COLOR_MATERIAL,
+                    GL11.GL_COLOR_LOGIC_OP, GL11.GL_CULL_FACE, GL11.GL_DEPTH_TEST, GL11.GL_DITHER,
+                    GL11.GL_FOG, GL11.GL_INDEX_LOGIC_OP, GL11.GL_LIGHTING, GL11.GL_LIGHT0,
+                    GL11.GL_LIGHT1, GL11.GL_LIGHT2, GL11.GL_LIGHT3, GL11.GL_LIGHT4, GL11.GL_LIGHT5,
+                    GL11.GL_LIGHT6, GL11.GL_LIGHT7, GL11.GL_LINE_SMOOTH, GL11.GL_LINE_STIPPLE,
+                    GL11.GL_MAP1_COLOR_4, GL11.GL_MAP1_INDEX, GL11.GL_MAP1_NORMAL,
+                    GL11.GL_MAP1_TEXTURE_COORD_1, GL11.GL_MAP1_TEXTURE_COORD_2,
+                    GL11.GL_MAP1_TEXTURE_COORD_3, GL11.GL_MAP1_TEXTURE_COORD_4,
+                    GL11.GL_MAP1_VERTEX_3, GL11.GL_MAP1_VERTEX_4, GL11.GL_MAP2_COLOR_4,
+                    GL11.GL_MAP2_INDEX, GL11.GL_MAP2_NORMAL, GL11.GL_MAP2_TEXTURE_COORD_1,
+                    GL11.GL_MAP2_TEXTURE_COORD_2, GL11.GL_MAP2_TEXTURE_COORD_3,
+                    GL11.GL_MAP2_TEXTURE_COORD_4, GL11.GL_MAP2_VERTEX_3, GL11.GL_MAP2_VERTEX_4,
+                    GL13.GL_MULTISAMPLE, GL11.GL_NORMALIZE, GL11.GL_POINT_SMOOTH,
+                    GL11.GL_POLYGON_OFFSET_POINT, GL11.GL_POLYGON_OFFSET_LINE,
+                    GL11.GL_POLYGON_OFFSET_FILL, GL11.GL_POLYGON_SMOOTH, GL11.GL_POLYGON_STIPPLE,
+                    GL12.GL_RESCALE_NORMAL, GL13.GL_SAMPLE_ALPHA_TO_COVERAGE,
+                    GL13.GL_SAMPLE_ALPHA_TO_ONE, GL13.GL_SAMPLE_COVERAGE, GL11.GL_SCISSOR_TEST,
+                    GL11.GL_STENCIL_TEST, GL11.GL_TEXTURE_1D, GL11.GL_TEXTURE_2D,
+                    GL12.GL_TEXTURE_3D, GL11.GL_TEXTURE_GEN_S, GL11.GL_TEXTURE_GEN_T,
+                    GL11.GL_TEXTURE_GEN_R, GL11.GL_TEXTURE_GEN_Q -> true;
+            default -> false;
+        };
+    }
+
     public static boolean glGetBoolean(int pname) {
         if (shouldBypassCache()) {
             return RENDER_BACKEND.getBoolean(pname);
@@ -1036,6 +1068,10 @@ public class GLStateManager {
             return RENDER_BACKEND.getInteger(pname);
         }
 
+        if (isEnableCap(pname)) {
+            return glIsEnabled(pname) ? GL11.GL_TRUE : GL11.GL_FALSE;
+        }
+
         return switch (pname) {
             case GL11.GL_ALPHA_TEST_FUNC -> alphaState.getFunction();
             case GL11.GL_DEPTH_FUNC -> depthState.getFunc();
@@ -1060,6 +1096,11 @@ public class GLStateManager {
             case GL14.GL_BLEND_SRC_RGB -> blendState.getSrcRgb();
             case GL14.GL_BLEND_EQUATION -> blendState.getEquationRgb();
             case GL20.GL_BLEND_EQUATION_ALPHA -> blendState.getEquationAlpha();
+
+            // Legacy blend-factor aliases (GL_BLEND_SRC/GL_BLEND_DST) differ from the GL14 RGB
+            // tokens and are rejected by the core-profile backend; map to the RGB factors.
+            case GL11.GL_BLEND_SRC -> blendState.getSrcRgb();
+            case GL11.GL_BLEND_DST -> blendState.getDstRgb();
 
             case GL11.GL_LOGIC_OP_MODE -> logicOpMode.getValue();
             case GL11.GL_DRAW_BUFFER -> drawBuffer.getValue();
@@ -1211,6 +1252,10 @@ public class GLStateManager {
     }
 
     public static float glGetFloat(int pname) {
+        if (isEnableCap(pname)) {
+            return glIsEnabled(pname) ? 1.0F : 0.0F;
+        }
+
         return switch (pname) {
             case GL11.GL_ALPHA_TEST_REF -> alphaState.getReference();
             case GL11.GL_FOG_DENSITY -> fogState.getDensity();
@@ -2235,6 +2280,20 @@ public class GLStateManager {
         final int textureUnit = getActiveTextureUnit();
         postTextureUnitState(textureUnit, false);
         textures.getTextureUnitStates(textureUnit).disable();
+    }
+
+    /**
+     * Force-syncs a texture unit's GL_TEXTURE_2D enable state and notifies TEXTURE_UNIT_STATE
+     * listeners. For render paths that restore captured state (e.g. DeferredDrawBatcher) where
+     * setting the state directly would silently desync Iris pipeline input tracking (issue #41).
+     */
+    public static void setTexture2DEnabled(int textureUnit, boolean enabled) {
+        final TextureUnitBooleanStateStack state = textures.getTextureUnitStates(textureUnit);
+        if (!shouldBypassCache() && state.isEnabled() == enabled) {
+            return;
+        }
+        postTextureUnitState(textureUnit, enabled);
+        state.setEnabled(enabled);
     }
 
     private static void postTextureUnitState(int textureUnit, boolean enabled) {

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/debug/GLSMDebug.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/debug/GLSMDebug.java
@@ -21,6 +21,7 @@ import static com.gtnewhorizon.gtnhlib.bytebuf.MemoryUtilities.memGetInt;
 public final class GLSMDebug {
     private static final Logger LOGGER = LogManager.getLogger("GLSMDebug");
     private static final boolean ENABLE_VERBOSE_DRAW_LOGS = Boolean.getBoolean("actinium.glsm.verboseDrawLogs");
+    private static final boolean ENABLE_GL_DEBUG_SYS_PROP = Boolean.getBoolean("actinium.glDebug");
     private static final long OPTION_REFRESH_NS = 500_000_000L;
     private static final int STREAM_LIMIT = 128;
     private static final int QUAD_LIMIT = 512;
@@ -29,6 +30,7 @@ public final class GLSMDebug {
     private static final int CLIENT_ARRAY_LIMIT = 64;
     private static final int BUFFER_BUILDER_LIMIT = 512;
     private static final int VERTEX_BUFFER_LIMIT = 256;
+    private static final int PROGRAM_DRAW_LIMIT = 1024;
 
     private static final AtomicInteger streamCount = new AtomicInteger();
     private static final AtomicInteger quadCount = new AtomicInteger();
@@ -37,6 +39,7 @@ public final class GLSMDebug {
     private static final AtomicInteger clientArrayCount = new AtomicInteger();
     private static final AtomicInteger bufferBuilderCount = new AtomicInteger();
     private static final AtomicInteger vertexBufferCount = new AtomicInteger();
+    private static final AtomicInteger programDrawCount = new AtomicInteger();
 
     private static long lastOptionRefresh;
     private static boolean cachedEnabled;
@@ -255,6 +258,26 @@ public final class GLSMDebug {
             format);
     }
 
+    /**
+     * Logs an immediate-mode/streaming draw that lands on a non-zero (shader pipeline) program.
+     * Used to diagnose mod content (e.g. Dynamic Surroundings popoffs) rendering through Iris passes.
+     */
+    public static void logDrawOnActiveProgram(String path, int drawMode, int flags, int vertexCount, int program) {
+        if (!shouldLogWorldRender()) return;
+        final int count = programDrawCount.incrementAndGet();
+        if (count > PROGRAM_DRAW_LIMIT) return;
+
+        LOGGER.info(
+            "program-draw #{} path={} program={} mode={} flags=0x{} vertices={} attribs=[{}]",
+            count,
+            path,
+            program,
+            drawModeName(drawMode),
+            Integer.toHexString(flags),
+            vertexCount,
+            attributeSummary());
+    }
+
     public static boolean forceOrphanStreaming() {
         return isEnabled();
     }
@@ -280,7 +303,7 @@ public final class GLSMDebug {
     }
 
     private static boolean shouldLogWorldRender() {
-        return ENABLE_VERBOSE_DRAW_LOGS && isEnabled() && "Client thread".equals(Thread.currentThread().getName()) && isWorldLoaded();
+        return ENABLE_VERBOSE_DRAW_LOGS && (isEnabled() || ENABLE_GL_DEBUG_SYS_PROP) && "Client thread".equals(Thread.currentThread().getName()) && isWorldLoaded();
     }
 
     private static boolean isWorldLoaded() {

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/streaming/TessellatorStreamingDrawer.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/streaming/TessellatorStreamingDrawer.java
@@ -302,6 +302,12 @@ public class TessellatorStreamingDrawer {
             packed);
         }
         GLStateManager.prepareWideLineEmulation(drawMode);
+        if (DEBUG_STREAMING_DRAWS) {
+            final int activeProgram = GLStateManager.getActiveProgram();
+            if (activeProgram != 0) {
+                GLSMDebug.logDrawOnActiveProgram("stream", drawMode, flags, vertexCount, activeProgram);
+            }
+        }
         final long preDrawStart = perfSampled ? GLSMPerfDebug.now() : 0L;
         ShaderManager.getInstance().preDraw(flags);
         if (perfSampled) {

--- a/src/main/java/com/gtnewhorizons/angelica/client/rendering/DeferredDrawBatcher.java
+++ b/src/main/java/com/gtnewhorizons/angelica/client/rendering/DeferredDrawBatcher.java
@@ -471,8 +471,10 @@ public final class DeferredDrawBatcher {
         boolean tex0Enabled = unpackTex0Enabled(key);
         boolean tex1Enabled = unpackTex1Enabled(key);
 
-        GLStateManager.getTextures().getTextureUnitStates(0).setEnabled(tex0Enabled);
-        GLStateManager.getTextures().getTextureUnitStates(1).setEnabled(tex1Enabled);
+        // Route through GLStateManager so texture-unit enable changes post TEXTURE_UNIT_STATE;
+        // bypassing the event silently desyncs Iris pipeline input tracking (issue #41).
+        GLStateManager.setTexture2DEnabled(0, tex0Enabled);
+        GLStateManager.setTexture2DEnabled(1, tex1Enabled);
         GLStateManager.glBindTexture(GL11.GL_TEXTURE_2D, textureId);
         GLStateManager.glBlendFunc(srcRgb, dstRgb);
         if (blendEnabled) {


### PR DESCRIPTION
## 改了什么

- `GLStateManager.glGetInteger` / `glGetFloat` 对 enable 能力位（`GL_TEXTURE_2D`、`GL_BLEND` 等全部 `glIsEnabled` 覆盖的 cap）改为从 glsm 跟踪状态应答（新增 `isEnableCap`），与兼容 profile 语义一致；core profile 后端本拒绝这些 pname，此前转发真实 GL 恒返回 0。
- 补 `GL_BLEND_SRC` / `GL_BLEND_DST` 旧式别名（0x0BE1/0x0BE0）映射到 RGB 混合因子，避免保存值被读成 0 后恢复成 `blendFunc(0, 0)`。
- 新增 `GLStateManager.setTexture2DEnabled(unit, enabled)`；`DeferredDrawBatcher.applyStateKey` 改走该路径，恢复纹理单元开关时补发 `TEXTURE_UNIT_STATE` 事件（原来直接改状态不发事件，Iris 输入追踪会静默脱钩——同类隐患）。
- 附带诊断能力：`actinium.glDebug` sysprop 无需游戏内选项即可开启世界渲染调试日志；streaming 绘制落在光影 program 上时记录 `program-draw` 日志。

## 为什么（根因）

OreLib（Dynamic Surroundings 依赖）的 `OpenGlState.push()` 用 `glGetInteger(GL_TEXTURE_2D)` 等非法方式查询状态保存现场。兼容 profile 下该查询合法，但 Actinium 的 core profile 后端拒绝，glsm 此前直接转发 → 恒返回 0 → OreLib 认为纹理处于关闭 → `pop()` 时**无条件 `disableTexture2D()`** → Iris 输入追踪认为 unit-0 无纹理 → 当帧剩余 pass（雨、粒子、手、半透明地形、世界边界）全部错配**无纹理程序变体** → 白屏。

这解释了 #41 的触发条件：**打怪**（伤害数字 popoff 每帧执行 push/pop 制造污染）+ **下雨**（错配的雨 quad 满屏无纹理渲染形成白屏洗刷，前景雨 quad 还会把动物涂成白色剪影）；只打怪时仅手/手持物变白（与 issue 评论一致）。日志实证：污染帧与 OreLib 首次重定向同帧同秒，PARTICLES 96→95、RAIN_SNOW 139→93/95、HAND→131/133 错配序列完整。

## 如何验证

- `./gradlew build --no-daemon` 通过（含 `check` 全部测试与 remap jar 契约测试）。
- dev 客户端回归：ComplementaryUnbound r5.5.1 + DynamicSurroundings 3.6.3.0BETA + OreLib 3.6.0.1，`/weather rain` 下打怪触发伤害数字——修复前稳定白屏（雨 quad 无纹理洗刷、手与动物变白），修复后雨丝纹理正常、不再白屏、popoff 消失后画面保持正常。

Closes #41
