### PR TITLE
perf(glsm): fix per-draw client-array re-uploads collapsing GUI/F3 frame rate

### DIFF
--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -1295,13 +1295,13 @@ public class GLStateManager {
     }
 
     private static void postVanillaBlendChange() {
-        if (GLSMHooks.VANILLA_BLEND_CHANGE.hasListeners()) {
+        if (GLSMHooks.hasActiveConsumers() && GLSMHooks.VANILLA_BLEND_CHANGE.hasListeners()) {
             GLSMHooks.VANILLA_BLEND_CHANGE.post(GLSMHooks.vanillaBlendChangeEvent);
         }
     }
 
     private static boolean snapshotVanillaBlendFunc() {
-        if (!GLSMHooks.VANILLA_BLEND_CHANGE.hasListeners()) {
+        if (!GLSMHooks.hasActiveConsumers() || !GLSMHooks.VANILLA_BLEND_CHANGE.hasListeners()) {
             return false;
         }
         blendState.readEffective(vanillaBlendBefore);
@@ -4631,7 +4631,7 @@ public class GLStateManager {
             if (caching) {
                 activeProgram = 0; // Track that FFP was requested
             }
-            if (GLSMHooks.PROGRAM_CHANGE.hasListeners()) {
+            if (GLSMHooks.hasActiveConsumers() && GLSMHooks.PROGRAM_CHANGE.hasListeners()) {
                 GLSMHooks.programChangeEvent.previousProgram = prev;
                 GLSMHooks.programChangeEvent.newProgram = 0;
                 GLSMHooks.programChangeEvent.postBind = false;
@@ -4639,7 +4639,7 @@ public class GLStateManager {
             }
             recordGpuCommand(GpuCommandType.PROGRAM_USE, program, 0);
             ffp.activate();
-            if (GLSMHooks.PROGRAM_CHANGE.hasListeners()) {
+            if (GLSMHooks.hasActiveConsumers() && GLSMHooks.PROGRAM_CHANGE.hasListeners()) {
                 GLSMHooks.programChangeEvent.previousProgram = prev;
                 GLSMHooks.programChangeEvent.newProgram = 0;
                 GLSMHooks.programChangeEvent.postBind = true;
@@ -4659,7 +4659,7 @@ public class GLStateManager {
             if (caching) {
                 activeProgram = program;
             }
-            if (GLSMHooks.PROGRAM_CHANGE.hasListeners()) {
+            if (GLSMHooks.hasActiveConsumers() && GLSMHooks.PROGRAM_CHANGE.hasListeners()) {
                 GLSMHooks.programChangeEvent.previousProgram = prev;
                 GLSMHooks.programChangeEvent.newProgram = program;
                 GLSMHooks.programChangeEvent.postBind = false;
@@ -4672,7 +4672,7 @@ public class GLStateManager {
             recordGpuCommand(GpuCommandType.PROGRAM_USE, program, 0);
             RENDER_BACKEND.useProgram(program);
             CompatUniformManager.onUseProgram(program);
-            if (GLSMHooks.PROGRAM_CHANGE.hasListeners()) {
+            if (GLSMHooks.hasActiveConsumers() && GLSMHooks.PROGRAM_CHANGE.hasListeners()) {
                 GLSMHooks.programChangeEvent.previousProgram = prev;
                 GLSMHooks.programChangeEvent.newProgram = program;
                 GLSMHooks.programChangeEvent.postBind = true;

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/GLStateManager.java
@@ -126,6 +126,8 @@ public class GLStateManager {
 
     public static final Logger LOGGER = LogManager.getLogger("GLSM");
     private static final boolean DEBUG_DRAW_LOGS = Boolean.getBoolean("actinium.glsm.verboseDrawLogs");
+    /** Escape hatch: -Dactinium.glsmFullClientArrayUpload=true restores whole-allocation uploads per draw. */
+    private static final boolean FULL_CLIENT_ARRAY_UPLOAD = Boolean.getBoolean("actinium.glsmFullClientArrayUpload");
 
     // Thread Checking - must be early in static init order so isMainThread() works for state initialization
     @Getter private static final Thread MainThread = Thread.currentThread();
@@ -434,6 +436,7 @@ public class GLStateManager {
     private static int clientArraysVBO = 0;
     private static int clientArraysVBOCapacity = 0;
     private static final int[] clientArraysVBOOffsets = new int[VertexAttribState.MAX_ATTRIBS];
+    private static final int[] clientArraysVBOUploadLengths = new int[VertexAttribState.MAX_ATTRIBS];
     private static int boundPixelUnpackBuffer;
     private static int boundPixelPackBuffer;
     private static final Int2IntOpenHashMap vaoEboMap = new Int2IntOpenHashMap();
@@ -2517,7 +2520,7 @@ public class GLStateManager {
     public static void glDrawArraysInstanced(int mode, int first, int count, int primcount) {
         prepareWideLineEmulation(mode);
         preDrawFFP();
-        prepareClientArrays();
+        prepareClientArrays(first, count);
         recordGpuCommand(GpuCommandType.DRAW_ARRAYS, mode, count);
         if (mode == GL11.GL_QUADS) {
             QuadConverter.drawQuadsAsTrianglesInstanced(first, count, primcount);
@@ -2548,10 +2551,14 @@ public class GLStateManager {
     }
 
     private static void prepareClientArrays() {
+        prepareClientArrays(0, -1);
+    }
+
+    private static void prepareClientArrays(int first, int count) {
         final boolean perfDebugEnabled = GLSMPerfDebug.isEnabled();
         final long perfStart = perfDebugEnabled ? GLSMPerfDebug.begin(GLSMPerfDebug.Stage.GL_PREPARE_CLIENT_ARRAYS) : 0L;
         if (ShaderManager.getInstance().isEnabled() && VertexAttribState.hasAnyClientSideEnabledAttrib()) {
-            uploadClientArraysToVBO();
+            uploadClientArraysToVBO(first, count);
         }
         if (perfDebugEnabled) {
             GLSMPerfDebug.end(GLSMPerfDebug.Stage.GL_PREPARE_CLIENT_ARRAYS, perfStart);
@@ -2559,19 +2566,27 @@ public class GLStateManager {
     }
 
     /**
-     * If any enabled vertex attribute uses a client-side pointer (no VBO), upload all such
-     * attribs into a shared stream VBO so the draw succeeds under core profile.
+     * If any enabled vertex attribute uses a client-side pointer (no VBO), upload such attribs
+     * into a shared stream VBO so the draw succeeds under core profile. When the draw's vertex
+     * range [first, first + count) is known (count >= 0), each attrib is narrowed to the bytes
+     * that range can actually read; the captured client pointer spans the whole underlying
+     * allocation, which can be megabytes larger than one draw needs. Indexed draws with an
+     * unknown maximum index pass count = -1 and keep the full-allocation upload.
      */
-    private static void uploadClientArraysToVBO() {
+    private static void uploadClientArraysToVBO(int first, int count) {
         final boolean perfDebugEnabled = GLSMPerfDebug.isEnabled();
         final long perfStart = perfDebugEnabled ? GLSMPerfDebug.begin(GLSMPerfDebug.Stage.GL_CLIENT_ARRAY_UPLOAD) : 0L;
+        final boolean fullUpload = FULL_CLIENT_ARRAY_UPLOAD || count < 0;
         int totalBytes = 0;
         for (int i = 0; i < VertexAttribState.MAX_ATTRIBS; i++) {
             clientArraysVBOOffsets[i] = -1;
             final VertexAttribState.Attrib a = VertexAttribState.get(i);
             if (!a.enabled || a.clientPointer == null) continue;
+            final int uploadLength = fullUpload ? a.clientPointer.remaining()
+                : VertexAttribState.computeUploadLength(a, first, count);
+            clientArraysVBOUploadLengths[i] = uploadLength;
             clientArraysVBOOffsets[i] = totalBytes;
-            totalBytes += a.clientPointer.remaining();
+            totalBytes += uploadLength;
         }
         if (totalBytes == 0) {
             if (perfDebugEnabled) {
@@ -2600,13 +2615,16 @@ public class GLStateManager {
         for (int i = 0; i < VertexAttribState.MAX_ATTRIBS; i++) {
             if (clientArraysVBOOffsets[i] < 0) continue;
             final VertexAttribState.Attrib a = VertexAttribState.get(i);
-            RENDER_BACKEND.bufferSubData(GL15.GL_ARRAY_BUFFER, clientArraysVBOOffsets[i], a.clientPointer.duplicate());
+            final ByteBuffer slice = a.clientPointer.duplicate();
+            slice.limit(slice.position() + clientArraysVBOUploadLengths[i]);
+            RENDER_BACKEND.bufferSubData(GL15.GL_ARRAY_BUFFER, clientArraysVBOOffsets[i], slice);
             RENDER_BACKEND.vertexAttribPointer(i, a.size, a.type, a.normalized, a.stride, (long) clientArraysVBOOffsets[i]);
         }
 
         glBindBuffer(GL15.GL_ARRAY_BUFFER, savedVBO);
         if (perfDebugEnabled) {
             GLSMPerfDebug.end(GLSMPerfDebug.Stage.GL_CLIENT_ARRAY_UPLOAD, perfStart);
+            GLSMPerfDebug.countClientArrayUpload(totalBytes);
         }
     }
 
@@ -2628,7 +2646,7 @@ public class GLStateManager {
         }
         prepareWideLineEmulation(mode);
         preDrawFFP();
-        prepareClientArrays();
+        prepareClientArrays(first, count);
         if (DEBUG_DRAW_LOGS) {
             GLSMDebug.logDrawArrays("draw-arrays", mode, first, count);
         }

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/debug/GLSMPerfDebug.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/debug/GLSMPerfDebug.java
@@ -12,6 +12,7 @@ public final class GLSMPerfDebug {
     private static final long REPORT_INTERVAL_NS = 1_000_000_000L;
     private static final int SAMPLE_MASK = 255;
     private static final int MAX_BUFFERBUILDER_SOURCE_LINES = 12;
+    private static final int MAX_CLIENT_ARRAY_STACK_LINES = 12;
     private static final String ENABLED_OVERRIDE = System.getProperty("actinium.glsmPerfDebug");
     private static volatile boolean enabled = resolveEnabled(ENABLED_OVERRIDE, false);
 
@@ -71,6 +72,7 @@ public final class GLSMPerfDebug {
     private static final int[] sourceCounts = new int[Source.values().length];
     private static final Map<String, Integer> bufferBuilderSourceCounts = new HashMap<>();
     private static final Map<String, Integer> bufferBuilderStackSamples = new HashMap<>();
+    private static final Map<String, Integer> clientArrayStackSamples = new HashMap<>();
     private static long fenceReclaimedBytes;
     private static int fenceReclaimedRegions;
     private static int fenceQueuePeak;
@@ -110,6 +112,7 @@ public final class GLSMPerfDebug {
         Arrays.fill(sourceCounts, 0);
         bufferBuilderSourceCounts.clear();
         bufferBuilderStackSamples.clear();
+        clientArrayStackSamples.clear();
         fenceReclaimedBytes = 0L;
         fenceReclaimedRegions = 0;
         fenceQueuePeak = 0;
@@ -147,6 +150,20 @@ public final class GLSMPerfDebug {
         if ((observed & SAMPLE_MASK) == 0) {
             final String stackKey = sourceKey + "/" + findBufferBuilderCaller() + "/vertices~" + bucketVertexCount(vertexCount);
             bufferBuilderStackSamples.put(stackKey, bufferBuilderStackSamples.getOrDefault(stackKey, 0) + 1);
+        }
+    }
+
+    /**
+     * Attributes a client-array VBO upload to its draw-call origin. Sampled at the same cadence
+     * as the stage timer; the key carries the first non-glsm caller and a power-of-two bucket of
+     * the uploaded byte total, so the periodic report shows who drives large uploads.
+     */
+    public static void countClientArrayUpload(int totalBytes) {
+        if (!isEnabled()) return;
+        final int observed = observedCounts[Stage.GL_CLIENT_ARRAY_UPLOAD.ordinal()];
+        if ((observed & SAMPLE_MASK) == 0) {
+            final String stackKey = findClientArrayCaller() + "/bytes~" + bucketVertexCount(totalBytes);
+            clientArrayStackSamples.put(stackKey, clientArrayStackSamples.getOrDefault(stackKey, 0) + 1);
         }
     }
 
@@ -228,6 +245,7 @@ public final class GLSMPerfDebug {
         }
         appendTopEntries(sb, "bufferbuilder.source", bufferBuilderSourceCounts, MAX_BUFFERBUILDER_SOURCE_LINES);
         appendTopEntries(sb, "bufferbuilder.stackSample", bufferBuilderStackSamples, MAX_BUFFERBUILDER_SOURCE_LINES);
+        appendTopEntries(sb, "clientArray.stackSample", clientArrayStackSamples, MAX_CLIENT_ARRAY_STACK_LINES);
         if (fenceReclaimedRegions != 0 || fenceQueuePeak != 0) {
             sb.append(" stream.fence[")
                 .append("reclaimedRegions=").append(fenceReclaimedRegions)
@@ -296,6 +314,28 @@ public final class GLSMPerfDebug {
         return (className.equals("net.minecraft.client.renderer.Tessellator")
             || className.equals("net.minecraft.client.renderer.WorldVertexBufferUploader"))
             && (methodName.equals("draw") || methodName.startsWith("handler$"));
+    }
+
+    /**
+     * Like {@link #findBufferBuilderCaller()} but additionally skips all glsm frames: the
+     * client-array upload is triggered from GLStateManager draw entry points, so the first
+     * interesting frame is the Minecraft/mod code that issued the draw.
+     */
+    private static String findClientArrayCaller() {
+        StackTraceElement[] stack = Thread.currentThread().getStackTrace();
+        for (StackTraceElement element : stack) {
+            String className = element.getClassName();
+            if (className.startsWith("com.gtnewhorizons.angelica.glsm.")
+                || className.startsWith("com.dhj.actinium.render.")
+                || className.startsWith("com.dhj.actinium.mixin.vintage.core.")
+                || className.startsWith("org.taumc.celeritas.impl.render.")
+                || className.startsWith("org.taumc.celeritas.mixin.core.")
+                || className.equals("java.lang.Thread")) {
+                continue;
+            }
+            return shortenClassName(className) + "#" + element.getMethodName();
+        }
+        return "unknown";
     }
 
     private static String shortenClassName(String className) {

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/hooks/GLSMHooks.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/hooks/GLSMHooks.java
@@ -18,6 +18,22 @@ public final class GLSMHooks {
     /** Optional host-owned observer for diagnostics at the native draw boundary. */
     public static DrawCallObserver drawCallObserver;
 
+    /** Escape hatch: -Dactinium.glsmHooksAlwaysActive=true forces the consumer gate on. */
+    private static final boolean ALWAYS_ACTIVE = Boolean.getBoolean("actinium.glsmHooksAlwaysActive");
+
+    /**
+     * Cheap gate for per-call snapshot/event work in GLStateManager hot paths. Written by the
+     * pipeline host (Iris PipelineManager): true while a consumer with observable side effects
+     * (a DeferredWorldRenderingPipeline) is active, false otherwise. Defaults to true so behavior
+     * is unchanged when no host maintains it.
+     */
+    public static volatile boolean consumersActive = true;
+
+    /** Whether hook consumers may act on events, i.e. snapshots and event posts must run. */
+    public static boolean hasActiveConsumers() {
+        return ALWAYS_ACTIVE || consumersActive;
+    }
+
     public static final EventBus<TextureBindEvent> TEXTURE_BIND = EventBus.create(TextureBindEvent.class);
     public static final EventBus<TextureDeleteEvent> TEXTURE_DELETE = EventBus.create(TextureDeleteEvent.class);
     public static final EventBus<TextureUnitStateEvent> TEXTURE_UNIT_STATE = EventBus.create(TextureUnitStateEvent.class);

--- a/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/states/VertexAttribState.java
+++ b/glsm/src/main/java/com/gtnewhorizons/angelica/glsm/states/VertexAttribState.java
@@ -102,6 +102,25 @@ public class VertexAttribState {
     }
 
     /**
+     * Computes how many leading bytes of {@code a.clientPointer} a draw over vertices
+     * [first, first + count) can actually read. The captured pointer deliberately spans the
+     * whole underlying allocation (mods like HBM-CE mutate the Java limit after setting the
+     * pointer), so the Java limit is never consulted; only the draw's first/count may narrow
+     * the range. The last read byte of the final vertex is (first + count - 1) * stride +
+     * vertexSize - 1, which stays correct even for stride smaller than the vertex size.
+     * Negative strides read backwards from the pointer, so they fall back to the full
+     * captured range. The result is always clamped to the captured allocation.
+     */
+    public static int computeUploadLength(Attrib a, int first, int count) {
+        final int remaining = a.clientPointer.remaining();
+        if (count <= 0) return 0;
+        if (a.stride < 0) return remaining;
+        final int stride = a.stride > 0 ? a.stride : a.size * a.typeSizeBytes();
+        final long lastByteExclusive = (long) (first + count - 1) * stride + (long) a.size * a.typeSizeBytes();
+        return (int) Math.min(remaining, lastByteExclusive);
+    }
+
+    /**
      * Captures the native pointer address without treating the Java buffer limit as its GL
      * allocation boundary. HBM reuses a BufferBuilder allocation and changes its limit between
      * uploads; OpenGL client pointers remain valid for the allocation range.

--- a/shader/src/main/java/net/coderbot/iris/pipeline/PipelineManager.java
+++ b/shader/src/main/java/net/coderbot/iris/pipeline/PipelineManager.java
@@ -2,6 +2,7 @@ package net.coderbot.iris.pipeline;
 
 import net.coderbot.iris.debug.flight.GlFlightRecording;
 import com.gtnewhorizons.angelica.glsm.GLStateManager;
+import com.gtnewhorizons.angelica.glsm.hooks.GLSMHooks;
 import lombok.Getter;
 import net.coderbot.iris.Iris;
 import net.coderbot.iris.gl.framebuffer.MinecraftFramebufferHelper;
@@ -35,6 +36,16 @@ public class PipelineManager {
 
 	public PipelineManager(Function<String, WorldRenderingPipeline> pipelineFactory) {
 		this.pipelineFactory = pipelineFactory;
+		updateGlsmHookConsumers();
+	}
+
+	/**
+	 * Only a DeferredWorldRenderingPipeline consumes the GLSM blend/program events with observable
+	 * side effects; while fixed-function rendering is active the per-call snapshot/post work in
+	 * GLStateManager is skipped entirely.
+	 */
+	private void updateGlsmHookConsumers() {
+		GLSMHooks.consumersActive = pipeline instanceof DeferredWorldRenderingPipeline;
 	}
 
 	public WorldRenderingPipeline preparePipeline(String currentDimension) {
@@ -67,6 +78,7 @@ public class PipelineManager {
 		}
 		pipelineLastUsedNs.put(currentDimension, nowNs);
 
+		updateGlsmHookConsumers();
 		return pipeline;
 	}
 
@@ -145,6 +157,7 @@ public class PipelineManager {
 		pipeline = null;
 		lastPreparedDimension = null;
 		versionCounterForSodiumShaderReload++;
+		updateGlsmHookConsumers();
 
 		// The lazy version-counter cleanup in the terrain shader provider only runs while
 		// shaders are enabled; delete the chunk programs here so disabling shaders does not

--- a/src/main/java/com/dhj/actinium/Actinium.java
+++ b/src/main/java/com/dhj/actinium/Actinium.java
@@ -3,6 +3,7 @@ package com.dhj.actinium;
 import com.dhj.actinium.compat.chunkanimator.ChunkAnimatorCompat;
 import com.dhj.actinium.compat.dh.ActiniumDHIrisCompat;
 import com.dhj.actinium.compat.dh.DistantHorizonsCompat;
+import com.dhj.actinium.compat.MissingModelCompat;
 import com.dhj.actinium.compat.kirino.KirinoCompat;
 import com.dhj.actinium.compat.neofontrender.NeoFontRenderCompat;
 import com.dhj.actinium.command.TogglePassCommand;
@@ -28,6 +29,7 @@ import net.coderbot.iris.compat.dh.DHCompat;
 import net.coderbot.iris.rendertarget.IRenderTargetExt;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.client.resources.IReloadableResourceManager;
 import net.minecraft.launchwrapper.Launch;
 import net.minecraftforge.client.ClientCommandHandler;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
@@ -174,6 +176,9 @@ public class Actinium {
         }
         ChunkAnimatorCompat.install();
         KirinoCompat.install();
+
+        ((IReloadableResourceManager) Minecraft.getMinecraft().getResourceManager())
+                .registerReloadListener(resourceManager -> MissingModelCompat.onResourceManagerReload());
 
         if ((Boolean) Launch.blackboard.get("fml.deobfuscatedEnvironment")) {
             ClientCommandHandler.instance.registerCommand(new TogglePassCommand());

--- a/src/main/java/com/dhj/actinium/compat/MissingModelCompat.java
+++ b/src/main/java/com/dhj/actinium/compat/MissingModelCompat.java
@@ -26,6 +26,19 @@ public final class MissingModelCompat {
     }
 
     /**
+     * Cached vanilla missing-model reference. Resolving it walks a four-deep getter chain through
+     * the block renderer dispatcher, which runs per block render during chunk mesh building; the
+     * reference itself only changes on resource reload, which clears the cache through
+     * {@link #onResourceManagerReload()}. Volatile because chunk meshes are built on worker threads.
+     */
+    private static volatile IBakedModel cachedMissingModel;
+
+    /** Drops the cached missing-model reference so the next check re-resolves it. */
+    public static void onResourceManagerReload() {
+        cachedMissingModel = null;
+    }
+
+    /**
      * Binary name of Forge's {@code FancyMissingModel.BakedModel}. The class is package-private,
      * so its name is matched instead of using {@code instanceof}; it ships with Minecraft Forge.
      */
@@ -55,8 +68,12 @@ public final class MissingModelCompat {
      * fancy label variant) and must not be rendered from a chunk build worker thread.
      */
     public static boolean isMissingModel(IBakedModel model) {
-        IBakedModel missingModel = Minecraft.getMinecraft().getBlockRendererDispatcher()
-                .getBlockModelShapes().getModelManager().getMissingModel();
+        IBakedModel missingModel = cachedMissingModel;
+        if (missingModel == null) {
+            missingModel = Minecraft.getMinecraft().getBlockRendererDispatcher()
+                    .getBlockModelShapes().getModelManager().getMissingModel();
+            cachedMissingModel = missingModel;
+        }
         return isMissingModel(model, missingModel);
     }
 

--- a/src/test/java/com/gtnewhorizons/angelica/glsm/hooks/GLSMHooksConsumersGateTest.java
+++ b/src/test/java/com/gtnewhorizons/angelica/glsm/hooks/GLSMHooksConsumersGateTest.java
@@ -1,0 +1,23 @@
+package com.gtnewhorizons.angelica.glsm.hooks;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GLSMHooksConsumersGateTest {
+    @AfterEach
+    void restoreGate() {
+        GLSMHooks.consumersActive = true;
+    }
+
+    @Test
+    void clearingGateSkipsConsumerWork() {
+        GLSMHooks.consumersActive = false;
+        assertFalse(GLSMHooks.hasActiveConsumers());
+
+        GLSMHooks.consumersActive = true;
+        assertTrue(GLSMHooks.hasActiveConsumers());
+    }
+}

--- a/src/test/java/com/gtnewhorizons/angelica/glsm/states/VertexAttribUploadLengthTest.java
+++ b/src/test/java/com/gtnewhorizons/angelica/glsm/states/VertexAttribUploadLengthTest.java
@@ -1,0 +1,80 @@
+package com.gtnewhorizons.angelica.glsm.states;
+
+import org.junit.jupiter.api.Test;
+import org.lwjgl.opengl.GL11;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class VertexAttribUploadLengthTest {
+    private static VertexAttribState.Attrib attrib(int size, int type, int stride, int bufferBytes) {
+        final VertexAttribState.Attrib a = new VertexAttribState.Attrib();
+        a.size = size;
+        a.type = type;
+        a.stride = stride;
+        a.clientPointer = ByteBuffer.allocate(bufferBytes);
+        return a;
+    }
+
+    @Test
+    void tightlyPackedFloatPosition() {
+        // stride=0 means tightly packed: 3 floats = 12 bytes per vertex; [0, 100) reads 1200 bytes.
+        assertEquals(1200, VertexAttribState.computeUploadLength(attrib(3, GL11.GL_FLOAT, 0, 4096), 0, 100));
+    }
+
+    @Test
+    void explicitStrideCoversWholeVertices() {
+        // stride=32 with a 12-byte vertex: last vertex of [0, 100) ends at 99*32+12 = 3180.
+        assertEquals(3180, VertexAttribState.computeUploadLength(attrib(3, GL11.GL_FLOAT, 32, 8192), 0, 100));
+    }
+
+    @Test
+    void nonZeroFirstStillUploadsFromAllocationStart() {
+        // QUADS-as-triangles style range [16, 20): bytes up to (16+4-1)*12+12 = 240 are needed.
+        assertEquals(240, VertexAttribState.computeUploadLength(attrib(3, GL11.GL_FLOAT, 0, 4096), 16, 4));
+    }
+
+    @Test
+    void hugeAllocationShrinksToDrawRange() {
+        // The HBM-CE case: a 4.2MB reused allocation, a 4-vertex GUI draw reads only 48 bytes.
+        assertEquals(48, VertexAttribState.computeUploadLength(attrib(3, GL11.GL_FLOAT, 0, 4_200_768), 0, 4));
+    }
+
+    @Test
+    void clampedToCapturedAllocation() {
+        assertEquals(1024, VertexAttribState.computeUploadLength(attrib(3, GL11.GL_FLOAT, 0, 1024), 0, 10000));
+    }
+
+    @Test
+    void respectsBufferPosition() {
+        final VertexAttribState.Attrib a = attrib(3, GL11.GL_FLOAT, 0, 4096);
+        a.clientPointer.position(1024);
+        assertEquals(1200, VertexAttribState.computeUploadLength(a, 0, 100));
+        assertEquals(3072, VertexAttribState.computeUploadLength(a, 0, 1000));
+    }
+
+    @Test
+    void zeroCountUploadsNothing() {
+        assertEquals(0, VertexAttribState.computeUploadLength(attrib(3, GL11.GL_FLOAT, 0, 4096), 0, 0));
+    }
+
+    @Test
+    void byteAndShortTypes() {
+        // RGBA color as 4 unsigned bytes: 4 bytes per vertex.
+        assertEquals(400, VertexAttribState.computeUploadLength(attrib(4, GL11.GL_UNSIGNED_BYTE, 0, 4096), 0, 100));
+        // 2 shorts = 4-byte vertex, stride=8, range [2, 12): (2+10-1)*8+4 = 92.
+        assertEquals(92, VertexAttribState.computeUploadLength(attrib(2, GL11.GL_SHORT, 8, 4096), 2, 10));
+    }
+
+    @Test
+    void narrowStrideKeepsLastVertexCovered() {
+        // stride=8 < 12-byte vertex: the last vertex's tail must still be uploaded.
+        assertEquals(11 * 8 + 12, VertexAttribState.computeUploadLength(attrib(3, GL11.GL_FLOAT, 8, 4096), 0, 12));
+    }
+
+    @Test
+    void negativeStrideFallsBackToFullAllocation() {
+        assertEquals(4096, VertexAttribState.computeUploadLength(attrib(3, GL11.GL_FLOAT, -1, 4096), 0, 4));
+    }
+}


### PR DESCRIPTION
## 问题

0.0.5 → 0.0.7 之间的性能回归：打开 F3 调试界面帧率从 140+ 暴跌至 15（帧时间 +60ms），背包、视频设置等 GUI 界面也明显卡顿。无光影同样复现。

## 根因

perfDebug 日志定位（`gl.clientArrayUpload[count=708-750/s, avgUs≈1150µs]`，F3 下约 50 次/帧 ≈ 57ms/帧）：

1. `2f54db7` 为修 HBM-CE 兼容，将 `VertexAttribState` 捕获的 client 指针扩到整个底层分配（HBM 复用 BufferBuilder 分配、set pointer 后改 limit）——正确性修复，语义必须保留；
2. 但 `GLStateManager.uploadClientArraysToVBO()` 在**每次 draw**（只要存在启用的 client-side 顶点属性，HBM-CE 的 client-state 泄漏使其常态启用）都把捕获的**整个分配**（实测 4.2MB，`bufferData` orphan + `bufferSubData`，约 1.1ms/次，与 PCIe 上传耗时吻合）重新上传；
3. GUI/F3 的文字与矩形 draw 风暴把它放大为帧级卡顿；普通帧约 5 次/帧的全量上传也吃掉了大部分帧时间。

## 改动（3 个提交）

- **`bcd0c67` perf(glsm)：client-array 上传按 draw 顶点区间裁剪**（主修复）。`glDrawArrays`（含 QUADS 经 QuadConverter 转换的路径，其共享 EBO 恰好引用 `[first, first+count)`）的读取区间已知，逐属性将上传裁剪到该区间实际读取的字节（4.2MB → 几十~几百字节）；最大索引未知的裸 `glDrawElements` 系列保守保持全量上传。新增 `VertexAttribState.computeUploadLength` 纯函数 + 10 个单元测试；GLSM perf 周期日志新增 `clientArray.stackSample` 调用方归因。逃逸通道：`-Dactinium.glsmFullClientArrayUpload=true`。
- **`20e6e73` perf(glsm)：无 deferred pipeline 时跳过 blend/program 快照与事件 post**。`IrisGLSMBridge` 启动时无条件注册监听器导致 `hasListeners()` 恒真，`2f54db7` 引入的每次 `tryBlendFunc`/`glUseProgram` 快照+比较在无光影时全部空转。新增 `GLSMHooks.consumersActive` 门禁，由 `PipelineManager` 在 pipeline 生命周期维护（仅 `DeferredWorldRenderingPipeline` 活跃时为 true）；有光影时行为逐字节不变。逃逸通道：`-Dactinium.glsmHooksAlwaysActive=true`。
- **`f499c63` perf(terrain)：缓存 vanilla missing-model 引用**，消除 chunk 构建期每方块的 4 级 getter 链（`MissingModelCompat`，资源重载时经监听器失效；桥 renderer 的第三方 Mixin 绑定契约未触碰）。

## 验证

- `./gradlew build --no-daemon` 全绿：根项目 140 个测试套件 0 失败，含 `CeleritasCompatBridgeJarTest` 7/7（桥契约）、新增 `VertexAttribUploadLengthTest` 10/10、`GLSMHooksConsumersGateTest`。
- 生产整合包实测（含 HBM-CE、DynamicSurroundings 等）：修复前 F3 开启 140+ → 15 fps；部署本分支构建后 F3/GUI 卡顿消失，用户已确认。
- 有光影路径：门禁仅在 deferred pipeline 活跃时放行，光影开启时快照/事件行为与修复前一致；本次未改动光影渲染语义，compatibility-matrix 无需更新。

## 备注

- 裸 `glDrawElements` 路径仍是全量上传；若后续日志显示该路径也热，可再加索引扫描求上界的优化。
- 排查过程中另发现 `a3ad50d` 的 BiomeColorNoise 存在最多 60 倍的平面噪声冗余计算（仅 worker 线程构建期、与本次症状无关），将另行评估处理，不在本 PR 范围。