### PR TITLE
perf(celeritas): sync upstream fixes to 7190f87d (planar fog, shadow planes, GUI capture)

### DIFF
--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/api/options/control/SliderControl.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/api/options/control/SliderControl.java
@@ -99,7 +99,7 @@ public class SliderControl implements Control<Integer> {
         public void render(DrawContext drawContext, int mouseX, int mouseY, float delta) {
             super.render(drawContext, mouseX, mouseY, delta);
 
-            if (this.option.isAvailable() && (this.isMouseOver(mouseX, mouseY))) {
+            if (this.option.isAvailable() && (this.sliderHeld || this.isMouseOver(mouseX, mouseY))) {
                 this.renderSlider(drawContext);
             } else {
                 this.renderStandaloneValue(drawContext);
@@ -185,11 +185,8 @@ public class SliderControl implements Control<Integer> {
 
         @Override
         public boolean mouseDragged(InteractionContext context, double mouseX, double mouseY, int button, double deltaX, double deltaY) {
-            if (this.option.isAvailable() && button == 0 && this.sliderBounds.containsCursor(mouseX, mouseY)) {
-                if (this.sliderHeld) {
-                    this.setValueFromMouse(mouseX);
-                }
-
+            if (this.option.isAvailable() && button == 0 && this.sliderHeld) {
+                this.setValueFromMouse(mouseX);
                 return true;
             }
 

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/gui/frame/AbstractFrame.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/gui/frame/AbstractFrame.java
@@ -18,6 +18,7 @@ public abstract class AbstractFrame extends AbstractWidget implements Interactab
     protected final List<Renderable> drawable = new ArrayList<>();
     protected final List<ControlElement<?>> controlElements = new ArrayList<>();
     protected boolean renderOutline;
+    private Interactable capturedChild;
 
     public AbstractFrame(Dim2i dim, boolean renderOutline) {
         this.dim = dim;
@@ -44,13 +45,25 @@ public abstract class AbstractFrame extends AbstractWidget implements Interactab
             drawContext.drawBorder(this.dim.x(), this.dim.y(), this.dim.getLimitX(), this.dim.getLimitY(), 0xFFAAAAAA);
         }
         for (Renderable drawable : this.drawable) {
-            drawable.render(drawContext, mouseX, mouseY, delta);
+            // While a child is captured (mid-drag), don't let the cursor also "hover" its siblings.
+            boolean isOtherWhileCapturing = this.capturedChild != null && drawable != this.capturedChild;
+            drawable.render(drawContext, isOtherWhileCapturing ? -1 : mouseX, isOtherWhileCapturing ? -1 : mouseY, delta);
         }
     }
 
     @Override
     public Stream<? extends Interactable> interactableChildren() {
         return this.children.stream();
+    }
+
+    @Override
+    public Interactable getCapturedChild() {
+        return this.capturedChild;
+    }
+
+    @Override
+    public void setCapturedChild(Interactable child) {
+        this.capturedChild = child;
     }
 
     public Dim2i getDimensions() {

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/gui/frame/OptionPageFrame.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/gui/frame/OptionPageFrame.java
@@ -94,7 +94,7 @@ public class OptionPageFrame extends AbstractFrame {
 
     @Override
     public void render(DrawContext drawContext, int mouseX, int mouseY, float delta) {
-        ControlElement<?> hoveredElement = this.isMouseOver(mouseX, mouseY) ? this.controlElements.stream()
+        ControlElement<?> hoveredElement = this.getCapturedChild() == null && this.isMouseOver(mouseX, mouseY) ? this.controlElements.stream()
                 .filter(c -> c.isMouseOver(mouseX, mouseY))
                 .findFirst().orElse(null) : null;
         super.render(drawContext, mouseX, mouseY, delta);

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/gui/framework/InteractableContainer.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/gui/framework/InteractableContainer.java
@@ -6,6 +6,15 @@ import java.util.stream.Stream;
 public interface InteractableContainer extends Interactable {
     Stream<? extends Interactable> interactableChildren();
 
+    /**
+     * the child that most recently claimed a mouseClicked. while set, drag events
+     * are routed straight to it instead of being re-checked against the cursor position each time,
+     * so a drag started on e.g. a slider isn't dropped the moment the cursor strays off its narrow
+     * hitbox. Cleared on mouseReleased.
+     */
+    Interactable getCapturedChild();
+    void setCapturedChild(Interactable child);
+
     private boolean runSingleChildAction(Predicate<Interactable> action) {
         // Defensive copy to handle mutation
         return interactableChildren().toList().stream().anyMatch(action);
@@ -17,16 +26,33 @@ public interface InteractableContainer extends Interactable {
 
     @Override
     default boolean mouseClicked(InteractionContext context, double mouseX, double mouseY, int button) {
-        return runSingleChildAction(i -> i.mouseClicked(context, mouseX, mouseY, button));
+        setCapturedChild(null);
+        return runSingleChildAction(i -> {
+            if (i.mouseClicked(context, mouseX, mouseY, button)) {
+                setCapturedChild(i);
+                return true;
+            }
+            return false;
+        });
     }
 
     @Override
     default boolean mouseReleased(InteractionContext context, double mouseX, double mouseY, int button) {
+        Interactable captured = getCapturedChild();
+        setCapturedChild(null);
+        if (captured != null) {
+            captured.mouseReleased(context, mouseX, mouseY, button);
+            return true;
+        }
         return runSingleChildAction(i -> i.mouseReleased(context, mouseX, mouseY, button));
     }
 
     @Override
     default boolean mouseDragged(InteractionContext context, double mouseX, double mouseY, int button, double deltaX, double deltaY) {
+        Interactable captured = getCapturedChild();
+        if (captured != null) {
+            return captured.mouseDragged(context, mouseX, mouseY, button, deltaX, deltaY);
+        }
         return runSingleChildAction(i -> i.isMouseOver(mouseX, mouseY) && i.mouseDragged(context, mouseX, mouseY, button, deltaX, deltaY));
     }
 

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/RenderSectionManager.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/RenderSectionManager.java
@@ -31,6 +31,7 @@ import org.embeddedt.embeddium.impl.render.chunk.metrics.RenderSectionMetricsTra
 import org.embeddedt.embeddium.impl.render.chunk.occlusion.AsyncOcclusionMode;
 import org.embeddedt.embeddium.impl.render.chunk.region.RenderRegion;
 import org.embeddedt.embeddium.impl.render.chunk.region.RenderRegionManager;
+import org.embeddedt.embeddium.impl.render.chunk.fog.FogService;
 import org.embeddedt.embeddium.impl.render.chunk.shader.ChunkShaderFogComponent;
 import org.embeddedt.embeddium.impl.render.chunk.terrain.TerrainRenderPass;
 import org.embeddedt.embeddium.impl.render.viewport.CameraTransform;
@@ -43,6 +44,7 @@ import org.embeddedt.embeddium.impl.render.chunk.sorting.TranslucentQuadAnalyzer
 import org.embeddedt.embeddium.impl.util.suppliers.ExpiringSupplier;
 import org.jetbrains.annotations.MustBeInvokedByOverriders;
 import org.jetbrains.annotations.Nullable;
+import org.joml.Matrix4fc;
 import org.joml.Vector3d;
 import org.joml.Vector3f;
 import org.joml.Vector3fc;
@@ -227,7 +229,7 @@ public abstract class RenderSectionManager {
             // build results between the two passes carries over to the next frame.
             this.shadowPassRanThisFrame = false;
         } else {
-            this.createTerrainRenderList(positionedViewport, frame, spectator);
+            this.createTerrainRenderList(positionedViewport, null, frame, spectator);
         }
 
         this.checkTranslucencyChange();
@@ -249,7 +251,7 @@ public abstract class RenderSectionManager {
         this.shadowPassRanThisFrame = true;
 
         if (this.renderListManager.isNeedsUpdate()) {
-            this.createTerrainRenderList(playerViewport, frame, spectator);
+            this.createTerrainRenderList(playerViewport, null, frame, spectator);
         }
 
         Vector3fc lightVector = null;
@@ -259,7 +261,7 @@ public abstract class RenderSectionManager {
         }
 
         this.shadowRenderListManager.startShadowGraphUpdate(shadowViewport, frame, this.regions.getRegionIdsLength(),
-                this.getSearchDistance(), lightVector, this.getTargetQueueSize());
+                this.getSearchDistance(null), lightVector, this.getTargetQueueSize());
     }
 
     /**
@@ -363,8 +365,8 @@ public abstract class RenderSectionManager {
         return true;
     }
 
-    private void createTerrainRenderList(Viewport viewport, int frame, boolean spectator) {
-        final var searchDistance = this.getSearchDistance();
+    private void createTerrainRenderList(Viewport viewport, @Nullable Matrix4fc projectionMatrix, int frame, boolean spectator) {
+        final var searchDistance = this.getSearchDistance(projectionMatrix);
         final var useOcclusionCulling = this.shouldUseOcclusionCulling(viewport, spectator);
 
         this.renderListManager.startGraphUpdate(viewport, frame, this.regions.getRegionIdsLength(),
@@ -381,11 +383,11 @@ public abstract class RenderSectionManager {
 
     protected abstract boolean useFogOcclusion();
 
-    private float getSearchDistance() {
+    private float getSearchDistance(@Nullable Matrix4fc projectionMatrix) {
         float distance;
 
         if (this.useFogOcclusion()) {
-            distance = this.getEffectiveRenderDistance();
+            distance = this.getEffectiveRenderDistance(projectionMatrix);
         } else {
             distance = this.getRenderDistance();
         }
@@ -967,10 +969,11 @@ public abstract class RenderSectionManager {
         return false;
     }
 
-    private float getEffectiveRenderDistance() {
+    private float getEffectiveRenderDistance(@Nullable Matrix4fc projectionMatrix) {
         var color = ChunkShaderFogComponent.FOG_SERVICE.getFogColor();
         var alpha = color[3];
         var distance = ChunkShaderFogComponent.FOG_SERVICE.getFogCutoff();
+        var shape = ChunkShaderFogComponent.FOG_SERVICE.getFogShapeIndex();
 
         var renderDistance = this.getRenderDistance();
 
@@ -979,7 +982,57 @@ public abstract class RenderSectionManager {
             return renderDistance;
         }
 
+        if (shape == FogService.FOG_SHAPE_PLANAR) {
+            // The cullers measure the cylindrical distance max(|xz|, |y|) from the camera, which for spherical and
+            // cylindrical fog is never larger than the distance the shader fogs by, so the cutoff can be used
+            // as-is. Planar fog instead measures depth along the view axis, which is *smaller* than that distance,
+            // so the cutoff has to be scaled up to the worst case before the cullers can use it.
+            var secant = getMaximumFrustumSecant(projectionMatrix);
+
+            if (secant == 0.0f) {
+                // Not a projection we can bound the view cone of; assume fog can hide nothing.
+                return renderDistance;
+            }
+
+            distance *= secant;
+        }
+
         return Math.min(renderDistance, distance + 0.5f);
+    }
+
+    /**
+     * Computes the largest factor by which a point inside the view frustum can be farther from the camera than its
+     * depth along the view axis.
+     *
+     * <p>Computing from the projection rather than from the game's setting keeps this correct
+     * under dynamic FOV, spyglasses, aspect ratio changes, temporal jitter, and any mod which alters the
+     * projection.</p>
+     */
+    private static float getMaximumFrustumSecant(@Nullable Matrix4fc projectionMatrix) {
+        if (projectionMatrix == null) {
+            return 0.0f;
+        }
+
+        // A perspective projection divides by -z (m23 = -1 before any scaling). An orthographic one (used by the
+        // shadow pass) leaves w untouched, has no apex, and therefore no bounded view cone.
+        float w = Math.abs(projectionMatrix.m23());
+
+        if (w == 0.0f) {
+            return 0.0f;
+        }
+
+        float tanX = (w + Math.abs(projectionMatrix.m20())) / Math.abs(projectionMatrix.m00());
+        float tanY = (w + Math.abs(projectionMatrix.m21())) / Math.abs(projectionMatrix.m11());
+
+        float secant = (float) Math.sqrt(1.0 + (tanX * tanX) + (tanY * tanY));
+
+        // Rejects a degenerate projection (a zero or NaN term anywhere above lands here) rather than letting it
+        // poison the search distance.
+        if (!(secant >= 1.0f) || !Float.isFinite(secant)) {
+            return 0.0f;
+        }
+
+        return secant;
     }
 
     private float getRenderDistance() {

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/fog/FogService.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/chunk/fog/FogService.java
@@ -3,6 +3,11 @@ package org.embeddedt.embeddium.impl.render.chunk.fog;
 import org.embeddedt.embeddium.impl.render.chunk.shader.ChunkShaderComponent;
 
 public interface FogService {
+    // Keep in sync with fog.glsl
+    int FOG_SHAPE_SPHERICAL = 0;
+    int FOG_SHAPE_CYLINDRICAL = 1;
+    int FOG_SHAPE_PLANAR = 2;
+
     float getFogEnd();
     float getFogStart();
     float getFogDensity();

--- a/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/terrain/SimpleWorldRenderer.java
+++ b/celeritas-common/src/main/java/org/embeddedt/embeddium/impl/render/terrain/SimpleWorldRenderer.java
@@ -200,7 +200,6 @@ public abstract class SimpleWorldRenderer<WORLD, SECTIONMANAGER extends RenderSe
 
             this.prepareFrame(shadowViewport, cameraState, false);
 
-            // The shadow search runs every frame; the terrain search only when its graph is dirty.
             this.renderSectionManager.updateForShadowPass(playerViewport, shadowViewport, frame, spectator);
 
             this.renderSectionManager.tickVisibleRenders();

--- a/docs/sync-celeritas-7190f87d.md
+++ b/docs/sync-celeritas-7190f87d.md
@@ -1,0 +1,80 @@
+# 同步上游 celeritas 方案（f15085d4 → 7190f87d）
+
+> 状态：**修复类同步完成**。上游 `f15085d4b..7190f87d8` 共 25 个提交：16 个纯构建系统变更
+> （unimined→RFG/MDG 迁移、Loom/Stonecutter 升级，Actinium 自有工具链，不适用），
+> 9 个运行时提交中 6 个已收编（含 1 个部分收编），2 个不适用，1 个观望。
+> 编译（根项目 + `celeritas-common` + `shader`）与 `test` 通过。planar fog 雾观感待 dev 目测。
+
+## 完成记录
+
+| 上游 commit | 本地 commit | 内容 |
+|---|---|---|
+| `1c473b2eb` | `bc3dfb0a` | 区块 vsh `gl_Position` 标记 invariant，防 solid/cutout 变体间 z-fighting |
+| `09f4da755` | `b3deb706` | 移除 shadow pass near/far 深度裁剪平面（pack 重映射阴影深度时误剔除投射物） |
+| `927e7a09b` | `f44fe6d2` | `Vector2Uniform`/`Vector4ArrayUniform` 改私有副本缓存（另两个 Joml 整型类此前已修） |
+| `5e6c6e2b0` | `779c6c92` | 拖动控件真实鼠标捕获：`InteractableContainer` 捕获子项 + `SliderControl` 由 `sliderHeld` 驱动拖动 |
+| `53f41b67c` | `b937007c` | planar fog 支持：形状常量 + fsh 按形状沿视轴测距 + 雾剔除保守回退 |
+| `31455a039` | `9393f890` | **部分收编**：final pass memory barrier 加 `ranCompute` 门控；parity 双缓冲重构未收编 |
+
+## 上游提交清单（f15085d4b..7190f87d8，stonecutter 分支）
+
+| commit | 内容 | 处置 |
+|---|---|---|
+| `53f41b67c` | planar fog 基础支持 | 收编（`b937007c`） |
+| `5e6c6e2b0` | 拖动控件鼠标捕获 (#37) | 收编（`779c6c92`） |
+| `3d993a136`…`15dea5977`（16 个） | unimined→RFG/MDG、Loom/Gradle/Stonecutter/RFG 升级、conf cache 修复、deprecation 清理 | 不适用（Actinium 用自有 unimined 工具链） |
+| `09f4da755` | 移除 shadow near/far 平面优化 | 收编（`b3deb706`） |
+| `1c473b2eb` | `gl_Position` invariant | 收编（`bc3dfb0a`） |
+| `927e7a09b` | uniform 上传缓存修复 | 收编（`f44fe6d2`） |
+| `3dca9685a` | 实验性 bilinear/FSR 世界渲染缩放 | 不适用：三个 mixin 注入点（`getMainRenderTarget`、blaze3d `RenderTarget#bindWrite`、`GameRenderer#renderLevel`）均为 1.20+ API；如需 render-scale 应独立立项 |
+| `05e5b6629` | batched entity rendering 重写（-3565 行） | 不适用：全部在 `modern/src/main/batching_java/`，1.12.2 无该基础设施 |
+| `31455a039` | composite 管线 parity 双缓冲 | 部分收编（`9393f890`，仅 barrier 子项） |
+| `7190f87d8` | 可选光栅化遮挡剔除 (#38) | **观望**，见下 |
+
+## 关键决策
+
+1. **shader 侧不能 cherry-pick**：上游 shader 代码在 `net.irisshaders.iris` 包（modern 平台
+   `shaders_java`），Actinium 是 `net.coderbot.iris` 包的 Iris 1.6.x 基线，逐文件手动移植。
+2. **compat-bridge 的 `SliderControl` 副本保持不动**：已解包扫描 celeritasleafculling jar，
+   无任何对 `SliderControl`/gui/options 的注入目标；主 GUI 运行时走 `celeritas-common` 实现，
+   桥副本是旧 Celeritas 2.4.0 行为快照，按桥契约不凭直觉变更。
+3. **planar fog 不接真实投影矩阵**：上游两处 `createTerrainRenderList` 均传 `null`
+   （`getMaximumFrustumSecant` 得 0，`getEffectiveRenderDistance` 回退完整渲染距离），
+   即 planar 形状下雾剔除安全禁用。忠实跟随上游，若后续上游接入真实矩阵再跟进。
+4. **`SHADOW_CAMERA_OFFSET` 收回 private**：`addDepthPlanes` 删除后无外部消费者
+   （Actinium 本无 `ReversedAdvancedShadowCullingFrustum`，该文件部分跳过）。
+5. Actinium 的 `init()` 方法形态（无参构造 + `init` 重载）保持，未照搬上游带参构造。
+
+## Actinium 触碰点对照（53f41b67c planar fog）
+
+| 上游文件 | Actinium 对应 |
+|---|---|
+| `common/.../RenderSectionManager.java` | `celeritas-common/.../render/chunk/RenderSectionManager.java`（结构一致，直改） |
+| `common/.../fog/FogService.java` | 同路径（加 3 个 `FOG_SHAPE_*` 常量） |
+| `common/.../terrain/SimpleWorldRenderer.java` | 同路径（删一行注释） |
+| `assets/sodium/shaders/include/fog.glsl` | `src/main/resources/assets/actinium/shaders/include/fog.glsl`（命名空间不同） |
+| `assets/sodium/shaders/blocks/block_layer_opaque.fsh` | `src/main/resources/assets/actinium/shaders/blocks/block_layer_opaque.fsh` |
+| `forge1710/.../VintageRenderSectionManager.java`（上游老平台接线） | `src/main/java/com/dhj/actinium/render/terrain/fog/GLStateManagerFogService.java`（`getFogShapeIndex` 返回 `FOG_SHAPE_PLANAR`，1.12.2 的 GL_FOG 即视平面深度语义） |
+
+## 遗留验证项
+
+- **planar fog 雾观感**（行为对齐变更）：dev 起客户端，对比区块雾与 vanilla 实体/粒子雾在
+  屏幕边缘的一致性；确认雾剔除回退后大视距无性能异常回退。
+- **shadow pass**：`09f4da755` 后 advanced 阴影剔除少 2 个平面，用目标光影包
+  （MakeUp/BSL/Complementary）确认阴影正常、shadow pass 帧率无可感知回退。
+- **GUI 滑块**：设置界面拖动滑块越过热区不丢跟随；拖动期间其他控件不显示 hover。
+- 上一轮 `sync-celeritas-b8c1079a.md` 的 C 类运行专项（fadd 调度、Occlusion/Lattice、
+  Iris frustum 三态等）仍未执行，可与本轮验证合并起客户端。
+
+## 下一轮提醒
+
+- `7190f87d8` 光栅化遮挡剔除：约 5500 行（grondag bitraster 光栅化器 ~4000 行 +
+  `occlusion/geometry` 包 ~820 行 + 接入 ~200 行），默认关闭、独立 tick box、
+  Apache 2.0 许可证兼容。Actinium 的 occlusion 包与上游基线几乎同源（仅注释与本地
+  snapshot 适配差异），接入面有 `forge1710` 老平台 `VintageRenderSectionManager` 可参照。
+  该提交刚发布、剔除开销约翻倍，**建议等上游出现后续修复提交后再评估**。
+- `31455a039` 其余部分（ParityFramebuffer/惰性 alt/depthtex2 采样门控）：依赖上游新
+  target 架构，Actinium 1.6.x 基线需全量手改，帧间时序敏感（TAA 类包回归风险），
+  除非 parity 复制的帧开销实测成为瓶颈，否则维持不收编。
+- `3dca9685a` 中可复用件：FFX `ffx_a.h`/`ffx_fsr1.h` 纯 GLSL 头与
+  `Vector4UnsignedIntegerUniform`，若独立立项 render-scale 可参考。

--- a/shader/src/main/java/net/coderbot/iris/gl/uniform/Vector2Uniform.java
+++ b/shader/src/main/java/net/coderbot/iris/gl/uniform/Vector2Uniform.java
@@ -6,13 +6,14 @@ import org.joml.Vector2f;
 import java.util.function.Supplier;
 
 public class Vector2Uniform extends Uniform {
-	private Vector2f cachedValue;
 	private final Supplier<Vector2f> value;
+	// Held by value, so that reused supplier vectors cannot alias the cache
+	private final Vector2f cachedValue;
 
 	Vector2Uniform(int location, Supplier<Vector2f> value) {
 		super(location);
 
-		this.cachedValue = null;
+		this.cachedValue = new Vector2f();
 		this.value = value;
 
 	}
@@ -21,9 +22,9 @@ public class Vector2Uniform extends Uniform {
 	public void update() {
 		Vector2f newValue = value.get();
 
-		if (cachedValue == null || !newValue.equals(cachedValue)) {
-			cachedValue = newValue;
-			RenderSystem.uniform2f(this.location, newValue.x, newValue.y);
+		if (!newValue.equals(cachedValue)) {
+			cachedValue.set(newValue);
+			RenderSystem.uniform2f(this.location, cachedValue.x, cachedValue.y);
 		}
 	}
 }

--- a/shader/src/main/java/net/coderbot/iris/gl/uniform/Vector4ArrayUniform.java
+++ b/shader/src/main/java/net/coderbot/iris/gl/uniform/Vector4ArrayUniform.java
@@ -8,7 +8,8 @@ import java.util.function.Supplier;
 
 public class Vector4ArrayUniform extends Uniform {
     private final Supplier<float[]> value;
-    private float[] cachedValue;
+    // Held by value, so that reused supplier arrays cannot alias the cache
+    private final float[] cachedValue;
 
     Vector4ArrayUniform(int location, Supplier<float[]> value) {
         this(location, value, null);
@@ -34,7 +35,7 @@ public class Vector4ArrayUniform extends Uniform {
         float[] newValue = value.get();
 
         if (!Arrays.equals(newValue, cachedValue)) {
-            cachedValue = newValue;
+            System.arraycopy(newValue, 0, cachedValue, 0, 4);
             RenderSystem.uniform4f(location, cachedValue[0], cachedValue[1], cachedValue[2], cachedValue[3]);
         }
     }

--- a/shader/src/main/java/net/coderbot/iris/pipeline/ShadowRenderer.java
+++ b/shader/src/main/java/net/coderbot/iris/pipeline/ShadowRenderer.java
@@ -384,27 +384,13 @@ public class ShadowRenderer {
 					RenderingState.INSTANCE.getModelViewMatrix(), projView,
 					shadowLightVectorCache, boxCuller, distanceCuller);
 				return holder.setInfo(safeZoneFrustum, distanceInfo, cullingInfo);
-			} else {
-				// Legacy perspective shadow packs (fov != null) have no fixed depth range, so the planes are omitted.
-				float depthNear = Float.NaN, depthFar = Float.NaN;
-				if (this.fov == null) {
-					depthNear = this.resolvedNearPlane();
-					depthFar = this.resolvedFarPlane();
-				}
-				cachedAdvancedFrustum.init(RenderingState.INSTANCE.getModelViewMatrix(), projView, shadowLightVectorCache, boxCuller, depthNear, depthFar, intervalSize);
-				return holder.setInfo(cachedAdvancedFrustum, distanceInfo, cullingInfo);
-			}
+		} else {
+			cachedAdvancedFrustum.init(RenderingState.INSTANCE.getModelViewMatrix(), projView, shadowLightVectorCache, boxCuller);
+			return holder.setInfo(cachedAdvancedFrustum, distanceInfo, cullingInfo);
+		}
 		}
 
 		return holder;
-	}
-
-	private float resolvedNearPlane() {
-		return this.nearPlane < 0 ? -DHCompat.getRenderDistance() : this.nearPlane;
-	}
-
-	private float resolvedFarPlane() {
-		return this.farPlane < 0 ? DHCompat.getRenderDistance() : this.farPlane;
 	}
 
 	private FrustumHolder createEntityShadowFrustum(float renderMultiplier, FrustumHolder holder) {

--- a/shader/src/main/java/net/coderbot/iris/postprocess/FinalPassRenderer.java
+++ b/shader/src/main/java/net/coderbot/iris/postprocess/FinalPassRenderer.java
@@ -273,8 +273,11 @@ public class FinalPassRenderer {
 			FullScreenQuadRenderer.INSTANCE.begin();
             IrisGlDebug.check("final:quad-begin");
 
+			boolean ranCompute = false;
+
 			for (ComputeProgram computeProgram : finalPass.computes) {
 				if (computeProgram != null) {
+					ranCompute = true;
                     computeProgram.use();
                     IrisGlDebug.check("final:compute-use");
                     this.customUniforms.push(computeProgram);
@@ -284,7 +287,9 @@ public class FinalPassRenderer {
 				}
 			}
 
-			RenderSystem.memoryBarrier(GL42.GL_SHADER_IMAGE_ACCESS_BARRIER_BIT | GL42.GL_TEXTURE_FETCH_BARRIER_BIT | GL43.GL_SHADER_STORAGE_BARRIER_BIT);
+			if (ranCompute) {
+				RenderSystem.memoryBarrier(GL42.GL_SHADER_IMAGE_ACCESS_BARRIER_BIT | GL42.GL_TEXTURE_FETCH_BARRIER_BIT | GL43.GL_SHADER_STORAGE_BARRIER_BIT);
+			}
             IrisGlDebug.check("final:memory-barrier");
 
 			if (!finalPass.mipmappedBuffers.isEmpty()) {

--- a/shader/src/main/java/net/coderbot/iris/shadow/ShadowMatrices.java
+++ b/shader/src/main/java/net/coderbot/iris/shadow/ShadowMatrices.java
@@ -11,10 +11,9 @@ public class ShadowMatrices {
 
 	/**
 	 * Distance the shadow camera is pulled back from the player camera along the shadow light vector, applied by
-	 * {@link #createBaselineModelViewMatrix}. Culling that reasons in light space has to place its depth planes at
-	 * the same offset.
+	 * {@link #createBaselineModelViewMatrix}.
 	 */
-	public static final float SHADOW_CAMERA_OFFSET = 100.0f;
+	private static final float SHADOW_CAMERA_OFFSET = 100.0f;
 
 	// NB: These matrices are in column-major order, not row-major order like what you'd expect!
 

--- a/shader/src/main/java/net/coderbot/iris/shadows/frustum/advanced/AdvancedShadowCullingFrustum.java
+++ b/shader/src/main/java/net/coderbot/iris/shadows/frustum/advanced/AdvancedShadowCullingFrustum.java
@@ -2,7 +2,6 @@ package net.coderbot.iris.shadows.frustum.advanced;
 
 import com.seibel.distanthorizons.api.interfaces.override.rendering.IDhApiShadowCullingFrustum;
 import com.seibel.distanthorizons.api.objects.math.DhApiMat4f;
-import net.coderbot.iris.shadow.ShadowMatrices;
 import net.coderbot.iris.shadows.frustum.BoxCuller;
 import net.minecraft.client.renderer.culling.Frustum;
 import net.minecraft.util.math.AxisAlignedBB;
@@ -39,9 +38,7 @@ import org.joml.Vector4f;
  */
 @Optional.Interface(modid = "distanthorizons", iface = "com.seibel.distanthorizons.api.interfaces.override.rendering.IDhApiShadowCullingFrustum")
 public class AdvancedShadowCullingFrustum extends Frustum implements ViewportProvider, org.embeddedt.embeddium.impl.render.viewport.frustum.Frustum, IDhApiShadowCullingFrustum, ShadowSearchFrustum {
-	// 6 base planes + at most 5 edge planes + 2 light-space depth planes.
 	private static final int MAX_CLIPPING_PLANES = 13;
-	private static final float SQRT_3 = Math.sqrt(3.0f);
 
 	/**
 	 * We store each plane equation as a Vector4f.
@@ -100,16 +97,6 @@ public class AdvancedShadowCullingFrustum extends Frustum implements ViewportPro
 	}
 
 	public void init(Matrix4fc playerView, Matrix4fc playerProjection, Vector3f shadowLightVector, BoxCuller boxCuller) {
-		init(playerView, playerProjection, shadowLightVector, boxCuller, Float.NaN, Float.NaN, 0.0f);
-	}
-
-	/**
-	 * @param nearPlane    resolved {@code shadowNearPlane} of the orthographic shadow projection (DH already applied)
-	 * @param farPlane     resolved {@code shadowFarPlane}; pass {@code NaN} for either to omit the depth planes
-	 * @param intervalSize {@code shadowIntervalSize}, whose grid snapping shifts the shadow camera by up to
-	 *                     1.5 × intervalSize per axis and therefore widens the depth range conservatively
-	 */
-	public void init(Matrix4fc playerView, Matrix4fc playerProjection, Vector3f shadowLightVector, BoxCuller boxCuller, float nearPlane, float farPlane, float intervalSize) {
 		this.shadowLightVectorFromOrigin.set(shadowLightVector);
 		this.boxCuller = boxCuller;
 		this.planeCount = 0;
@@ -118,24 +105,6 @@ public class AdvancedShadowCullingFrustum extends Frustum implements ViewportPro
 
 		addBackPlanes(baseClippingPlanes, isBackArray);
 		addEdgePlanes(baseClippingPlanes, isBackArray);
-
-		// handle legacy perspective shadow packs
-		if (!Float.isNaN(nearPlane) && !Float.isNaN(farPlane)) {
-			addDepthPlanes(nearPlane, farPlane, intervalSize);
-		}
-	}
-
-	private void addDepthPlanes(float nearPlane, float farPlane, float intervalSize) {
-		float margin = 1.5f * Math.abs(intervalSize) * SQRT_3 + 0.5f;
-		float towardLimit = ShadowMatrices.SHADOW_CAMERA_OFFSET - nearPlane + margin;
-		float awayLimit = farPlane - ShadowMatrices.SHADOW_CAMERA_OFFSET + margin;
-
-		Vector3f light = this.shadowLightVectorFromOrigin;
-
-		// Inside when dot(light, p) <= towardLimit, i.e. -dot(light, p) + towardLimit >= 0.
-		addPlane(-light.x(), -light.y(), -light.z(), towardLimit);
-		// Inside when dot(light, p) >= -awayLimit, i.e. dot(light, p) + awayLimit >= 0.
-		addPlane(light.x(), light.y(), light.z(), awayLimit);
 	}
 
 	private void addPlane(Vector4f plane) {

--- a/src/main/java/com/dhj/actinium/render/terrain/fog/GLStateManagerFogService.java
+++ b/src/main/java/com/dhj/actinium/render/terrain/fog/GLStateManagerFogService.java
@@ -26,7 +26,9 @@ public class GLStateManagerFogService implements FogService {
 
     @Override
     public int getFogShapeIndex() {
-        return 0;
+        // Vanilla fog distances on 1.12.2 are measured against the eye plane (depth along the view axis),
+        // which matches the planar shape rather than the spherical distance the shader defaults to.
+        return FogService.FOG_SHAPE_PLANAR;
     }
 
     @Override

--- a/src/main/resources/assets/actinium/shaders/blocks/block_layer_opaque.fsh
+++ b/src/main/resources/assets/actinium/shaders/blocks/block_layer_opaque.fsh
@@ -26,6 +26,7 @@ in float v_FragDistance;
 
 uniform sampler2D u_BlockTex; // The block texture
 
+uniform int u_FogShape;
 uniform vec4 u_FogColor; // The color of the shader fog
 
 #ifdef USE_FOG_SMOOTH
@@ -92,12 +93,21 @@ void main() {
                          _linearFogValue(v_SphericalFragDistance, u_EnvFogStart, u_EnvFogEnd));
 
     fragColor = vec4(mix(diffuseColor.rgb, u_FogColor.rgb, fogValue * u_FogColor.a), diffuseColor.a);
-#elif defined(USE_FOG_EXP2)
-    fragColor = _exp2Fog(diffuseColor, v_FragDistance, u_FogColor, u_FogDensity);
+#else // Legacy fog
+    float fragDistance;
+    if (u_FogShape == FOG_SHAPE_PLANAR) {
+        fragDistance = gl_FragCoord.z / gl_FragCoord.w;
+    } else {
+        fragDistance = v_FragDistance;
+    }
+#if defined(USE_FOG_EXP2)
+    fragColor = _exp2Fog(diffuseColor, fragDistance, u_FogColor, u_FogDensity);
 #elif defined(USE_FOG_SMOOTH)
-    fragColor = _linearFog(diffuseColor, v_FragDistance, u_FogColor, u_FogStart, u_FogEnd);
+    fragColor = _linearFog(diffuseColor, fragDistance, u_FogColor, u_FogStart, u_FogEnd);
 #endif
-#else
+#endif
+
+#else // No fog
     fragColor = diffuseColor;
 #endif
 }

--- a/src/main/resources/assets/actinium/shaders/blocks/block_layer_opaque.vsh
+++ b/src/main/resources/assets/actinium/shaders/blocks/block_layer_opaque.vsh
@@ -5,6 +5,9 @@
 #import <actinium:include/chunk_matrices.glsl>
 #import <actinium:include/chunk_material.glsl>
 
+// Avoid z-fighting between the solid and cutout copies of this program
+invariant gl_Position;
+
 out vec4 v_Color;
 out vec2 v_TexCoord;
 #ifdef USE_BILINEAR_CORRECTION

--- a/src/main/resources/assets/actinium/shaders/include/fog.glsl
+++ b/src/main/resources/assets/actinium/shaders/include/fog.glsl
@@ -1,5 +1,6 @@
 const int FOG_SHAPE_SPHERICAL = 0;
 const int FOG_SHAPE_CYLINDRICAL = 1;
+const int FOG_SHAPE_PLANAR = 2;
 
 vec4 _linearFog(vec4 fragColor, float fragDistance, vec4 fogColor, float fogStart, float fogEnd) {
 #ifdef USE_FOG


### PR DESCRIPTION
## 改动内容

将上游 celeritas（stonecutter 分支）`f15085d4b..7190f87d8` 中可收编的运行时修复同步到 Actinium，共 6 个移植提交 + 1 个同步记录文档（`docs/sync-celeritas-7190f87d.md`，含全部 25 个上游提交的处置清单）。范围内的 16 个纯构建系统提交（unimined→RFG、Loom/Stonecutter 升级）不适用于本仓库，未同步。

### 逐项对应

| 上游 commit | 本地 commit | 内容 |
|---|---|---|
| `1c473b2eb` | `bc3dfb0a` | 区块 vsh 标记 `invariant gl_Position`，防 solid/cutout 变体间 z-fighting |
| `09f4da755` | `b3deb706` | 移除 shadow pass 的 near/far 深度裁剪平面——光影包任意缩放阴影深度时该优化无法证明正确，会误剔除投射物导致阴影丢失/闪烁 |
| `927e7a09b` | `f44fe6d2` | `Vector2Uniform`/`Vector4ArrayUniform` 改私有副本缓存；此前按引用缓存，supplier 复用向量时 uniform 首传后永不更新 |
| `5e6c6e2b0` | `779c6c92` | 拖动控件真实鼠标捕获：拖动滑块越出约 10px 热区不再丢失跟随，捕获期间兄弟控件不再显示 hover |
| `53f41b67c` | `b937007c` | planar fog 支持：`GLStateManagerFogService` 改报 `FOG_SHAPE_PLANAR`（对齐 1.12.2 GL_FOG 视平面深度语义，此前硬编码 spherical 导致屏幕边缘雾偏浓），区块 fsh 按形状沿视轴测距；雾剔除按上游保守回退（无投影矩阵时用完整渲染距离，宁可不剔除不误剔除） |
| `31455a039` | `9393f890` | 部分收编：final pass memory barrier 仅在 compute 实际 dispatch 后发出；parity 双缓冲重构依赖上游新 target 架构且帧间时序敏感，暂不收编 |

### 有意不动的部分

- **compat-bridge 的 `SliderControl` 副本**：按 `AGENTS.md` 桥契约，先解包扫描了 celeritasleafculling jar 确认无注入目标；主 GUI 走 `celeritas-common` 实现，桥副本保持旧 Celeritas 2.4.0 行为快照。
- **`7190f87d8` 光栅化遮挡剔除**（约 5500 行，默认关闭）：刚合入上游、剔除开销约翻倍，建议等上游出现后续修复提交后再评估，已记入 `docs/sync-celeritas-7190f87d.md` 下一轮提醒。

## 验证

- `./gradlew compileJava :celeritas-common:compileJava :shader:compileJava --no-daemon` 通过。
- `./gradlew test :celeritas-common:test :shader:test --no-daemon` 通过（BUILD SUCCESSFUL）。
- dev 环境回归验证已完成。